### PR TITLE
providers/gce: add basic hostname mock-test

### DIFF
--- a/src/providers/gce/mock_tests.rs
+++ b/src/providers/gce/mock_tests.rs
@@ -1,0 +1,29 @@
+use errors::*;
+use mockito;
+use providers::gce;
+use providers::MetadataProvider;
+
+#[test]
+fn basic_hostname() {
+    let ep = "/instance/hostname";
+    let hostname = "test-hostname";
+
+    let mut provider = gce::GceProvider::try_new().unwrap();
+    provider.client = provider.client.max_attempts(1);
+
+    provider.hostname().unwrap_err();
+
+    let _m = mockito::mock("GET", ep).with_status(503).create();
+    provider.hostname().unwrap_err();
+
+    let _m = mockito::mock("GET", ep)
+        .with_status(200)
+        .with_body(hostname)
+        .create();
+    let v = provider.hostname().unwrap();
+    assert_eq!(v, Some(hostname.to_string()));
+
+    let _m = mockito::mock("GET", ep).with_status(404).create();
+    let v = provider.hostname().unwrap();
+    assert_eq!(v, None);
+}

--- a/src/providers/gce/mod.rs
+++ b/src/providers/gce/mod.rs
@@ -14,15 +14,19 @@
 
 //! google compute engine metadata fetcher
 
-use std::collections::HashMap;
-
+#[cfg(test)]
+use mockito;
 use openssh_keys::PublicKey;
 use reqwest::header::{HeaderName, HeaderValue};
+use std::collections::HashMap;
 
 use errors::*;
 use network;
 use providers::MetadataProvider;
 use retry;
+
+#[cfg(test)]
+mod mock_tests;
 
 static HDR_METADATA_FLAVOR: &str = "metadata-flavor";
 
@@ -43,6 +47,13 @@ impl GceProvider {
         Ok(GceProvider { client })
     }
 
+    #[cfg(test)]
+    fn endpoint_for(name: &str) -> String {
+        let url = mockito::server_url();
+        format!("{}/{}", url, name)
+    }
+
+    #[cfg(not(test))]
     fn endpoint_for(name: &str) -> String {
         format!(
             "http://metadata.google.internal/computeMetadata/v1/{}",


### PR DESCRIPTION
This adds a simple mock-test covering hostname fetching.
It would prevent regressions like https://github.com/coreos/coreos-metadata/pull/177 in the future.