### PR TITLE
internal/providers/ec2: fix ssh keys

### DIFF
--- a/internal/providers/ec2/ec2.go
+++ b/internal/providers/ec2/ec2.go
@@ -122,7 +122,7 @@ func fetchIP(key string) (net.IP, error) {
 }
 
 func fetchSshKeys() ([]string, error) {
-	keydata, present, err := fetchString("public-keys")
+	keydata, present, err := fetchString("meta-data/public-keys")
 	if err != nil {
 		return nil, fmt.Errorf("error reading keys: %v", err)
 	}
@@ -151,7 +151,7 @@ func fetchSshKeys() ([]string, error) {
 
 	keys := []string{}
 	for _, id := range keyIDs {
-		sshkey, _, err := fetchString(fmt.Sprintf("public-keys/%s/openssh-key", id))
+		sshkey, _, err := fetchString(fmt.Sprintf("meta-data/public-keys/%s/openssh-key", id))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
A recent commit resulted in the ec2 fetching logic to need to fetch a
resource from the dynamic endpoint in the ec2 metadata service in
addition to the meta-data endpoint. This resulted in all calls to fetch
a resource now needing to specify an additional part of the url prefix.
The logic for fetching ssh keys was overlooked when this change was
made.

This commit adds this meta-data prefix to the ssh key fetching logic.

Tested on an ec2 vm.

Fixes https://github.com/coreos/bugs/issues/1981.