### PR TITLE
providers/gce: parse the boolean returned

### DIFF
--- a/internal/providers/gce/gce.go
+++ b/internal/providers/gce/gce.go
@@ -17,6 +17,7 @@ package gce
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -72,7 +73,7 @@ func fetchAllSshKeys() ([]string, error) {
 		return nil, err
 	}
 
-	if blockProjectKeys == "TRUE" {
+	if block, err := strconv.ParseBool(blockProjectKeys); err == nil && block {
 		return instanceSshKeys, nil
 	}
 


### PR DESCRIPTION
Despite the documentation's insistence that the API would return "TRUE",
it returned "true".
