### PR TITLE
providers: rename vagrant-virtualbox to virtualbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,6 @@ The supported cloud providers and their respective metadata are as follows:
   - virtualbox
     - Attributes
       - COREOS_VIRTUALBOX_HOSTNAME
-      - COREOS_VIRTUALBOX_IPV4 (only via vagrant)
+      - COREOS_VIRTUALBOX_IPV4_PRIVATE (only via vagrant)
 
 [ignition]: https://github.com/coreos/ignition

--- a/README.md
+++ b/README.md
@@ -50,5 +50,9 @@ The supported cloud providers and their respective metadata are as follows:
       - COREOS_OPENSTACK_IPV4_LOCAL
       - COREOS_OPENSTACK_IPV4_PUBLIC
       - COREOS_OPENSTACK_INSTANCE_ID
+  - virtualbox
+    - Attributes
+      - COREOS_VIRTUALBOX_HOSTNAME
+      - COREOS_VIRTUALBOX_IPV4 (only via vagrant)
 
 [ignition]: https://github.com/coreos/ignition

--- a/internal/main.go
+++ b/internal/main.go
@@ -148,7 +148,7 @@ func getMetadataProvider(providerName string) (func() (providers.Metadata, error
 		return packet.FetchMetadata, nil
 	case "openstack-metadata":
 		return openstackMetadata.FetchMetadata, nil
-	case "virtualbox":
+	case "virtualbox", "vagrant-virtualbox":
 		return virtualbox.FetchMetadata, nil
 	default:
 		return nil, ErrUnknownProvider

--- a/internal/main.go
+++ b/internal/main.go
@@ -31,7 +31,7 @@ import (
 	"github.com/coreos/coreos-metadata/internal/providers/gce"
 	"github.com/coreos/coreos-metadata/internal/providers/openstackMetadata"
 	"github.com/coreos/coreos-metadata/internal/providers/packet"
-	"github.com/coreos/coreos-metadata/internal/providers/vagrant_virtualbox"
+	"github.com/coreos/coreos-metadata/internal/providers/virtualbox"
 
 	"github.com/coreos/update-ssh-keys/authorized_keys_d"
 )
@@ -148,8 +148,8 @@ func getMetadataProvider(providerName string) (func() (providers.Metadata, error
 		return packet.FetchMetadata, nil
 	case "openstack-metadata":
 		return openstackMetadata.FetchMetadata, nil
-	case "vagrant-virtualbox":
-		return vagrant_virtualbox.FetchMetadata, nil
+	case "virtualbox":
+		return virtualbox.FetchMetadata, nil
 	default:
 		return nil, ErrUnknownProvider
 	}

--- a/internal/main.go
+++ b/internal/main.go
@@ -148,6 +148,8 @@ func getMetadataProvider(providerName string) (func() (providers.Metadata, error
 		return packet.FetchMetadata, nil
 	case "openstack-metadata":
 		return openstackMetadata.FetchMetadata, nil
+	// There was previous a vagrant-virtualbox provider which had the same attributes as virtualbox now has,
+	// just with a slightly different name. We will keep that providerName here for backwards compatibility
 	case "virtualbox", "vagrant-virtualbox":
 		return virtualbox.FetchMetadata, nil
 	default:


### PR DESCRIPTION
This allows us to avoid using specific oem-ids for vagrant provisioned
machines and use more ids