### PR TITLE
version: release v1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "coreos-metadata"
-version = "1.0.6"
+version = "1.1.0"
 dependencies = [
  "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coreos-metadata"
-version = "1.0.6"
+version = "1.1.0"
 authors = ["Stephen Demos <stephen.demos@coreos.com>"]
 
 [[bin]]


### PR DESCRIPTION
Release Notes draft: 

* Remove support for the Oracle OCI metadata provider (#86)