### PR TITLE
travis: only run ci with rust version in sdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,3 @@
 language: rust
 rust:
-  - stable
-  - beta
-  - nightly
-matrix:
-  allow_failures:
-    - rust: nightly
+  - 1.21.0


### PR DESCRIPTION
there are occasionally build failures when we are using packages that
are out of date enough to have been broken by new rust versions. we
don't actually care about any rust versions besides the one that is
currently in the sdk.