### PR TITLE
Add systemd units and a basic Makefile to install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+DESTDIR ?=
+PREFIX ?= /usr
+
+DEFAULT_INSTANCE ?= core
+
+units = $(addprefix systemd/,coreos-metadata.service coreos-metadata-sshkeys@.service)
+
+%.service: %.service.in
+	sed -e 's,@DEFAULT_INSTANCE@,'$(DEFAULT_INSTANCE)',' < $< > $@.tmp && mv $@.tmp $@
+
+all:
+	cargo build --release
+
+install-units: $(units)
+	for unit in $(units); do install -D --target-directory=$(DESTDIR)$(PREFIX)/lib/systemd/system/ $$unit; done

--- a/systemd/.gitignore
+++ b/systemd/.gitignore
@@ -1,0 +1,1 @@
+coreos-metadata-sshkeys@.service

--- a/systemd/coreos-metadata-sshkeys@.service.in
+++ b/systemd/coreos-metadata-sshkeys@.service.in
@@ -1,0 +1,11 @@
+[Unit]
+Description=CoreOS Metadata Agent (SSH Keys)
+
+[Service]
+Type=oneshot
+Environment=COREOS_METADATA_OPT_PROVIDER=--cmdline
+ExecStart=/usr/bin/coreos-metadata ${COREOS_METADATA_OPT_PROVIDER} --ssh-keys=%i
+
+[Install]
+DefaultInstance=@DEFAULT_INSTANCE@
+RequiredBy=multi-user.target

--- a/systemd/coreos-metadata.service
+++ b/systemd/coreos-metadata.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=CoreOS Metadata Agent
+
+[Service]
+Type=oneshot
+Environment=COREOS_METADATA_OPT_PROVIDER=--cmdline
+ExecStart=/usr/bin/coreos-metadata ${COREOS_METADATA_OPT_PROVIDER} --attributes=/run/metadata/coreos
+
+[Install]
+RequiredBy=metadata.target


### PR DESCRIPTION
We're looking at adapting coreos-metdata for [FCOS](https://coreos.fedoraproject.org/).
We'll need to package it again as an RPM (probably).

Regardless, I think it's best to have systemd unit files upstream.
Taken from:
https://github.com/coreos/coreos-overlay/tree/master/coreos-base/coreos-metadata/files