### PR TITLE
main: accept long args with one hyphen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "coreos-metadata"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
the "go style" flags where flags can be accepted with either one or two
hyphens at the beginning needs to be supported, since we are trying to
match the original go interface as closely as possible. the solution is
to do a little preprocessing on the arguments that are passed, where if
a flag with a single hyphen is passed, we add another hyphen. this only
works because the flags we have defined don't have short arguments. we
would have to be more careful if short arguments are ever added.

fixes coreos/bugs#2240

as a separate note, looks like I didn't run `cargo build` after bumping the
 version in `Cargo.toml`, so the version number didn't get propogated to
 `Cargo.lock`. this also happens to fix that.