### PR TITLE
github: add issue reporting templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Report an issue with coreos-metadata
+---
+
+# Bug #
+
+## Operating System Version ##
+
+## coreos-metadata Version ##
+
+## Environment ##
+
+What hardware/cloud provider/hypervisor is being used to run coreos-metadata?
+
+## Expected Behavior ##
+
+## Actual Behavior ##
+
+## Reproduction Steps ##
+
+  1. ...
+  2. ...
+
+## Other Information ##

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an enhancement to coreos-metadata
+---
+
+# Feature Request #
+
+## Environment ##
+
+What hardware/cloud provider/hypervisor is being used to run coreos-metadata?
+
+## Desired Feature ##
+
+## Other Information ##


### PR DESCRIPTION
This will cause GitHub's "New issue" button to redirect to a template chooser.  For a sense of the UX, see [here](https://github.com/bgilbert/bugs/issues).