### PR TITLE
main: allow overriding the platform with an environment variable

### DIFF
--- a/internal/main.go
+++ b/internal/main.go
@@ -40,8 +40,9 @@ var (
 )
 
 const (
-	cmdlinePath    = "/proc/cmdline"
-	cmdlineOEMFlag = "coreos.oem.id"
+	cmdlinePath        = "/proc/cmdline"
+	cmdlineOEMFlag     = "coreos.oem.id"
+	envVarNameProvider = "COREOS_METADATA_PROVIDER_OVERRIDE"
 )
 
 func main() {
@@ -78,6 +79,10 @@ func main() {
 		}
 
 		flags.provider = parseCmdline(args)
+	}
+
+	if envVarProvider := os.Getenv(envVarNameProvider); envVarProvider != "" {
+		flags.provider = envVarProvider
 	}
 
 	switch flags.provider {


### PR DESCRIPTION
This commit allows overriding the provider as specified via flags or
kernel commandline with the environment variable
COREOS_METADATA_PROVIDER_OVERRIDE. If this variable is set to a
non-empty value, its contents will be used for the provider regardless
of what other flags are set.

This is due to the request here: https://github.com/coreos/container-linux-config-transpiler/pull/58#pullrequestreview-33290010