### PR TITLE
version: bump to v1.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coreos-metadata"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Stephen Demos <stephen.demos@coreos.com>"]
 
 [[bin]]


### PR DESCRIPTION
Release notes draft:
* update `openssh-keys` to v0.2.0 to fix bug with authorized_keys file parsing.