### PR TITLE
[WIP] Add initial support for the openstack OEM

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,11 @@ The supported cloud providers and their respective metadata are as follows:
       - COREOS_GCE_HOSTNAME
       - COREOS_GCE_IP_EXTERNAL_0
       - COREOS_GCE_IP_LOCAL_0
+  - openstack (EC2 configdrive compatibility)
+    - SSH Keys
+    - Attributes
+      - COREOS_EC2_HOSTNAME
+      - COREOS_EC2_IPV4_LOCAL
+      - COREOS_EC2_IPV4_PUBLIC
 
 [ignition]: https://github.com/coreos/ignition

--- a/build
+++ b/build
@@ -4,7 +4,7 @@ NAME="coreos-metadata"
 ORG_PATH="github.com/coreos"
 REPO_PATH="${ORG_PATH}/${NAME}"
 VERSION=$(git describe --dirty)
-GLDFLAGS="-X main.version \"${VERSION}\""
+GLDFLAGS="-X main.version=\"${VERSION}\""
 
 if [ ! -h gopath/src/${REPO_PATH} ]; then
 	mkdir -p gopath/src/${ORG_PATH}

--- a/internal/main.go
+++ b/internal/main.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/coreos/coreos-metadata/internal/providers"
 	"github.com/coreos/coreos-metadata/internal/providers/azure"
+	"github.com/coreos/coreos-metadata/internal/providers/configdrive"
 	"github.com/coreos/coreos-metadata/internal/providers/ec2"
 	"github.com/coreos/coreos-metadata/internal/providers/gce"
 
@@ -74,7 +75,7 @@ func main() {
 	}
 
 	switch flags.provider {
-	case "azure", "ec2", "gce":
+	case "azure", "ec2", "gce", "openstack":
 	default:
 		fmt.Fprintf(os.Stderr, "invalid provider %q\n", flags.provider)
 		os.Exit(2)
@@ -122,6 +123,8 @@ func fetchMetadata(provider string) (providers.Metadata, error) {
 		return ec2.FetchMetadata()
 	case "gce":
 		return gce.FetchMetadata()
+	case "openstack":
+		return configdrive.FetchMetadata()
 	default:
 		panic("bad provider")
 	}

--- a/internal/providers/configdrive/configdrive.go
+++ b/internal/providers/configdrive/configdrive.go
@@ -1,0 +1,109 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configdrive
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+
+	"github.com/coreos/coreos-metadata/internal/providers"
+)
+
+type jsonMap map[string]interface{}
+
+func FetchMetadata() (providers.Metadata, error) {
+	var parsedData jsonMap
+
+	data, err := ioutil.ReadFile("/media/configdrive/ec2/2009-04-04/meta-data.json")
+	if err != nil {
+		return providers.Metadata{}, err
+	}
+
+	if err := json.Unmarshal(data, &parsedData); err != nil {
+		return providers.Metadata{}, err
+	}
+
+	instanceId, _, err := parsedData.fetchString("instance-id")
+	if err != nil {
+		return providers.Metadata{}, err
+	}
+
+	public, err := parsedData.fetchIP("public-ipv4")
+	if err != nil {
+		return providers.Metadata{}, err
+	}
+	local, err := parsedData.fetchIP("local-ipv4")
+	if err != nil {
+		return providers.Metadata{}, err
+	}
+	hostname, _, err := parsedData.fetchString("hostname")
+	if err != nil {
+		return providers.Metadata{}, err
+	}
+
+	sshKeys, err := parsedData.fetchSshKeys()
+	if err != nil {
+		return providers.Metadata{}, err
+	}
+
+	return providers.Metadata{
+		Attributes: map[string]string{
+			"EC2_INSTANCE_ID": instanceId,
+			"EC2_IPV4_LOCAL":  providers.String(local),
+			"EC2_IPV4_PUBLIC": providers.String(public),
+			"EC2_HOSTNAME":    hostname,
+		},
+		SshKeys: sshKeys,
+	}, nil
+}
+
+func (c jsonMap) fetchString(key string) (string, bool, error) {
+	value, ok := c[key].(string)
+	return value, (ok && value != ""), nil
+}
+
+func (c jsonMap) fetchIP(key string) (net.IP, error) {
+	str, present, err := c.fetchString(key)
+	if err != nil {
+		return nil, err
+	}
+
+	if !present {
+		return nil, nil
+	}
+
+	if ip := net.ParseIP(str); ip != nil {
+		return ip, nil
+	} else {
+		return nil, fmt.Errorf("couldn't parse %q as IP address", str)
+	}
+}
+
+func (c jsonMap) fetchSshKeys() ([]string, error) {
+	keys := []string{}
+
+	keyInfoList := c["public-keys"].(map[string]interface{})
+	for _, keyInfo := range keyInfoList {
+		sshkey, ok := keyInfo.(map[string]interface{})["openssh-key"].(string)
+		if !ok {
+			return nil, nil
+		}
+		keys = append(keys, sshkey)
+	}
+
+	return keys, nil
+}


### PR DESCRIPTION
This is a first-pass at supporting OpenStack via the EC2-compatible configdrive CD.  The network metadata service will be added eventually.
