### PR TITLE
cargo: log less in release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ nix = "0.9"
 
 [dependencies.slog]
 version = "2.0"
-features = ["max_level_trace"]
+features = ["max_level_trace", "release_max_level_info"]
 
 [dev-dependencies]
 mockito = "0.9"


### PR DESCRIPTION
the debug build is a very verbose logger, which is a good thing when you
are developing, but we don't want the release build to talk as loudly
about what it is doing.