### PR TITLE
travis: bump clippy version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - nightly-2018-06-11  # pinned toolchain for clippy
+  - nightly-2018-07-24  # pinned toolchain for clippy
   - 1.26.0              # minimum supported toolchain
   - stable
   - beta
@@ -12,12 +12,11 @@ matrix:
 
 env:
   global:
-    - CLIPPY_VERSION=0.0.207
-    - CLIPPY_RUST_VERSION=nightly-2018-06-11
+    - CLIPPY_RUST_VERSION=nightly-2018-07-24
 
 before_script:
   - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then
-      cargo install clippy --vers $CLIPPY_VERSION --force;
+      rustup component add clippy-preview;
     fi'
 
 script:


### PR DESCRIPTION
See also coreos/update-ssh-keys#30; this lets us use the new `clippy-preview` component in `rustup`.