### PR TITLE
providers/packet: Add support for generating network units

### DIFF
--- a/internal/main.go
+++ b/internal/main.go
@@ -242,5 +242,13 @@ func writeNetworkUnits(root string, metadata providers.Metadata) error {
 		}
 	}
 
+	for _, device := range metadata.NetDev {
+		name := filepath.Join(root, device.UnitName())
+		err := ioutil.WriteFile(name, []byte(device.NetdevConfig()), 0644)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/internal/main.go
+++ b/internal/main.go
@@ -235,7 +235,7 @@ func writeNetworkUnits(root string, metadata providers.Metadata) error {
 	}
 
 	for _, iface := range metadata.Network {
-		name := filepath.Join(root, fmt.Sprintf("00-%s.network", iface.HardwareAddress))
+		name := filepath.Join(root, iface.UnitName())
 		err := ioutil.WriteFile(name, []byte(iface.NetworkConfig()), 0644)
 		if err != nil {
 			return err

--- a/internal/providers/metadata.go
+++ b/internal/providers/metadata.go
@@ -28,6 +28,7 @@ type Metadata struct {
 }
 
 type NetworkInterface struct {
+	Name            string
 	HardwareAddress net.HardwareAddr
 	Priority        int
 	Nameservers     []net.IP
@@ -45,15 +46,27 @@ func (i NetworkInterface) UnitName() string {
 	if priority == 0 {
 		priority = 10
 	}
-	return fmt.Sprintf("%02d-%s.network", priority, i.HardwareAddress)
+	name := i.Name
+	if name == "" {
+		name = i.HardwareAddress.String()
+	}
+	return fmt.Sprintf("%02d-%s.network", priority, name)
 }
 
 func (i NetworkInterface) NetworkConfig() string {
-	config := fmt.Sprintf("[Match]\nMACAddress=%s\n\n[Network]\n", i.HardwareAddress)
+	config := "[Match]\n"
+	if i.Name != "" {
+		config += fmt.Sprintf("Name=%s\n", i.Name)
+	}
+	if i.HardwareAddress != nil {
+		config += fmt.Sprintf("MACAddress=%s\n", i.HardwareAddress)
+	}
 
+	config += "\n[Network]\n"
 	for _, nameserver := range i.Nameservers {
 		config += fmt.Sprintf("DNS=%s\n", nameserver)
 	}
+
 	for _, addr := range i.IPAddresses {
 		config += fmt.Sprintf("\n[Address]\nAddress=%s\n", addr.String())
 	}

--- a/internal/providers/metadata.go
+++ b/internal/providers/metadata.go
@@ -29,6 +29,7 @@ type Metadata struct {
 
 type NetworkInterface struct {
 	HardwareAddress net.HardwareAddr
+	Priority        int
 	Nameservers     []net.IP
 	IPAddresses     []net.IPNet
 	Routes          []NetworkRoute
@@ -37,6 +38,14 @@ type NetworkInterface struct {
 type NetworkRoute struct {
 	Destination net.IPNet
 	Gateway     net.IP
+}
+
+func (i NetworkInterface) UnitName() string {
+	priority := i.Priority
+	if priority == 0 {
+		priority = 10
+	}
+	return fmt.Sprintf("%02d-%s.network", priority, i.HardwareAddress)
 }
 
 func (i NetworkInterface) NetworkConfig() string {

--- a/internal/providers/metadata.go
+++ b/internal/providers/metadata.go
@@ -34,6 +34,7 @@ type NetworkInterface struct {
 	Nameservers     []net.IP
 	IPAddresses     []net.IPNet
 	Routes          []NetworkRoute
+	Bond            string
 }
 
 type NetworkRoute struct {
@@ -65,6 +66,9 @@ func (i NetworkInterface) NetworkConfig() string {
 	config += "\n[Network]\n"
 	for _, nameserver := range i.Nameservers {
 		config += fmt.Sprintf("DNS=%s\n", nameserver)
+	}
+	if i.Bond != "" {
+		config += fmt.Sprintf("Bond=%s\n", i.Bond)
 	}
 
 	for _, addr := range i.IPAddresses {

--- a/internal/providers/packet/packet.go
+++ b/internal/providers/packet/packet.go
@@ -79,6 +79,7 @@ func parseNetwork(network metadata.NetworkInfo) ([]providers.NetworkInterface, e
 
 		ifaces = append(ifaces, providers.NetworkInterface{
 			HardwareAddress: mac,
+			Bond:            bondDev,
 		})
 	}
 

--- a/internal/providers/packet/packet.go
+++ b/internal/providers/packet/packet.go
@@ -81,7 +81,9 @@ func parseNetwork(network metadata.NetworkInfo) ([]providers.NetworkInterface, e
 		})
 	}
 
-	iface := providers.NetworkInterface{}
+	iface := providers.NetworkInterface{
+		Priority: 5,
+	}
 	for _, addr := range network.Addresses {
 		addrlen := 16
 		if addr.Address.To4() != nil {

--- a/internal/providers/packet/packet.go
+++ b/internal/providers/packet/packet.go
@@ -69,6 +69,7 @@ func FetchMetadata() (providers.Metadata, error) {
 
 func parseNetwork(network metadata.NetworkInfo) ([]providers.NetworkInterface, error) {
 	ifaces := []providers.NetworkInterface{}
+	bondDev := "bond0"
 
 	for _, iface := range network.Interfaces {
 		mac, err := net.ParseMAC(iface.MAC)
@@ -82,6 +83,7 @@ func parseNetwork(network metadata.NetworkInfo) ([]providers.NetworkInterface, e
 	}
 
 	iface := providers.NetworkInterface{
+		Name:     bondDev,
 		Priority: 5,
 	}
 	for _, addr := range network.Addresses {


### PR DESCRIPTION
The Packet provisioner is currently responsible for this.

There is a small change on DigitalOcean: network units are now created with priority 10 instead of 0 so other units can be sequenced ahead of them.  This doesn't affect the stock configuration.