### PR TITLE
internal/providers/ec2: add COREOS_EC2_REGION

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ The supported cloud providers and their respective metadata are as follows:
       - COREOS_EC2_IPV4_LOCAL
       - COREOS_EC2_IPV4_PUBLIC
       - COREOS_EC2_AVAILABILITY_ZONE
+      - COREOS_EC2_INSTANCE_ID
+      - COREOS_EC2_REGION
   - gce
     - SSH Keys
     - Attributes


### PR DESCRIPTION
This commit adds the region in ec2 to the set of metadata discovered by
coreos-metadata.

The instance ID was already discovered by coreos-metadata, but for some
reason was not mentioned in the README, so this commit also adds mention
of it there.