### PR TITLE
cargo: coreos-metadata release 3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "coreos-metadata"
-version = "3.0.0"
+version = "3.0.1-alpha.0"
 dependencies = [
  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "coreos-metadata"
-version = "3.0.0-alpha.0"
+version = "3.0.0"
 dependencies = [
  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud-provider metadata agent"
-version = "3.0.0-alpha.0"
+version = "3.0.0"
 
 [[bin]]
 name = "coreos-metadata"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud-provider metadata agent"
-version = "3.0.0"
+version = "3.0.1-alpha.0"
 
 [[bin]]
 name = "coreos-metadata"


### PR DESCRIPTION
coreos-metadata v3.0.0:
 * cargo: bump update-ssh-keys to 0.3.0
 * src: make a single-binary only project
 * providers/gcp: scrape new endpoint for ssh keys
