### PR TITLE
provider: add boot check-in on azure and packet

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use reqwest::header;
+use serde_json;
 
 error_chain!{
     links {
@@ -24,6 +25,7 @@ error_chain!{
         XmlDeserialize(::serde_xml_rs::Error);
         Base64Decode(::base64::DecodeError);
         Io(::std::io::Error);
+        Json(serde_json::Error);
         Reqwest(::reqwest::Error);
         OpensslStack(::openssl::error::ErrorStack);
         HeaderValue(header::InvalidHeaderValue);

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,6 @@ extern crate reqwest;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde;
-#[cfg_attr(test, macro_use)]
 extern crate serde_json;
 extern crate serde_xml_rs;
 #[macro_use]

--- a/src/providers/azure/mock_tests.rs
+++ b/src/providers/azure/mock_tests.rs
@@ -1,0 +1,82 @@
+use mockito::{self, Matcher};
+use providers::{azure, MetadataProvider};
+
+#[test]
+fn test_boot_checkin() {
+    let fab_version = "/?comp=versions";
+    let ver_body = r#"<?xml version="1.0" encoding="utf-8"?>
+<Versions>
+  <Preferred>
+    <Version>2015-04-05</Version>
+  </Preferred>
+  <Supported>
+    <Version>2015-04-05</Version>
+    <Version>2012-11-30</Version>
+    <Version>2012-09-15</Version>
+    <Version>2012-05-15</Version>
+    <Version>2011-12-31</Version>
+    <Version>2011-10-15</Version>
+    <Version>2011-08-31</Version>
+    <Version>2011-04-07</Version>
+    <Version>2010-12-15</Version>
+    <Version>2010-28-10</Version>
+  </Supported>
+</Versions>"#;
+    let m_version = mockito::mock("GET", fab_version)
+        .with_body(ver_body)
+        .with_status(200)
+        .create();
+
+    let fab_goalstate = "/machine/?comp=goalstate";
+    let gs_body = r#"<?xml version="1.0" encoding="utf-8"?>
+<GoalState xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="goalstate10.xsd">
+  <Version>2012-11-30</Version>
+  <Incarnation>1</Incarnation>
+  <Machine>
+    <ExpectedState>Started</ExpectedState>
+    <StopRolesDeadlineHint>300000</StopRolesDeadlineHint>
+    <LBProbePorts>
+      <Port>16001</Port>
+    </LBProbePorts>
+    <ExpectHealthReport>FALSE</ExpectHealthReport>
+  </Machine>
+  <Container>
+    <ContainerId>a511aa6d-29e7-4f53-8788-55655dfe848f</ContainerId>
+    <RoleInstanceList>
+      <RoleInstance>
+        <InstanceId>f6cd1d7ef1644557b9059345e5ba890c.lars-test-1</InstanceId>
+        <State>Started</State>
+        <Configuration>
+          <HostingEnvironmentConfig>http://100.115.176.3:80/machine/a511aa6d-29e7-4f53-8788-55655dfe848f/f6cd1d7ef1644557b9059345e5ba890c.lars%2Dtest%2D1?comp=config&amp;type=hostingEnvironmentConfig&amp;incarnation=1</HostingEnvironmentConfig>
+          <SharedConfig>http://100.115.176.3:80/machine/a511aa6d-29e7-4f53-8788-55655dfe848f/f6cd1d7ef1644557b9059345e5ba890c.lars%2Dtest%2D1?comp=config&amp;type=sharedConfig&amp;incarnation=1</SharedConfig>
+          <ExtensionsConfig>http://100.115.176.3:80/machine/a511aa6d-29e7-4f53-8788-55655dfe848f/f6cd1d7ef1644557b9059345e5ba890c.lars%2Dtest%2D1?comp=config&amp;type=extensionsConfig&amp;incarnation=1</ExtensionsConfig>
+          <FullConfig>http://100.115.176.3:80/machine/a511aa6d-29e7-4f53-8788-55655dfe848f/f6cd1d7ef1644557b9059345e5ba890c.lars%2Dtest%2D1?comp=config&amp;type=fullConfig&amp;incarnation=1</FullConfig>
+          <Certificates>http://100.115.176.3:80/machine/a511aa6d-29e7-4f53-8788-55655dfe848f/f6cd1d7ef1644557b9059345e5ba890c.lars%2Dtest%2D1?comp=certificates&amp;incarnation=1</Certificates>
+          <ConfigName>f6cd1d7ef1644557b9059345e5ba890c.0.f6cd1d7ef1644557b9059345e5ba890c.0.lars-test-1.1.xml</ConfigName>
+        </Configuration>
+      </RoleInstance>
+    </RoleInstanceList>
+  </Container>
+</GoalState>
+"#;
+    let m_goalstate = mockito::mock("GET", fab_goalstate)
+        .with_body(gs_body)
+        .with_status(200)
+        .create();
+
+    let fab_health = "/machine/?comp=health";
+    let m_health = mockito::mock("POST", fab_health)
+        .match_header("content-type", Matcher::Regex("text/xml".to_string()))
+        .match_header("x-ms-version", Matcher::Regex("2012-11-30".to_string()))
+        .match_body(Matcher::Regex("<State>Ready</State>".to_string()))
+        .with_status(200)
+        .create();
+
+    let provider = azure::Azure::try_new();
+    let r = provider.unwrap().boot_checkin();
+
+    m_version.assert();
+    m_goalstate.assert();
+    m_health.assert();
+    r.unwrap();
+}

--- a/src/providers/azure/mod.rs
+++ b/src/providers/azure/mod.rs
@@ -392,7 +392,7 @@ impl MetadataProvider for Azure {
     fn boot_checkin(&self) -> Result<()> {
         let body = ready_state!(self.container_id(), self.instance_id()?);
         let url = self.fabric_base_url() + "/machine/?comp=health";
-        self.client.post(retry::Xml, url, body.into())
+        self.client.post(retry::Xml, url, Some(body.into()))
             .dispatch_post()?;
         Ok(())
     }

--- a/src/providers/cloudstack/configdrive.rs
+++ b/src/providers/cloudstack/configdrive.rs
@@ -137,6 +137,11 @@ impl MetadataProvider for ConfigDrive {
     fn network_devices(&self) -> Result<Vec<network::Device>> {
         Ok(vec![])
     }
+
+    fn boot_checkin(&self) -> Result<()> {
+        warn!("boot check-in requested, but not supported on this platform");
+        Ok(())
+    }
 }
 
 impl ::std::ops::Drop for ConfigDrive {

--- a/src/providers/cloudstack/network.rs
+++ b/src/providers/cloudstack/network.rs
@@ -101,4 +101,9 @@ impl MetadataProvider for CloudstackNetwork {
     fn network_devices(&self) -> Result<Vec<network::Device>> {
         Ok(vec![])
     }
+
+    fn boot_checkin(&self) -> Result<()> {
+        warn!("boot check-in requested, but not supported on this platform");
+        Ok(())
+    }
 }

--- a/src/providers/digitalocean/mod.rs
+++ b/src/providers/digitalocean/mod.rs
@@ -265,4 +265,9 @@ impl MetadataProvider for DigitalOceanProvider {
     fn network_devices(&self) -> Result<Vec<network::Device>> {
         Ok(vec![])
     }
+
+    fn boot_checkin(&self) -> Result<()> {
+        warn!("boot check-in requested, but not supported on this platform");
+        Ok(())
+    }
 }

--- a/src/providers/ec2/mod.rs
+++ b/src/providers/ec2/mod.rs
@@ -140,4 +140,9 @@ impl MetadataProvider for Ec2Provider {
     fn network_devices(&self) -> Result<Vec<network::Device>> {
         Ok(vec![])
     }
+
+    fn boot_checkin(&self) -> Result<()> {
+        warn!("boot check-in requested, but not supported on this platform");
+        Ok(())
+    }
 }

--- a/src/providers/gce/mod.rs
+++ b/src/providers/gce/mod.rs
@@ -146,4 +146,9 @@ impl MetadataProvider for GceProvider {
     fn network_devices(&self) -> Result<Vec<network::Device>> {
         Ok(vec![])
     }
+
+    fn boot_checkin(&self) -> Result<()> {
+        warn!("boot check-in requested, but not supported on this platform");
+        Ok(())
+    }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -61,6 +61,7 @@ pub trait MetadataProvider {
     fn ssh_keys(&self) -> Result<Vec<AuthorizedKeyEntry>>;
     fn networks(&self) -> Result<Vec<network::Interface>>;
     fn network_devices(&self) -> Result<Vec<network::Device>>;
+    fn boot_checkin(&self) -> Result<()>;
 
     fn write_attributes(&self, attributes_file_path: String) -> Result<()> {
         let mut attributes_file = create_file(&attributes_file_path)?;

--- a/src/providers/openstack/network.rs
+++ b/src/providers/openstack/network.rs
@@ -91,4 +91,9 @@ impl MetadataProvider for OpenstackProvider {
     fn network_devices(&self) -> Result<Vec<network::Device>> {
         Ok(vec![])
     }
+
+    fn boot_checkin(&self) -> Result<()> {
+        warn!("boot check-in requested, but not supported on this platform");
+        Ok(())
+    }
 }

--- a/src/providers/packet/mock_tests.rs
+++ b/src/providers/packet/mock_tests.rs
@@ -1,0 +1,39 @@
+use mockito::{self, Matcher};
+use providers::{packet, MetadataProvider};
+
+#[test]
+fn test_boot_checkin() {
+    let ep = "/events";
+    let data = packet::PacketData {
+        id: String::new(),
+        hostname: String::new(),
+        iqn: String::new(),
+        plan: String::new(),
+        facility: String::new(),
+        tags: vec![],
+        ssh_keys: vec![],
+        network: packet::PacketNetworkInfo {
+            interfaces: vec![],
+            addresses: vec![],
+            bonding: packet::PacketBondingMode { mode: 0 },
+        },
+        error: None,
+        phone_home_url: mockito::server_url(),
+    };
+    let provider = packet::PacketProvider { data };
+
+    let json_body = json!({
+        "state": "succeeded",
+        "code": 1042,
+        "message": "coreos-metadata: boot check-in",
+    });
+    let mock = mockito::mock("POST", ep)
+        .match_header("content-type", Matcher::Regex("text/json.*".to_string()))
+        .match_body(Matcher::Json(json_body))
+        .with_status(200)
+        .create();
+
+    let r = provider.boot_checkin();
+    mock.assert();
+    r.unwrap();
+}

--- a/src/providers/packet/mock_tests.rs
+++ b/src/providers/packet/mock_tests.rs
@@ -3,7 +3,6 @@ use providers::{packet, MetadataProvider};
 
 #[test]
 fn test_boot_checkin() {
-    let ep = "/events";
     let data = packet::PacketData {
         id: String::new(),
         hostname: String::new(),
@@ -22,14 +21,9 @@ fn test_boot_checkin() {
     };
     let provider = packet::PacketProvider { data };
 
-    let json_body = json!({
-        "state": "succeeded",
-        "code": 1042,
-        "message": "coreos-metadata: boot check-in",
-    });
-    let mock = mockito::mock("POST", ep)
-        .match_header("content-type", Matcher::Regex("text/json.*".to_string()))
-        .match_body(Matcher::Json(json_body))
+    let mock = mockito::mock("POST", "/")
+        .match_header("content-type", Matcher::Regex("application/json".to_string()))
+        .match_body("")
         .with_status(200)
         .create();
 

--- a/src/providers/packet/mod.rs
+++ b/src/providers/packet/mod.rs
@@ -302,7 +302,7 @@ impl MetadataProvider for PacketProvider {
         let client = retry::Client::try_new()?;
         let url = self.data.phone_home_url.clone() + "/events";
         let body = serde_json::to_string(&user_state)?;
-        client.post(retry::Json, url, body.into())
+        client.post(retry::Json, url, Some(body.into()))
             .dispatch_post()?;
         Ok(())
     }

--- a/src/providers/packet/mod.rs
+++ b/src/providers/packet/mod.rs
@@ -24,7 +24,6 @@ use std::str::FromStr;
 
 use openssh_keys::PublicKey;
 use pnet::util::MacAddr;
-use serde_json;
 use update_ssh_keys::AuthorizedKeyEntry;
 
 use errors::*;
@@ -81,15 +80,6 @@ struct PacketAddressInfo {
     address: IpAddr,
     netmask: IpAddr,
     gateway: IpAddr,
-}
-
-/// Custom user-state that can be posted on instance
-/// boot to Packet phone-home events endpoint.
-#[derive(Clone, Debug, Serialize)]
-pub(crate) struct PacketUserState {
-    state: String,
-    code: u16,
-    message: String,
 }
 
 #[derive(Clone, Debug)]
@@ -294,16 +284,9 @@ impl MetadataProvider for PacketProvider {
     }
 
     fn boot_checkin(&self) -> Result<()> {
-        let user_state = PacketUserState {
-            state: "succeeded".into(),
-            code: 1042,
-            message: "coreos-metadata: boot check-in".into(),
-        };
         let client = retry::Client::try_new()?;
-        let url = self.data.phone_home_url.clone() + "/events";
-        let body = serde_json::to_string(&user_state)?;
-        client.post(retry::Json, url, Some(body.into()))
-            .dispatch_post()?;
+        let url = self.data.phone_home_url.clone();
+        client.post(retry::Json, url, None).dispatch_post()?;
         Ok(())
     }
 }

--- a/src/providers/vagrant_virtualbox/mod.rs
+++ b/src/providers/vagrant_virtualbox/mod.rs
@@ -91,4 +91,9 @@ impl MetadataProvider for VagrantVirtualboxProvider {
     fn network_devices(&self) -> Result<Vec<network::Device>> {
         Ok(vec![])
     }
+
+    fn boot_checkin(&self) -> Result<()> {
+        warn!("boot check-in requested, but not supported on this platform");
+        Ok(())
+    }
 }

--- a/src/retry/client.rs
+++ b/src/retry/client.rs
@@ -148,12 +148,12 @@ impl Client {
         }
     }
 
-    pub fn post<D>(&self, d: D, url: String, body: Cow<str>) -> RequestBuilder<D>
+    pub fn post<D>(&self, d: D, url: String, body: Option<Cow<str>>) -> RequestBuilder<D>
         where D: Deserializer
     {
         RequestBuilder{
             url,
-            body: Some(body.into_owned()),
+            body: body.map(|b| b.into_owned()),
             d,
             client: self.client.clone(),
             headers: self.headers.clone(),

--- a/src/retry/client.rs
+++ b/src/retry/client.rs
@@ -67,7 +67,7 @@ impl Deserializer for Json {
             .chain_err(|| "failed json deserialization")
     }
     fn content_type(&self) -> header::HeaderValue {
-        header::HeaderValue::from_static("text/json; charset=utf-8")
+        header::HeaderValue::from_static("application/json")
     }
 }
 

--- a/src/retry/client.rs
+++ b/src/retry/client.rs
@@ -192,7 +192,6 @@ impl<D> RequestBuilder<D>
             .chain_err(|| "failed to parse uri")?;
         let mut req = Request::new(Method::GET, url);
         req.headers_mut().extend(self.headers.clone().into_iter());
-        req.headers_mut().append(header::CONTENT_TYPE, self.d.content_type());
 
         self.retry.clone().retry(|attempt| {
             info!("Fetching {}: Attempt #{}", req.url(), attempt + 1);


### PR DESCRIPTION
This is a respin of #130. So far it's mostly #130 rebased on top of #145 + minor fixes squashed in. A basic test in Azure works, though I'd like to test it some more. No testing done on Packet yet.