### PR TITLE
util: drop key_lookup

### DIFF
--- a/src/providers/packet/mod.rs
+++ b/src/providers/packet/mod.rs
@@ -127,7 +127,7 @@ impl PacketProvider {
     fn get_dns_servers() -> Result<Vec<IpAddr>> {
         let f = File::open("/run/systemd/netif/state")
             .chain_err(|| "failed to open /run/systemd/netif/state")?;
-        let ip_strings = util::key_lookup_reader('=', "DNS", f)
+        let ip_strings = util::key_lookup('=', "DNS", f)
             .chain_err(|| "failed to parse /run/systemd/netif/state")?
             .ok_or("DNS not found in netif state file")?;
         let mut addrs = Vec::new();


### PR DESCRIPTION
key_lookup is no longer used anywhere; drop it and rename
key_lookup_reader to key_lookup.

Figured fixing this warning before cutting 2.0.0 would be a good idea. There's really not much reason to keep `key_lookup` around since it's trivial to use `std::io::Cursor` to use `key_lookup_reader` with strings.