### PR TITLE
providers: Add support for Packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,12 @@ The supported cloud providers and their respective metadata are as follows:
       - COREOS_GCE_IP_EXTERNAL_0
       - COREOS_GCE_IP_LOCAL_0
 
+  - packet
+    - SSH Keys
+    - Attributes
+      - COREOS_PACKET_HOSTNAME
+      - COREOS_PACKET_IPV4_PUBLIC_0
+      - COREOS_PACKET_IPV4_PRIVATE_0
+      - COREOS_PACKET_IPV6_PUBLIC_0
+
 [ignition]: https://github.com/coreos/ignition

--- a/internal/main.go
+++ b/internal/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/coreos/coreos-metadata/internal/providers/azure"
 	"github.com/coreos/coreos-metadata/internal/providers/ec2"
 	"github.com/coreos/coreos-metadata/internal/providers/gce"
+	"github.com/coreos/coreos-metadata/internal/providers/packet"
 
 	"github.com/coreos/update-ssh-keys/authorized_keys_d"
 )
@@ -74,7 +75,7 @@ func main() {
 	}
 
 	switch flags.provider {
-	case "azure", "ec2", "gce":
+	case "azure", "ec2", "gce", "packet":
 	default:
 		fmt.Fprintf(os.Stderr, "invalid provider %q\n", flags.provider)
 		os.Exit(2)
@@ -122,6 +123,8 @@ func fetchMetadata(provider string) (providers.Metadata, error) {
 		return ec2.FetchMetadata()
 	case "gce":
 		return gce.FetchMetadata()
+	case "packet":
+		return packet.FetchMetadata()
 	default:
 		panic("bad provider")
 	}

--- a/internal/providers/packet/packet.go
+++ b/internal/providers/packet/packet.go
@@ -1,0 +1,99 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/coreos/coreos-metadata/internal/providers"
+	"github.com/coreos/coreos-metadata/internal/retry"
+	"github.com/packethost/packngo/metadata"
+)
+
+func FetchMetadata() (providers.Metadata, error) {
+	body, err := retry.Client{
+		InitialBackoff: time.Second,
+		MaxBackoff:     time.Second * 5,
+		MaxAttempts:    10,
+	}.Get(metadata.BaseURL + "/metadata")
+	if err != nil {
+		return providers.Metadata{}, err
+	}
+
+	var data struct {
+		Error string `json:"error"`
+		*metadata.CurrentDevice
+	}
+
+	if err := json.Unmarshal(body, &data); err != nil {
+		return providers.Metadata{}, err
+	}
+
+	if data.Error != "" {
+		return providers.Metadata{}, errors.New(data.Error)
+	}
+
+	attrs := ipAddresses(data.Network)
+	attrs["PACKET_HOSTNAME"] = data.Hostname
+
+	return providers.Metadata{
+		Attributes: attrs,
+		SshKeys:    data.SSHKeys,
+	}, nil
+}
+
+func ipAddresses(network metadata.NetworkInfo) map[string]string {
+	var publicIPv4, privateIPv4, publicIPv6, privateIPv6 []net.IP
+
+	for _, addr := range network.Addresses {
+		switch {
+		case addr.Family == 4 && addr.Public:
+			publicIPv4 = append(publicIPv4, addr.Address)
+
+		case addr.Family == 4 && !addr.Public:
+			privateIPv4 = append(privateIPv4, addr.Address)
+
+		case addr.Family == 6 && addr.Public:
+			publicIPv6 = append(publicIPv6, addr.Address)
+
+		case addr.Family == 6 && !addr.Public:
+			privateIPv6 = append(privateIPv6, addr.Address)
+		}
+	}
+
+	addresses := make(map[string]string)
+
+	for i, ip := range publicIPv4 {
+		addresses[fmt.Sprintf("PACKET_IPV4_PUBLIC_%d", i)] = providers.String(ip)
+	}
+
+	for i, ip := range privateIPv4 {
+		addresses[fmt.Sprintf("PACKET_IPV4_PRIVATE_%d", i)] = providers.String(ip)
+	}
+
+	for i, ip := range publicIPv6 {
+		addresses[fmt.Sprintf("PACKET_IPV6_PUBLIC_%d", i)] = providers.String(ip)
+	}
+
+	for i, ip := range privateIPv6 {
+		addresses[fmt.Sprintf("PACKET_IPV6_PRIVATE_%d", i)] = providers.String(ip)
+	}
+
+	return addresses
+}

