### PR TITLE
build: don't hardcode path to bash

### DIFF
--- a/build
+++ b/build
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+
+set -eu
 
 NAME="coreos-metadata"
 ORG_PATH="github.com/coreos"

--- a/test
+++ b/test
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+
+set -eu
 
 source ./build
 


### PR DESCRIPTION
Bash isn't always located at this location on developer machines.