### PR TITLE
azure/crypto: remove all unwraps

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ pub mod errors {
             Io(::std::io::Error);
             Reqwest(::reqwest::Error);
             Hyper(::hyper::error::Error);
+            OpensslStack(::openssl::error::ErrorStack);
         }
         errors {
             UnknownProvider(p: String) {

--- a/src/providers/azure/crypto/x509.rs
+++ b/src/providers/azure/crypto/x509.rs
@@ -65,9 +65,13 @@ pub fn generate_cert(config: &Config) -> Result<(X509, PKey)> {
 
     // call fails without expiration dates
     // I guess they are important anyway, but still
-    x509builder.set_not_before(&Asn1Time::days_from_now(0).unwrap())
+    let not_before = Asn1Time::days_from_now(0)
+        .chain_err(|| "failed to parse 'notBefore' timestamp")?;
+    let not_after = Asn1Time::days_from_now(config.expire_in_days)
+        .chain_err(|| "failed to parse 'notAfter' timestamp")?;
+    x509builder.set_not_before(&not_before)
         .chain_err(|| "failed to set x509 start date")?;
-    x509builder.set_not_after(&Asn1Time::days_from_now(config.expire_in_days).unwrap())
+    x509builder.set_not_after(&not_after)
         .chain_err(|| "failed to set x509 expiration date")?;
 
     // add the issuer and subject name


### PR DESCRIPTION
This converts all `unwrap` usages in `azure/crypto` into proper
error chaining.