### PR TITLE
providers/digitalocean: private ip index bug fix

### DIFF
--- a/src/providers/digitalocean/mod.rs
+++ b/src/providers/digitalocean/mod.rs
@@ -121,7 +121,7 @@ fn parse_attrs(data: &Metadata) -> Result<Vec<(String,String)>> {
         for a in ifaces {
             if a.ipv4.is_some() {
                 attrs.push((
-                    format!("DIGITALOCEAN_IPV4_PRIVATE_{}", public_counter),
+                    format!("DIGITALOCEAN_IPV4_PRIVATE_{}", private_counter),
                     format!("{}", a.ipv4.unwrap().ip_address)
                 ));
             }


### PR DESCRIPTION
I just noticed that my private IP was empty in dependent systemctl services because I expected it to be set as `COREOS_DIGITALOCEAN_IPV4_PRIVATE_0` but `/run/metadata/coreos` named it `COREOS_DIGITALOCEAN_IPV4_PRIVATE_1`. I checked the code and it looks like a minor copy-and-paste error.