### PR TITLE
travis: bump rust version to match sdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: rust
 rust:
-  - 1.21.0
+  - 1.26.0


### PR DESCRIPTION
The SDK is now on Rust 1.26.0, so we should be building with that
version.