### PR TITLE
[WIP] provider: add boot check-in on azure and packet

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use reqwest::header;
+use serde_json;
 
 error_chain!{
     links {
@@ -24,6 +25,7 @@ error_chain!{
         XmlDeserialize(::serde_xml_rs::Error);
         Base64Decode(::base64::DecodeError);
         Io(::std::io::Error);
+        Json(serde_json::Error);
         Reqwest(::reqwest::Error);
         OpensslStack(::openssl::error::ErrorStack);
         HeaderValue(header::InvalidHeaderValue);

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ extern crate reqwest;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde;
+#[cfg_attr(test, macro_use)]
 extern crate serde_json;
 extern crate serde_xml_rs;
 #[macro_use]
@@ -63,6 +64,7 @@ const CMDLINE_OEM_FLAG: &str = "coreos.oem.id";
 struct Config {
     provider: String,
     attributes_file: Option<String>,
+    check_in: bool,
     ssh_keys_user: Option<String>,
     hostname_file: Option<String>,
     network_units_dir: Option<String>,
@@ -110,6 +112,12 @@ fn run() -> Result<()> {
         .map_or(Ok(()), |x| metadata.write_network_units(x))
         .chain_err(|| "writing network units")?;
 
+    // perform boot check-in.
+    if config.check_in {
+        metadata.boot_checkin()
+            .chain_err(|| "checking-in instance boot to cloud provider")?;
+    }
+
     debug!("Done!");
 
     Ok(())
@@ -142,6 +150,9 @@ fn init() -> Result<Config> {
              .long("attributes")
              .help("The file into which the metadata attributes are written")
              .takes_value(true))
+        .arg(Arg::with_name("check-in")
+             .long("cmdline")
+             .help("Check-in this instance boot with the cloud provider"))
         .arg(Arg::with_name("cmdline")
              .long("cmdline")
              .help("Read the cloud provider from the kernel cmdline"))
@@ -174,6 +185,7 @@ fn init() -> Result<Config> {
             }
         },
         attributes_file: matches.value_of("attributes").map(String::from),
+        check_in: matches.is_present("check-in"),
         ssh_keys_user: matches.value_of("ssh-keys").map(String::from),
         hostname_file: matches.value_of("hostname").map(String::from),
         network_units_dir: matches.value_of("network-units").map(String::from),

--- a/src/providers/azure/mock_tests.rs
+++ b/src/providers/azure/mock_tests.rs
@@ -1,0 +1,82 @@
+use mockito::{self, Matcher};
+use providers::{azure, MetadataProvider};
+
+#[test]
+fn test_boot_checkin() {
+    let fab_version = "/?comp=versions";
+    let ver_body = r#"<?xml version="1.0" encoding="utf-8"?>
+<Versions>
+  <Preferred>
+    <Version>2015-04-05</Version>
+  </Preferred>
+  <Supported>
+    <Version>2015-04-05</Version>
+    <Version>2012-11-30</Version>
+    <Version>2012-09-15</Version>
+    <Version>2012-05-15</Version>
+    <Version>2011-12-31</Version>
+    <Version>2011-10-15</Version>
+    <Version>2011-08-31</Version>
+    <Version>2011-04-07</Version>
+    <Version>2010-12-15</Version>
+    <Version>2010-28-10</Version>
+  </Supported>
+</Versions>"#;
+    let m_version = mockito::mock("GET", fab_version)
+        .with_body(ver_body)
+        .with_status(200)
+        .create();
+
+    let fab_goalstate = "/machine/?comp=goalstate";
+    let gs_body = r#"<?xml version="1.0" encoding="utf-8"?>
+<GoalState xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="goalstate10.xsd">
+  <Version>2012-11-30</Version>
+  <Incarnation>1</Incarnation>
+  <Machine>
+    <ExpectedState>Started</ExpectedState>
+    <StopRolesDeadlineHint>300000</StopRolesDeadlineHint>
+    <LBProbePorts>
+      <Port>16001</Port>
+    </LBProbePorts>
+    <ExpectHealthReport>FALSE</ExpectHealthReport>
+  </Machine>
+  <Container>
+    <ContainerId>a511aa6d-29e7-4f53-8788-55655dfe848f</ContainerId>
+    <RoleInstanceList>
+      <RoleInstance>
+        <InstanceId>f6cd1d7ef1644557b9059345e5ba890c.lars-test-1</InstanceId>
+        <State>Started</State>
+        <Configuration>
+          <HostingEnvironmentConfig>http://100.115.176.3:80/machine/a511aa6d-29e7-4f53-8788-55655dfe848f/f6cd1d7ef1644557b9059345e5ba890c.lars%2Dtest%2D1?comp=config&amp;type=hostingEnvironmentConfig&amp;incarnation=1</HostingEnvironmentConfig>
+          <SharedConfig>http://100.115.176.3:80/machine/a511aa6d-29e7-4f53-8788-55655dfe848f/f6cd1d7ef1644557b9059345e5ba890c.lars%2Dtest%2D1?comp=config&amp;type=sharedConfig&amp;incarnation=1</SharedConfig>
+          <ExtensionsConfig>http://100.115.176.3:80/machine/a511aa6d-29e7-4f53-8788-55655dfe848f/f6cd1d7ef1644557b9059345e5ba890c.lars%2Dtest%2D1?comp=config&amp;type=extensionsConfig&amp;incarnation=1</ExtensionsConfig>
+          <FullConfig>http://100.115.176.3:80/machine/a511aa6d-29e7-4f53-8788-55655dfe848f/f6cd1d7ef1644557b9059345e5ba890c.lars%2Dtest%2D1?comp=config&amp;type=fullConfig&amp;incarnation=1</FullConfig>
+          <Certificates>http://100.115.176.3:80/machine/a511aa6d-29e7-4f53-8788-55655dfe848f/f6cd1d7ef1644557b9059345e5ba890c.lars%2Dtest%2D1?comp=certificates&amp;incarnation=1</Certificates>
+          <ConfigName>f6cd1d7ef1644557b9059345e5ba890c.0.f6cd1d7ef1644557b9059345e5ba890c.0.lars-test-1.1.xml</ConfigName>
+        </Configuration>
+      </RoleInstance>
+    </RoleInstanceList>
+  </Container>
+</GoalState>
+"#;
+    let m_goalstate = mockito::mock("GET", fab_goalstate)
+        .with_body(gs_body)
+        .with_status(200)
+        .create();
+
+    let fab_health = "/machine/?comp=health";
+    let m_health = mockito::mock("POST", fab_health)
+        .match_header("content-type", Matcher::Regex("text/xml".to_string()))
+        .match_header("x-ms-version", Matcher::Regex("2012-11-30".to_string()))
+        .match_body(Matcher::Regex("<State>Ready</State>".to_string()))
+        .with_status(200)
+        .create();
+
+    let provider = azure::Azure::try_new();
+    let r = provider.unwrap().boot_checkin();
+
+    m_version.assert();
+    m_goalstate.assert();
+    m_health.assert();
+    r.unwrap();
+}

--- a/src/providers/azure/mod.rs
+++ b/src/providers/azure/mod.rs
@@ -28,14 +28,15 @@ use errors::*;
 use network;
 use providers::MetadataProvider;
 use retry;
-use util;
+
+#[cfg(test)]
+mod mock_tests;
 
 static HDR_AGENT_NAME: &str = "x-ms-agent-name";
 static HDR_VERSION: &str = "x-ms-version";
 static HDR_CIPHER_NAME: &str = "x-ms-cipher-name";
 static HDR_CERT: &str = "x-ms-guest-agent-public-x509-cert";
 
-const OPTION_245: &str = "OPTION_245";
 const MS_AGENT_NAME: &str = "com.coreos.metadata";
 const MS_VERSION: &str = "2012-11-30";
 const SMIME_HEADER: &str = "\
@@ -46,6 +47,28 @@ Content-Transfer-Encoding: base64
 
 ";
 
+macro_rules! ready_state {
+    ($container:expr, $instance:expr) => {
+        format!(r#"<?xml version="1.0" encoding="utf-8"?>
+<Health xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <GoalStateIncarnation>1</GoalStateIncarnation>
+  <Container>
+    <ContainerId>{}</ContainerId>
+    <RoleInstanceList>
+      <Role>
+        <InstanceId>{}</InstanceId>
+        <Health>
+          <State>Ready</State>
+        </Health>
+      </Role>
+    </RoleInstanceList>
+  </Container>
+</Health>
+"#,
+                $container, $instance)
+    }
+}
+
 #[derive(Debug, Deserialize, Clone, Default)]
 struct GoalState {
     #[serde(rename = "Container")]
@@ -54,8 +77,10 @@ struct GoalState {
 
 #[derive(Debug, Deserialize, Clone, Default)]
 struct Container {
+    #[serde(rename = "ContainerId")]
+    pub container_id: String,
     #[serde(rename = "RoleInstanceList")]
-    pub role_instance_list: RoleInstanceList
+    pub role_instance_list: RoleInstanceList,
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]
@@ -67,7 +92,9 @@ struct RoleInstanceList {
 #[derive(Debug, Deserialize, Clone)]
 struct RoleInstance {
     #[serde(rename = "Configuration")]
-    pub configuration: Configuration
+    pub configuration: Configuration,
+    #[serde(rename = "InstanceId")]
+    pub instance_id: String,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -174,13 +201,14 @@ impl Azure {
     }
 
     fn get_goal_state(&self) -> Result<GoalState> {
-        self.client.get(retry::Xml, format!("http://{}/machine/?comp=goalstate", self.endpoint)).send()
+        self.client.get(retry::Xml, format!("{}/machine/?comp=goalstate", self.fabric_base_url())).send()
             .chain_err(|| "failed to get goal state")?
         .ok_or_else(|| "failed to get goal state: not found response".into())
     }
 
+    #[cfg(not(test))]
     fn get_fabric_address() -> Result<IpAddr> {
-        let v = util::dns_lease_key_lookup(OPTION_245)?;
+        let v = ::util::dns_lease_key_lookup("OPTION_245")?;
         // value is an 8 digit hex value. convert it to u32 and
         // then parse that into an ip. Ipv4Addr::from(u32)
         // performs conversion from big-endian
@@ -190,8 +218,24 @@ impl Azure {
         Ok(IpAddr::V4(dec.into()))
     }
 
+    #[cfg(not(test))]
+    fn fabric_base_url(&self) -> String {
+        format!("http://{}", self.endpoint)
+    }
+
+    #[cfg(test)]
+    fn get_fabric_address() -> Result<IpAddr> {
+        use std::net::Ipv4Addr;
+        Ok(IpAddr::from(Ipv4Addr::new(127, 0, 0, 1)))
+    }
+
+    #[cfg(test)]
+    fn fabric_base_url(&self) -> String {
+        ::mockito::server_url().to_string()
+    }
+
     fn is_fabric_compatible(&self, version: &str) -> Result<()> {
-        let versions: Versions = self.client.get(retry::Xml, format!("http://{}/?comp=versions", self.endpoint)).send()
+        let versions: Versions = self.client.get(retry::Xml, format!("{}/?comp=versions", self.fabric_base_url())).send()
             .chain_err(|| "failed to get versions")?
             .ok_or_else(|| "failed to get versions: not found")?;
 
@@ -282,6 +326,20 @@ impl Azure {
 
         Ok(attributes)
     }
+
+    /// Return this instance `ContainerId`.
+    pub(crate) fn container_id(&self) -> &str {
+        &self.goal_state.container.container_id
+    }
+
+    /// Return this instance `InstanceId`.
+    pub(crate) fn instance_id(&self) -> Result<&str> {
+        Ok(&self.goal_state.container
+           .role_instance_list
+           .role_instances.get(0)
+           .ok_or_else(|| "empty RoleInstanceList".to_string())?
+           .instance_id)
+    }
 }
 
 impl MetadataProvider for Azure {
@@ -315,5 +373,13 @@ impl MetadataProvider for Azure {
 
     fn network_devices(&self) -> Result<Vec<network::Device>> {
         Ok(vec![])
+    }
+
+    fn boot_checkin(&self) -> Result<()> {
+        let body = ready_state!(self.container_id(), self.instance_id()?);
+        let url = self.fabric_base_url() + "/machine/?comp=health";
+        self.client.post(retry::Xml, url, body.into())
+            .dispatch_post()?;
+        Ok(())
     }
 }

--- a/src/providers/cloudstack/configdrive.rs
+++ b/src/providers/cloudstack/configdrive.rs
@@ -137,6 +137,11 @@ impl MetadataProvider for ConfigDrive {
     fn network_devices(&self) -> Result<Vec<network::Device>> {
         Ok(vec![])
     }
+
+    fn boot_checkin(&self) -> Result<()> {
+        warn!("boot check-in requested, but not supported on this platform");
+        Ok(())
+    }
 }
 
 impl ::std::ops::Drop for ConfigDrive {

--- a/src/providers/cloudstack/network.rs
+++ b/src/providers/cloudstack/network.rs
@@ -101,4 +101,9 @@ impl MetadataProvider for CloudstackNetwork {
     fn network_devices(&self) -> Result<Vec<network::Device>> {
         Ok(vec![])
     }
+
+    fn boot_checkin(&self) -> Result<()> {
+        warn!("boot check-in requested, but not supported on this platform");
+        Ok(())
+    }
 }

--- a/src/providers/digitalocean/mod.rs
+++ b/src/providers/digitalocean/mod.rs
@@ -265,4 +265,9 @@ impl MetadataProvider for DigitalOceanProvider {
     fn network_devices(&self) -> Result<Vec<network::Device>> {
         Ok(vec![])
     }
+
+    fn boot_checkin(&self) -> Result<()> {
+        warn!("boot check-in requested, but not supported on this platform");
+        Ok(())
+    }
 }

--- a/src/providers/ec2/mod.rs
+++ b/src/providers/ec2/mod.rs
@@ -140,4 +140,9 @@ impl MetadataProvider for Ec2Provider {
     fn network_devices(&self) -> Result<Vec<network::Device>> {
         Ok(vec![])
     }
+
+    fn boot_checkin(&self) -> Result<()> {
+        warn!("boot check-in requested, but not supported on this platform");
+        Ok(())
+    }
 }

--- a/src/providers/gce/mod.rs
+++ b/src/providers/gce/mod.rs
@@ -146,4 +146,9 @@ impl MetadataProvider for GceProvider {
     fn network_devices(&self) -> Result<Vec<network::Device>> {
         Ok(vec![])
     }
+
+    fn boot_checkin(&self) -> Result<()> {
+        warn!("boot check-in requested, but not supported on this platform");
+        Ok(())
+    }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -61,6 +61,7 @@ pub trait MetadataProvider {
     fn ssh_keys(&self) -> Result<Vec<AuthorizedKeyEntry>>;
     fn networks(&self) -> Result<Vec<network::Interface>>;
     fn network_devices(&self) -> Result<Vec<network::Device>>;
+    fn boot_checkin(&self) -> Result<()>;
 
     fn write_attributes(&self, attributes_file_path: String) -> Result<()> {
         let mut attributes_file = create_file(&attributes_file_path)?;

--- a/src/providers/openstack/network.rs
+++ b/src/providers/openstack/network.rs
@@ -91,4 +91,9 @@ impl MetadataProvider for OpenstackProvider {
     fn network_devices(&self) -> Result<Vec<network::Device>> {
         Ok(vec![])
     }
+
+    fn boot_checkin(&self) -> Result<()> {
+        warn!("boot check-in requested, but not supported on this platform");
+        Ok(())
+    }
 }

--- a/src/providers/packet/mock_tests.rs
+++ b/src/providers/packet/mock_tests.rs
@@ -1,0 +1,39 @@
+use mockito::{self, Matcher};
+use providers::{packet, MetadataProvider};
+
+#[test]
+fn test_boot_checkin() {
+    let ep = "/events";
+    let data = packet::PacketData {
+        id: String::new(),
+        hostname: String::new(),
+        iqn: String::new(),
+        plan: String::new(),
+        facility: String::new(),
+        tags: vec![],
+        ssh_keys: vec![],
+        network: packet::PacketNetworkInfo {
+            interfaces: vec![],
+            addresses: vec![],
+            bonding: packet::PacketBondingMode { mode: 0 },
+        },
+        error: None,
+        phone_home_url: mockito::server_url(),
+    };
+    let provider = packet::PacketProvider { data };
+
+    let json_body = json!({
+        "state": "succeeded",
+        "code": 1042,
+        "message": "coreos-metadata: boot check-in",
+    });
+    let mock = mockito::mock("POST", ep)
+        .match_header("content-type", Matcher::Regex("text/json.*".to_string()))
+        .match_body(Matcher::Json(json_body))
+        .with_status(200)
+        .create();
+
+    let r = provider.boot_checkin();
+    mock.assert();
+    r.unwrap();
+}

--- a/src/providers/vagrant_virtualbox/mod.rs
+++ b/src/providers/vagrant_virtualbox/mod.rs
@@ -91,4 +91,9 @@ impl MetadataProvider for VagrantVirtualboxProvider {
     fn network_devices(&self) -> Result<Vec<network::Device>> {
         Ok(vec![])
     }
+
+    fn boot_checkin(&self) -> Result<()> {
+        warn!("boot check-in requested, but not supported on this platform");
+        Ok(())
+    }
 }

--- a/src/retry/client.rs
+++ b/src/retry/client.rs
@@ -19,6 +19,7 @@
 //! of attempts and a backoff strategy. It also takes care of automatically
 //! deserializing responses and handles headers in a sane way.
 
+use std::borrow::Cow;
 use std::io::Read;
 use std::time::Duration;
 
@@ -138,6 +139,21 @@ impl Client {
     {
         RequestBuilder{
             url,
+            body: None,
+            d,
+            client: self.client.clone(),
+            headers: self.headers.clone(),
+            retry: self.retry.clone(),
+            return_on_404: self.return_on_404,
+        }
+    }
+
+    pub fn post<D>(&self, d: D, url: String, body: Cow<str>) -> RequestBuilder<D>
+        where D: Deserializer
+    {
+        RequestBuilder{
+            url,
+            body: Some(body.into_owned()),
             d,
             client: self.client.clone(),
             headers: self.headers.clone(),
@@ -151,6 +167,7 @@ pub struct RequestBuilder<D>
     where D: Deserializer
 {
     url: String,
+    body: Option<String>,
     d: D,
     client: reqwest::Client,
     headers: header::HeaderMap,
@@ -180,6 +197,34 @@ impl<D> RequestBuilder<D>
         self.retry.clone().retry(|attempt| {
             info!("Fetching {}: Attempt #{}", req.url(), attempt + 1);
             self.dispatch_request(&req)
+        })
+    }
+
+    pub fn dispatch_post(self) -> Result<reqwest::StatusCode>
+    {
+        let url = reqwest::Url::parse(self.url.as_str())
+            .chain_err(|| "failed to parse uri")?;
+
+        self.retry.clone().retry(|attempt| {
+            let mut builder = reqwest::Client::new()
+                .post(url.clone())
+                .headers(self.headers.clone())
+                .header(header::CONTENT_TYPE, self.d.content_type());
+            if let Some(ref content) = self.body {
+                builder = builder.body(content.clone());
+            };
+            let req = builder.build()
+                .chain_err(|| "failed to build POST request")?;
+
+            info!("Posting {}: attempt #{}", req.url(), attempt + 1);
+            let status = self.client.execute(req)
+                .chain_err(|| "failed to POST request")?
+                .status();
+            if status.is_success() {
+                Ok(status)
+            } else {
+                Err(format!("POST failed: {}", status).into())
+            }
         })
     }
 
@@ -213,7 +258,8 @@ impl<D> RequestBuilder<D>
     }
 }
 
-/// Reqwests Request struct doesn't implement copy, so we have to do it here
+/// Reqwests Request struct doesn't implement `Clone`,
+/// so we have to do it here.
 fn clone_request(req: &Request) -> Request {
     let mut newreq = Request::new(req.method().clone(), req.url().clone());
     newreq.headers_mut().extend(req.headers().clone().into_iter());


### PR DESCRIPTION
DO NOT MERGE: neither providers have been tested on the field.

---

This adds a phone-home feature via the `--check-in` flag, in order to
support reporting back readiness state to the hosting infrastructure.
Initial implementation supports azure and packet.

Closes: https://github.com/coreos/coreos-metadata/issues/120