### PR TITLE
cargo: enable LTO for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["Stephen Demos <stephen.demos@coreos.com>"]
 name = "coreos-metadata"
 path = "src/bin/coreos-metadata.rs"
 
+[profile.release]
+lto = true
+
 [dependencies]
 clap = "2.26"
 users = "0.6"


### PR DESCRIPTION
LTO makes the final binary a bit smaller, and isn't really a risk here,
so enable it.