### PR TITLE
travis: build on minimum and current toolchains

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
 language: rust
 rust:
-  - 1.26.0
+  - 1.26.0  # minimum supported toolchain
+  - stable
+  - beta
+  - nightly
+
+matrix:
+  allow_failures:
+    - rust: nightly

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# CoreOS Metadata
+# coreos-metadata
+
+[![Build Status](https://travis-ci.org/coreos/coreos-metadata.svg?branch=master)](https://travis-ci.org/coreos/coreos-metadata)
+![minimum rust 1.26](https://img.shields.io/badge/rust-1.26%2B-orange.svg)
 
 This is a small utility, typically used in conjunction with [Ignition][ignition], which reads metadata from a given cloud-provider and applies it to the system.
 This can include adding SSH keys and writing cloud-specific attributes into an environment file (e.g. `/run/metadata/coreos`), which can then be consumed by systemd service units via `EnvironmentFile=`.


### PR DESCRIPTION
This checks that master and further PRs won't break on current          
toolchains, nor on older ones used by downstream distributions          
(pinning to 1.26 for historical ContainerLinux compatibility).