### PR TITLE
providers: add support for hetzner cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ The supported cloud providers and their respective metadata are as follows:
       - COREOS_GCE_HOSTNAME
       - COREOS_GCE_IP_EXTERNAL_0
       - COREOS_GCE_IP_LOCAL_0
+  - hcloud
+    - SSH Keys
+    - Attributes
+      - COREOS_HCLOUD_HOSTNAME
+      - COREOS_HCLOUD_IPV4_LOCAL
+      - COREOS_HCLOUD_IPV4_PUBLIC
+      - COREOS_HCLOUD_INSTANCE_ID
   - openstack-metadata
     - SSH Keys
     - Attributes

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -32,6 +32,7 @@ pub fn fetch_metadata(provider: &str) -> errors::Result<Box<MetadataProvider>> {
         "digitalocean" => box_result!(digitalocean::DigitalOceanProvider::new()),
         "ec2" => box_result!(ec2::Ec2Provider::new()),
         "gce" => box_result!(gce::GceProvider::new()),
+        "hcloud" => box_result!(hcloud::HetznerCloudProvider::new()),
         "openstack-metadata" => box_result!(openstack::network::OpenstackProvider::new()),
         "packet" => box_result!(packet::PacketProvider::new()),
         "vagrant-virtualbox" => box_result!(vagrant_virtualbox::VagrantVirtualboxProvider::new()),

--- a/src/providers/hcloud/mod.rs
+++ b/src/providers/hcloud/mod.rs
@@ -1,0 +1,109 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! aws ec2 metadata fetcher
+//!
+
+use std::collections::HashMap;
+
+use openssh_keys::PublicKey;
+use update_ssh_keys::AuthorizedKeyEntry;
+
+use errors::*;
+use network;
+use providers::MetadataProvider;
+use retry;
+use serde_json;
+
+#[cfg(not(test))]
+const URL: &str = "http://169.254.169.254/2009-04-04";
+
+#[allow(non_snake_case)]
+#[derive(Debug, Deserialize)]
+struct InstanceIdDoc {
+    region: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct HetznerCloudProvider {
+    client: retry::Client,
+}
+
+impl HetznerCloudProvider {
+    pub fn new() -> Result<HetznerCloudProvider> {
+        let client = retry::Client::new()?
+            .return_on_404(true);
+
+        Ok(HetznerCloudProvider { client })
+    }
+
+    fn endpoint_for(key: &str) -> String {
+        format!("{}/{}", URL, key)
+    }
+}
+
+impl MetadataProvider for HetznerCloudProvider {
+    fn attributes(&self) -> Result<HashMap<String, String>> {
+        let mut out = HashMap::with_capacity(4);
+
+        let add_value = |map: &mut HashMap<_, _>, key: &str, name| -> Result<()> {
+            let value = self.client.get(retry::Raw, HetznerCloudProvider::endpoint_for(name)).send()?;
+
+            if let Some(value) = value {
+                map.insert(key.to_string(), value);
+            }
+
+            Ok(())
+        };
+
+        add_value(&mut out, "HCLOUD_INSTANCE_ID", "meta-data/instance-id")?;
+        add_value(&mut out, "HCLOUD_IPV4_LOCAL", "meta-data/local-ipv4")?;
+        add_value(&mut out, "HCLOUD_IPV4_PUBLIC", "meta-data/public-ipv4")?;
+        add_value(&mut out, "HCLOUD_HOSTNAME", "meta-data/hostname")?;
+
+        Ok(out)
+    }
+
+    fn hostname(&self) -> Result<Option<String>> {
+        self.client.get(retry::Raw, HetznerCloudProvider::endpoint_for("meta-data/hostname")).send()
+    }
+
+    fn ssh_keys(&self) -> Result<Vec<AuthorizedKeyEntry>> {
+        let raw_keys: Option<String> = self.client
+            .get(retry::Raw, HetznerCloudProvider::endpoint_for("meta-data/public-keys"))
+            .send()?;
+
+        if let Some(raw_keys) = raw_keys {
+            let keys: Vec<String> = serde_json::from_str(&raw_keys).unwrap();
+            let mut out = Vec::new();
+
+            for key in keys {
+                let key = PublicKey::parse(&key)?;
+                out.push(AuthorizedKeyEntry::Valid{key});
+            }
+
+            Ok(out)
+        } else {
+            Ok(vec![])
+        }
+    }
+
+    fn networks(&self) -> Result<Vec<network::Interface>> {
+        Ok(vec![])
+    }
+
+    fn network_devices(&self) -> Result<Vec<network::Device>> {
+        Ok(vec![])
+    }
+}

--- a/src/providers/hcloud/mod.rs
+++ b/src/providers/hcloud/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 CoreOS, Inc.
+// Copyright 2018 CoreOS, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! aws ec2 metadata fetcher
+//! Hetzner Cloud metadata fetcher
 //!
 
 use std::collections::HashMap;

--- a/src/providers/hcloud/mod.rs
+++ b/src/providers/hcloud/mod.rs
@@ -26,7 +26,6 @@ use providers::MetadataProvider;
 use retry;
 use serde_json;
 
-#[cfg(not(test))]
 const URL: &str = "http://169.254.169.254/2009-04-04";
 
 #[allow(non_snake_case)]

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -28,6 +28,7 @@ pub mod digitalocean;
 pub mod cloudstack;
 pub mod ec2;
 pub mod gce;
+pub mod hcloud;
 pub mod openstack;
 pub mod packet;
 pub mod vagrant_virtualbox;


### PR DESCRIPTION
Along with:
- https://github.com/coreos/ignition/pull/667
- https://github.com/coreos/coreos-overlay/pull/3490
- https://github.com/coreos/scripts/pull/859
- https://github.com/coreos/container-linux-config-transpiler/pull/164
- https://github.com/coreos/bootengine/pull/150

This will greatly enhance working with CoreOS on the Hetzner Cloud.