### PR TITLE
version: release v2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "coreos-metadata"
-version = "1.0.6"
+version = "2.0.0"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coreos-metadata"
-version = "1.0.6"
+version = "2.0.0"
 authors = ["Stephen Demos <stephen.demos@coreos.com>"]
 
 [[bin]]


### PR DESCRIPTION
Since #88 changed the public API in a backwards-incompatible way, we need to do a major version bump.