### PR TITLE
providers/oracle: use default when key is missing

### DIFF
--- a/src/providers/oracle/mod.rs
+++ b/src/providers/oracle/mod.rs
@@ -25,6 +25,7 @@ struct InstanceData {
 
 #[derive(Debug, Deserialize, Clone)]
 struct Metadata {
+    #[serde(default)]
     ssh_authorized_keys: String,
 }
 


### PR DESCRIPTION
the oracle metadata service doesn't require that a machine has an ssh
key assigned to it. when an ssh key is missing, it returns metadata
without the `ssh_authorized_keys` field in the json, which caused serde
to fail when attempting to deserialize it. this change makes serde use
the default instance for string (which is "") if it can't find the field
when deserializing.

ref coreos/bugs#2288

cc @bgilbert 