### PR TITLE
internal/providers/digitalocean: add COREOS_DIGITALOCEAN_REGION

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The supported cloud providers and their respective metadata are as follows:
       - COREOS_DIGITALOCEAN_IPV4_PRIVATE_0
       - COREOS_DIGITALOCEAN_IPV6_PUBLIC_0
       - COREOS_DIGITALOCEAN_IPV6_PRIVATE_0
+      - COREOS_DIGITALOCEAN_REGION
   - ec2
     - SSH Keys
     - Attributes

--- a/internal/providers/digitalocean/digitalocean.go
+++ b/internal/providers/digitalocean/digitalocean.go
@@ -52,6 +52,7 @@ type Metadata struct {
 	Hostname   string     `json:"hostname"`
 	Interfaces Interfaces `json:"interfaces"`
 	PublicKeys []string   `json:"public_keys"`
+	Region     string     `json:"region"`
 	DNS        DNS        `json:"dns"`
 }
 
@@ -87,6 +88,7 @@ func FetchMetadata() (providers.Metadata, error) {
 func parseAttributes(metadata Metadata) map[string]string {
 	attrs := map[string]string{
 		"DIGITALOCEAN_HOSTNAME": metadata.Hostname,
+		"DIGITALOCEAN_REGION":   metadata.Region,
 	}
 
 	for i, iface := range metadata.Interfaces.Public {


### PR DESCRIPTION
While doing some hacking I noticed this wasn't accessible via `coreos-metadata` so I thought we should add it :)