### PR TITLE
 providers/packet: respect bond interface requests 

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -51,7 +51,7 @@ pub fn bonding_mode_to_string(mode: &u32) -> Result<String> {
     Err(format!("no such bonding mode: {}", mode).into())
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NetworkRoute {
     pub destination: IpNetwork,
     pub gateway: IpAddr,
@@ -63,7 +63,7 @@ pub struct NetworkRoute {
 /// so we just panic! if it's not what we expected.
 /// I guess that there aren't really type systems with inclusive disjunction
 /// so it's not really that big of a deal.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Interface {
     pub name: Option<String>,
     pub mac_address: Option<MacAddr>,
@@ -74,13 +74,13 @@ pub struct Interface {
     pub bond: Option<String>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Section {
     pub name: String,
     pub attributes: Vec<(String, String)>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Device {
     pub name: String,
     pub kind: String,

--- a/src/network.rs
+++ b/src/network.rs
@@ -72,6 +72,7 @@ pub struct Interface {
     pub ip_addresses: Vec<IpNetwork>,
     pub routes: Vec<NetworkRoute>,
     pub bond: Option<String>,
+    pub unmanaged: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -115,6 +116,11 @@ impl Interface {
             config.push_str(&format!("DNS={}\n", ns))
         }
         self.bond.clone().map(|bond| config.push_str(&format!("Bond={}\n", bond)));
+
+        // [Link] section
+        if self.unmanaged {
+            config.push_str("\n[Link]\nUnmanaged=yes\n");
+        }
 
         // [Address] sections
         for addr in &self.ip_addresses {
@@ -178,6 +184,7 @@ mod tests {
                 ip_addresses: vec![],
                 routes: vec![],
                 bond: None,
+                unmanaged: false,
             }, "20-lo.network"),
             (Interface {
                 name: Some(String::from("lo")),
@@ -187,6 +194,7 @@ mod tests {
                 ip_addresses: vec![],
                 routes: vec![],
                 bond: None,
+                unmanaged: false,
             }, "10-lo.network"),
             (Interface {
                 name: None,
@@ -196,6 +204,7 @@ mod tests {
                 ip_addresses: vec![],
                 routes: vec![],
                 bond: None,
+                unmanaged: false,
             }, "20-00:00:00:00:00:00.network"),
             (Interface {
                 name: Some(String::from("lo")),
@@ -205,6 +214,7 @@ mod tests {
                 ip_addresses: vec![],
                 routes: vec![],
                 bond: None,
+                unmanaged: false,
             }, "20-lo.network"),
         ];
 
@@ -224,6 +234,7 @@ mod tests {
             ip_addresses: vec![],
             routes: vec![],
             bond: None,
+            unmanaged: false,
         };
         let _name = i.unit_name();
     }
@@ -283,6 +294,7 @@ mod tests {
                     }
                 ],
                 bond: Some(String::from("james")),
+                unmanaged: false,
             }, "[Match]
 Name=lo
 MACAddress=00:00:00:00:00:00
@@ -313,6 +325,7 @@ Gateway=127.0.0.1
                 ip_addresses: vec![],
                 routes: vec![],
                 bond: None,
+                unmanaged: false,
             }, "[Match]
 
 [Network]

--- a/src/providers/digitalocean/mod.rs
+++ b/src/providers/digitalocean/mod.rs
@@ -166,6 +166,7 @@ fn parse_interfaces(data: &Metadata, interfaces: Vec<Interface>) -> Result<Vec<n
             bond: None,
             name: None,
             priority: None,
+            unmanaged: false,
         });
     }
     let mut iface_configs = Vec::new();

--- a/src/providers/packet/mod.rs
+++ b/src/providers/packet/mod.rs
@@ -132,6 +132,9 @@ fn parse_network(netinfo: &PacketNetworkInfo) -> Result<(Vec<Interface>,Vec<Devi
             nameservers: Vec::new(),
             ip_addresses: Vec::new(),
             routes: Vec::new(),
+            // the interface should be unmanaged if it doesn't have a bond
+            // section
+            unmanaged: i.bond.is_none(),
         });
 
         // if there is a bond key, make sure we have a bond device for it
@@ -144,6 +147,7 @@ fn parse_network(netinfo: &PacketNetworkInfo) -> Result<(Vec<Interface>,Vec<Devi
                 bond: None,
                 ip_addresses: Vec::new(),
                 routes: Vec::new(),
+                unmanaged: false,
             };
             if !bonds.iter().any(|&(_, ref b): &(MacAddr, Interface)| &bond == b) {
                 bonds.push((mac, bond));

--- a/src/providers/packet/mod.rs
+++ b/src/providers/packet/mod.rs
@@ -102,8 +102,10 @@ pub fn fetch_metadata() -> Result<Metadata> {
 }
 
 fn get_dns_servers() -> Result<Vec<IpAddr>> {
-    let f = File::open("/run/systemd/netif/state")?;
-    let ip_strings = util::key_lookup_reader('=', "DNS", f)?
+    let f = File::open("/run/systemd/netif/state")
+        .chain_err(|| "failed to open /run/systemd/netif/state")?;
+    let ip_strings = util::key_lookup_reader('=', "DNS", f)
+        .chain_err(|| "failed to parse /run/systemd/netif/state")?
         .ok_or("DNS not found in netif state file")?;
     let mut addrs = Vec::new();
     for ip_string in ip_strings.split(' ') {

--- a/src/providers/packet/mod.rs
+++ b/src/providers/packet/mod.rs
@@ -62,6 +62,7 @@ struct PacketBondingMode {
 struct PacketInterfaceInfo {
     name: String,
     mac: String,
+    bond: Option<String>,
 }
 
 #[derive(Clone,Deserialize)]
@@ -117,83 +118,102 @@ fn get_dns_servers() -> Result<Vec<IpAddr>> {
 
 fn parse_network(netinfo: &PacketNetworkInfo) -> Result<(Vec<Interface>,Vec<Device>)> {
     let mut interfaces = Vec::new();
+    let mut bonds = Vec::new();
+    let dns_servers = get_dns_servers()?;
     for i in netinfo.interfaces.clone() {
         let mac = MacAddr::from_str(&i.mac)
             .map_err(|err| Error::from(format!("{:?}", err)))
             .chain_err(|| format!("failed to parse mac address: '{}'", i.mac))?;
         interfaces.push(Interface {
             mac_address: Some(mac),
-            bond: Some("bond0".to_owned()),
+            bond: i.bond.clone(),
             name: None,
             priority: None,
             nameservers: Vec::new(),
             ip_addresses: Vec::new(),
             routes: Vec::new(),
         });
+
+        // if there is a bond key, make sure we have a bond device for it
+        if let Some(ref bond_name) = i.bond {
+            let bond = Interface {
+                name: Some(bond_name.clone()),
+                priority: Some(5),
+                nameservers: dns_servers.clone(),
+                mac_address: None,
+                bond: None,
+                ip_addresses: Vec::new(),
+                routes: Vec::new(),
+            };
+            if !bonds.iter().any(|&(_, ref b): &(MacAddr, Interface)| &bond == b) {
+                bonds.push((mac, bond));
+            }
+        }
     }
-    let mut iface = Interface{
-        name: Some("bond0".to_owned()),
-        priority: Some(5),
-        nameservers: get_dns_servers()?,
-        mac_address: None,
-        bond: None,
-        ip_addresses: Vec::new(),
-        routes: Vec::new(),
-    };
+
+    // according to the folks from packet, all the addresses given to us in the
+    // network section should be attached to the first bond we find in the list
+    // of interfaces. we should always have at least one bond listed, but if we
+    // don't find any, we just print out a scary warning and don't attach the
+    // addresses to anything.
+    if bonds.is_empty() {
+        warn!("no bond interfaces. addresses are left unassigned.");
+        // the rest of the function operates on bonds, so just return
+        return Ok((interfaces, vec![]));
+    }
+
+    // remove panics if the index is out of bounds, but we know that there is at
+    // least one bond in the vector because we return if it's empty
+    let (first_mac, mut first_bond) = bonds.remove(0);
     for a in netinfo.addresses.clone() {
         let prefix = ipnetwork::ip_mask_to_prefix(a.netmask)
             .chain_err(|| "invalid network mask")?;
-        iface.ip_addresses.push(
-            match a.address {
-                IpAddr::V4(addrv4) => IpNetwork::V4(Ipv4Network::new(addrv4, prefix)
-                    .chain_err(|| "invalid IP address or prefix")?),
-                IpAddr::V6(addrv6) => IpNetwork::V6(Ipv6Network::new(addrv6, prefix)
-                    .chain_err(|| "invalid IP address or prefix")?),
-            }
-        );
+        first_bond.ip_addresses.push(IpNetwork::new(a.address, prefix)
+                                .chain_err(|| "invalid IP address or prefix")?);
         let dest = match (a.public,a.address) {
             (false,IpAddr::V4(_)) =>
-                    IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(10,0,0,0),8).unwrap()),
+                IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(10,0,0,0),8).unwrap()),
             (true,IpAddr::V4(_)) =>
-                    IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(0,0,0,0),0).unwrap()),
+                IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(0,0,0,0),0).unwrap()),
             (_,IpAddr::V6(_)) =>
-                    IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0,0,0,0,0,0,0,0),0).unwrap()),
+                IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0,0,0,0,0,0,0,0),0).unwrap()),
         };
