### PR TITLE
Release 3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "coreos-metadata"
-version = "3.1.0"
+version = "3.1.1-alpha.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "coreos-metadata"
-version = "3.0.3-alpha.0"
+version = "3.1.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud-provider metadata agent"
-version = "3.1.0"
+version = "3.1.1-alpha.0"
 
 [[bin]]
 name = "coreos-metadata"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud-provider metadata agent"
-version = "3.0.3-alpha.0"
+version = "3.1.0-alpha.0"
 
 [[bin]]
 name = "coreos-metadata"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud-provider metadata agent"
-version = "3.1.0-alpha.0"
+version = "3.1.0"
 
 [[bin]]
 name = "coreos-metadata"


### PR DESCRIPTION
coreos-metadata 3.1.0:
 * provider: add boot check-in on azure and packet
 * azure: hardcode fallback for wireserver endpoint
 * providers/packet: minor code cleanup
 * cargo: update most dependencies to latest versions