### PR TITLE
providers/gce: fix panic fetching metadata

### DIFF
--- a/src/providers/gce/mod.rs
+++ b/src/providers/gce/mod.rs
@@ -25,7 +25,7 @@ use network;
 use providers::MetadataProvider;
 use retry;
 
-static HDR_METADATA_FLAVOR: &str = "Metadata-Flavor";
+static HDR_METADATA_FLAVOR: &str = "metadata-flavor";
 
 #[derive(Clone, Debug)]
 pub struct GceProvider {


### PR DESCRIPTION
`http::header::HeaderName::from_static()` does not accept uppercase letters.  Introduced in b1e2a5ddbef0.

Fixes panic:

    thread 'main' panicked at 'invalid header name', [...]/http-0.1.14/src/header/name.rs:1660:23