-        iface.routes.push(
-            NetworkRoute {
-                destination: dest,
-                gateway: a.gateway,
-            }
-
-        );
+        first_bond.routes.push(NetworkRoute {
+            destination: dest,
+            gateway: a.gateway,
+        });
     }
-    interfaces.push(iface);
+    bonds.push((first_mac, first_bond));
 
     let mut attrs = vec![
-		("TransmitHashPolicy".to_owned(), "layer3+4".to_owned()),
-		("MIIMonitorSec".to_owned(), ".1".to_owned()),
-		("UpDelaySec".to_owned(), ".2".to_owned()),
-		("DownDelaySec".to_owned(), ".2".to_owned()),
-		("Mode".to_owned(), network::bonding_mode_to_string(&netinfo.bonding.mode)?),
+        ("TransmitHashPolicy".to_owned(), "layer3+4".to_owned()),
+        ("MIIMonitorSec".to_owned(), ".1".to_owned()),
+        ("UpDelaySec".to_owned(), ".2".to_owned()),
+        ("DownDelaySec".to_owned(), ".2".to_owned()),
+        ("Mode".to_owned(), network::bonding_mode_to_string(&netinfo.bonding.mode)?),
     ];
     if netinfo.bonding.mode == network::BONDING_MODE_LACP {
         attrs.push(("LACPTransmitRate".to_owned(), "fast".to_owned()));
     }
-    let network_devices = vec![
-        Device{
-            name: "bond0".to_owned(),
+
+    let mut network_devices = vec![];
+    for (mac, bond) in bonds {
+        network_devices.push(Device {
+            name: bond.name.clone()
+                .ok_or("bond doesn't have a name, should be impossible")?,
             kind: "bond".to_owned(),
-            mac_address: interfaces[0].mac_address
-                .ok_or("first interface doesn't have a mac address, should be impossible")?,
+            mac_address: mac,
             priority: Some(5),
             sections: vec![
                 Section{
                     name: "Bond".to_owned(),
-                    attributes: attrs,
+                    attributes: attrs.clone(),
                 }
             ],
-        },
-    ];
+        });
+        // finally, make sure the bond interfaces are in the interface list
+        interfaces.push(bond)
+    }
 
     Ok((interfaces,network_devices))
 }


### PR DESCRIPTION
the metadata for network interfaces has a bond field. up until now, we ignored it and just always created a bond named bond0, attached all addresses to it, and bonded both physical interfaces to it. now, we create any bond interfaces mentioned in the network interfaces list, so there may be multiple bonds. it also doesn't configure bonds for interfaces that don't have a bond key listed in the metadata.

/cc @bgilbert 