--- a/internal/vendor/github.com/packethost/packngo/LICENSE.txt
+++ b/internal/vendor/github.com/packethost/packngo/LICENSE.txt
@@ -1,0 +1,56 @@
+Copyright (c) 2014 The packngo AUTHORS. All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+======================
+Portions of the client are based on code at:
+https://github.com/google/go-github/ and
+https://github.com/digitalocean/godo
+
+Copyright (c) 2013 The go-github AUTHORS. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/internal/vendor/github.com/packethost/packngo/metadata/metadata.go
+++ b/internal/vendor/github.com/packethost/packngo/metadata/metadata.go
@@ -1,0 +1,153 @@
+package metadata
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+)
+
+const BaseURL = "https://metadata.packet.net"
+
+func GetMetadata() (*CurrentDevice, error) {
+	res, err := http.Get(BaseURL + "/metadata")
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		Error string `json:"error"`
+		*CurrentDevice
+	}
+	if err := json.Unmarshal(b, &result); err != nil {
+		return nil, err
+	}
+	if result.Error != "" {
+		return nil, errors.New(result.Error)
+	}
+	return result.CurrentDevice, nil
+}
+
+func GetUserData() ([]byte, error) {
+	res, err := http.Get(BaseURL + "/userdata")
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+	return b, err
+}
+
+type AddressFamily int
+
+const (
+	IPv4 = AddressFamily(4)
+	IPv6 = AddressFamily(6)
+)
+
+type AddressInfo struct {
+	ID          string        `json:"id"`
+	Family      AddressFamily `json:"address_family"`
+	Public      bool          `json:"public"`
+	Management  bool          `json:"management"`
+	Address     net.IP        `json:"address"`
+	NetworkMask net.IP        `json:"netmask"`
+	Gateway     net.IP        `json:"gateway"`
+
+	// These are available, but not really needed:
+	//   Network     net.IP `json:"network"`
+	//   NetworkBits int    `json:"cidr"`
+}
+
+type BondingMode int
+
+const (
+	BondingBalanceRR    = BondingMode(0)
+	BondingActiveBackup = BondingMode(1)
+	BondingBalanceXOR   = BondingMode(2)
+	BondingBroadcast    = BondingMode(3)
+	BondingLACP         = BondingMode(4)
+	BondingBalanceTLB   = BondingMode(5)
+	BondingBalanceALB   = BondingMode(6)
+)
+
+var bondingModeStrings = map[BondingMode]string{
+	BondingBalanceRR:    "balance-rr",
+	BondingActiveBackup: "active-backup",
+	BondingBalanceXOR:   "balance-xor",
+	BondingBroadcast:    "broadcast",
+	BondingLACP:         "802.3ad",
+	BondingBalanceTLB:   "balance-tlb",
+	BondingBalanceALB:   "balance-alb",
+}
+
+func (m BondingMode) String() string {
+	if str, ok := bondingModeStrings[m]; ok {
+		return str
+	}
+	return fmt.Sprintf("%d", m)
+}
+
+type CurrentDevice struct {
+	ID       string          `json:"id"`
+	Hostname string          `json:"hostname"`
+	IQN      string          `json:"iqn"`
+	Plan     string          `json:"plan"`
+	Facility string          `json:"facility"`
+	Tags     []string        `json:"tags"`
+	SSHKeys  []string        `json:"ssh_keys"`
+	OS       OperatingSystem `json:"operating_system"`
+	Network  NetworkInfo     `json:"network"`
+	Volumes  []VolumeInfo    `json:"volume"`
+
+	// This is available, but is actually inaccurate, currently:
+	//   APIBaseURL string          `json:"api_url"`
+}
+
+type InterfaceInfo struct {
+	Name string `json:"name"`
+	MAC  string `json:"mac"`
+}
+
+func (i *InterfaceInfo) ParseMAC() (net.HardwareAddr, error) {
+	return net.ParseMAC(i.MAC)
+}
+
+type NetworkInfo struct {
+	Interfaces []InterfaceInfo `json:"interfaces"`
+	Addresses  []AddressInfo   `json:"addresses"`
+
+	Bonding struct {
+		Mode BondingMode `json:"mode"`
+	} `json:"bonding"`
+}
+
+func (n *NetworkInfo) BondingMode() BondingMode {
+	return n.Bonding.Mode
+}
+
+type OperatingSystem struct {
+	Slug    string `json:"slug"`
+	Distro  string `json:"distro"`
+	Version string `json:"version"`
+}
+
+type VolumeInfo struct {
+	Name string   `json:"name"`
+	IQN  string   `json:"iqn"`
+	IPs  []net.IP `json:"ips"`
+
+	Capacity struct {
+		Size int    `json:"size,string"`
+		Unit string `json:"unit"`
+	} `json:"capacity"`
+}


### PR DESCRIPTION
Adding support for Packet.

I chose not to vendor [packngo](https://github.com/packethost/packngo) and instead just have some structs with the fields I need, but I'm happy to change that.

Also, I don't think there's really a notion of a primary public or private address, so I just grab the first of each in the list.
