### PR TITLE
providers/ec2: added EC2_PUBLIC_HOSTNAME attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The supported cloud providers and their respective metadata are as follows:
     - SSH Keys
     - Attributes
       - COREOS_EC2_HOSTNAME
+      - COREOS_EC2_PUBLIC_HOSTNAME
       - COREOS_EC2_IPV4_LOCAL
       - COREOS_EC2_IPV4_PUBLIC
       - COREOS_EC2_AVAILABILITY_ZONE

--- a/src/providers/ec2/mod.rs
+++ b/src/providers/ec2/mod.rs
@@ -100,6 +100,7 @@ impl MetadataProvider for Ec2Provider {
         add_value(&mut out, "EC2_IPV4_PUBLIC", "meta-data/public-ipv4")?;
         add_value(&mut out, "EC2_AVAILABILITY_ZONE", "meta-data/placement/availability-zone")?;
         add_value(&mut out, "EC2_HOSTNAME", "meta-data/hostname")?;
+        add_value(&mut out, "EC2_PUBLIC_HOSTNAME", "meta-data/public-hostname")?;
 
         let region = self.client
             .get(retry::Json, Ec2Provider::endpoint_for("dynamic/instance-identity/document"))


### PR DESCRIPTION
Added attribute EC2_PUBLIC_HOSTNAME for the EC2 provider

Attribute EC2_PUBLIC_HOSTNAME for EC2, was introduced at `2007-01-19`