### PR TITLE
providers/ec2: Fetch EC2 availability zone.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The supported cloud providers and their respective metadata are as follows:
       - COREOS_EC2_HOSTNAME
       - COREOS_EC2_IPV4_LOCAL
       - COREOS_EC2_IPV4_PUBLIC
+      - COREOS_EC2_AVAILABILITY_ZONE
   - gce
     - SSH Keys
     - Attributes

--- a/internal/providers/ec2/ec2.go
+++ b/internal/providers/ec2/ec2.go
@@ -43,6 +43,10 @@ func FetchMetadata() (providers.Metadata, error) {
 	if err != nil {
 		return providers.Metadata{}, err
 	}
+	availabilityZone, _, err := fetchString("placement/availability-zone")
+	if err != nil {
+		return providers.Metadata{}, err
+	}
 
 	sshKeys, err := fetchSshKeys()
 	if err != nil {
@@ -51,10 +55,11 @@ func FetchMetadata() (providers.Metadata, error) {
 
 	return providers.Metadata{
 		Attributes: map[string]string{
-			"EC2_INSTANCE_ID": instanceId,
-			"EC2_IPV4_LOCAL":  providers.String(local),
-			"EC2_IPV4_PUBLIC": providers.String(public),
-			"EC2_HOSTNAME":    hostname,
+			"EC2_INSTANCE_ID":       instanceId,
+			"EC2_IPV4_LOCAL":        providers.String(local),
+			"EC2_IPV4_PUBLIC":       providers.String(public),
+			"EC2_HOSTNAME":          hostname,
+			"EC2_AVAILABILITY_ZONE": availabilityZone,
 		},
 		Hostname: hostname,
 		SshKeys:  sshKeys,


### PR DESCRIPTION
Hi

This change is required in order to mount the AWS EFS endpoint correctly, which uses availability zone as a part of connection string.

I've tested this change on CoreOS 1353.7.0. 