### PR TITLE
providers: rename ec2 -> aws, gce -> gcp in non-legacy mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ This can include adding SSH keys and writing cloud-specific attributes into an e
 The supported cloud providers and their respective metadata are listed below.
 On CoreOS Container Linux, the supported providers and metadata are [somewhat different][cl-legacy].
 
+  - aws
+    - SSH Keys
+    - Attributes
+      - COREOS_AWS_HOSTNAME
+      - COREOS_AWS_PUBLIC_HOSTNAME
+      - COREOS_AWS_IPV4_LOCAL
+      - COREOS_AWS_IPV4_PUBLIC
+      - COREOS_AWS_AVAILABILITY_ZONE
+      - COREOS_AWS_INSTANCE_ID
+      - COREOS_AWS_REGION
   - azure
     - SSH Keys
     - Attributes
@@ -49,22 +59,12 @@ On CoreOS Container Linux, the supported providers and metadata are [somewhat di
       - COREOS_DIGITALOCEAN_IPV6_PUBLIC_0
       - COREOS_DIGITALOCEAN_IPV6_PRIVATE_0
       - COREOS_DIGITALOCEAN_REGION
-  - ec2
+  - gcp
     - SSH Keys
     - Attributes
-      - COREOS_EC2_HOSTNAME
-      - COREOS_EC2_PUBLIC_HOSTNAME
-      - COREOS_EC2_IPV4_LOCAL
-      - COREOS_EC2_IPV4_PUBLIC
-      - COREOS_EC2_AVAILABILITY_ZONE
-      - COREOS_EC2_INSTANCE_ID
-      - COREOS_EC2_REGION
-  - gce
-    - SSH Keys
-    - Attributes
-      - COREOS_GCE_HOSTNAME
-      - COREOS_GCE_IP_EXTERNAL_0
-      - COREOS_GCE_IP_LOCAL_0
+      - COREOS_GCP_HOSTNAME
+      - COREOS_GCP_IP_EXTERNAL_0
+      - COREOS_GCP_IP_LOCAL_0
   - openstack-metadata
     - SSH Keys
     - Attributes

--- a/docs/container-linux-legacy.md
+++ b/docs/container-linux-legacy.md
@@ -1,15 +1,14 @@
-# coreos-metadata
-
-[![Build Status](https://travis-ci.org/coreos/coreos-metadata.svg?branch=master)](https://travis-ci.org/coreos/coreos-metadata)
-![minimum rust 1.29](https://img.shields.io/badge/rust-1.29%2B-orange.svg)
+# coreos-metadata on CoreOS Container Linux
 
 This is a small utility, typically used in conjunction with [Ignition][ignition], which reads metadata from a given cloud-provider and applies it to the system.
 This can include adding SSH keys and writing cloud-specific attributes into an environment file (e.g. `/run/metadata/coreos`), which can then be consumed by systemd service units via `EnvironmentFile=`.
 
+coreos-metadata can be built with the `cl-legacy` feature to enable legacy behavior for Container Linux.
+Other distros should not enable this feature.
+
 ## Support
 
-The supported cloud providers and their respective metadata are listed below.
-On CoreOS Container Linux, the supported providers and metadata are [somewhat different][cl-legacy].
+On Container Linux, the supported cloud providers and their respective metadata are as follows:
 
   - azure
     - SSH Keys
@@ -98,4 +97,3 @@ These can be safely used by external providers on a platform not supported by co
 
 [ignition]: https://github.com/coreos/ignition
 [custom-metadata]: https://github.com/coreos/container-linux-config-transpiler/blob/v0.8.0/doc/dynamic-data.md#custom-metadata-providers
-[cl-legacy]: docs/container-linux-legacy.md

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -14,12 +14,12 @@
 
 use errors;
 use providers;
+use providers::aws::AwsProvider;
 use providers::azure::Azure;
 use providers::cloudstack::configdrive::ConfigDrive;
 use providers::cloudstack::network::CloudstackNetwork;
 use providers::digitalocean::DigitalOceanProvider;
-use providers::ec2::Ec2Provider;
-use providers::gce::GceProvider;
+use providers::gcp::GcpProvider;
 use providers::openstack::network::OpenstackProvider;
 use providers::packet::PacketProvider;
 use providers::vagrant_virtualbox::VagrantVirtualboxProvider;
@@ -39,8 +39,8 @@ pub fn fetch_metadata(provider: &str) -> errors::Result<Box<providers::MetadataP
         "cloudstack-metadata" => box_result!(CloudstackNetwork::try_new()?),
         "cloudstack-configdrive" => box_result!(ConfigDrive::try_new()?),
         "digitalocean" => box_result!(DigitalOceanProvider::try_new()?),
-        "ec2" => box_result!(Ec2Provider::try_new()?),
-        "gce" => box_result!(GceProvider::try_new()?),
+        "ec2" => box_result!(AwsProvider::try_new()?),
+        "gce" => box_result!(GcpProvider::try_new()?),
         "openstack-metadata" => box_result!(OpenstackProvider::try_new()?),
         "packet" => box_result!(PacketProvider::try_new()?),
         "vagrant-virtualbox" => box_result!(VagrantVirtualboxProvider::new()),

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -35,12 +35,18 @@ macro_rules! box_result {
 /// function dispatches the call to the correct provider-specific fetch function
 pub fn fetch_metadata(provider: &str) -> errors::Result<Box<providers::MetadataProvider>> {
     match provider {
+        #[cfg(not(feature = "cl-legacy"))]
+        "aws" => box_result!(AwsProvider::try_new()?),
         "azure" => box_result!(Azure::try_new()?),
         "cloudstack-metadata" => box_result!(CloudstackNetwork::try_new()?),
         "cloudstack-configdrive" => box_result!(ConfigDrive::try_new()?),
         "digitalocean" => box_result!(DigitalOceanProvider::try_new()?),
+        // FIXME: "ec2" is accepted in non-legacy mode temporarily for transition
         "ec2" => box_result!(AwsProvider::try_new()?),
+        #[cfg(feature = "cl-legacy")]
         "gce" => box_result!(GcpProvider::try_new()?),
+        #[cfg(not(feature = "cl-legacy"))]
+        "gcp" => box_result!(GcpProvider::try_new()?),
         "openstack-metadata" => box_result!(OpenstackProvider::try_new()?),
         "packet" => box_result!(PacketProvider::try_new()?),
         "vagrant-virtualbox" => box_result!(VagrantVirtualboxProvider::new()),

--- a/src/providers/aws/mock_tests.rs
+++ b/src/providers/aws/mock_tests.rs
@@ -1,16 +1,16 @@
 use errors::*;
 use mockito;
-use providers::ec2;
+use providers::aws;
 
 #[test]
-fn test_ec2_basic() {
+fn test_aws_basic() {
     let ep = "/meta-data/public-keys";
     let client = ::retry::Client::try_new()
         .chain_err(|| "failed to create http client")
         .unwrap()
         .max_attempts(1)
         .return_on_404(true);
-    let provider = ec2::Ec2Provider { client };
+    let provider = aws::AwsProvider { client };
 
     provider.fetch_ssh_keys().unwrap_err();
 

--- a/src/providers/aws/mod.rs
+++ b/src/providers/aws/mod.rs
@@ -29,6 +29,11 @@ use retry;
 #[cfg(test)]
 mod mock_tests;
 
+#[cfg(not(feature = "cl-legacy"))]
+static ENV_PREFIX: &str = "AWS";
+#[cfg(feature = "cl-legacy")]
+static ENV_PREFIX: &str = "EC2";
+
 #[allow(non_snake_case)]
 #[derive(Debug, Deserialize)]
 struct InstanceIdDoc {
@@ -110,16 +115,36 @@ impl MetadataProvider for AwsProvider {
             Ok(())
         };
 
-        add_value(&mut out, "EC2_INSTANCE_ID", "meta-data/instance-id")?;
-        add_value(&mut out, "EC2_IPV4_LOCAL", "meta-data/local-ipv4")?;
-        add_value(&mut out, "EC2_IPV4_PUBLIC", "meta-data/public-ipv4")?;
         add_value(
             &mut out,
-            "EC2_AVAILABILITY_ZONE",
+            &format!("{}_INSTANCE_ID", ENV_PREFIX),
+            "meta-data/instance-id",
+        )?;
+        add_value(
+            &mut out,
+            &format!("{}_IPV4_LOCAL", ENV_PREFIX),
+            "meta-data/local-ipv4",
+        )?;
+        add_value(
+            &mut out,
+            &format!("{}_IPV4_PUBLIC", ENV_PREFIX),
+            "meta-data/public-ipv4",
+        )?;
+        add_value(
+            &mut out,
+            &format!("{}_AVAILABILITY_ZONE", ENV_PREFIX),
             "meta-data/placement/availability-zone",
         )?;
-        add_value(&mut out, "EC2_HOSTNAME", "meta-data/hostname")?;
-        add_value(&mut out, "EC2_PUBLIC_HOSTNAME", "meta-data/public-hostname")?;
+        add_value(
+            &mut out,
+            &format!("{}_HOSTNAME", ENV_PREFIX),
+            "meta-data/hostname",
+        )?;
+        add_value(
+            &mut out,
+            &format!("{}_PUBLIC_HOSTNAME", ENV_PREFIX),
+            "meta-data/public-hostname",
+        )?;
 
         let region = self
             .client
@@ -130,7 +155,7 @@ impl MetadataProvider for AwsProvider {
             .send()?
             .map(|instance_id_doc: InstanceIdDoc| instance_id_doc.region);
         if let Some(region) = region {
-            out.insert("EC2_REGION".to_string(), region);
+            out.insert(format!("{}_REGION", ENV_PREFIX), region);
         }
 
         Ok(out)

--- a/src/providers/aws/mod.rs
+++ b/src/providers/aws/mod.rs
@@ -36,15 +36,15 @@ struct InstanceIdDoc {
 }
 
 #[derive(Clone, Debug)]
-pub struct Ec2Provider {
+pub struct AwsProvider {
     client: retry::Client,
 }
 
-impl Ec2Provider {
-    pub fn try_new() -> Result<Ec2Provider> {
+impl AwsProvider {
+    pub fn try_new() -> Result<AwsProvider> {
         let client = retry::Client::try_new()?.return_on_404(true);
 
-        Ok(Ec2Provider { client })
+        Ok(AwsProvider { client })
     }
 
     #[cfg(test)]
@@ -64,7 +64,7 @@ impl Ec2Provider {
             .client
             .get(
                 retry::Raw,
-                Ec2Provider::endpoint_for("meta-data/public-keys"),
+                AwsProvider::endpoint_for("meta-data/public-keys"),
             )
             .send()?;
 
@@ -79,7 +79,7 @@ impl Ec2Provider {
                     .client
                     .get(
                         retry::Raw,
-                        Ec2Provider::endpoint_for(&format!(
+                        AwsProvider::endpoint_for(&format!(
                             "meta-data/public-keys/{}/openssh-key",
                             tokens[0]
                         )),
@@ -93,14 +93,14 @@ impl Ec2Provider {
     }
 }
 
-impl MetadataProvider for Ec2Provider {
+impl MetadataProvider for AwsProvider {
     fn attributes(&self) -> Result<HashMap<String, String>> {
         let mut out = HashMap::with_capacity(6);
 
         let add_value = |map: &mut HashMap<_, _>, key: &str, name| -> Result<()> {
             let value = self
                 .client
-                .get(retry::Raw, Ec2Provider::endpoint_for(name))
+                .get(retry::Raw, AwsProvider::endpoint_for(name))
                 .send()?;
 
             if let Some(value) = value {
@@ -125,7 +125,7 @@ impl MetadataProvider for Ec2Provider {
             .client
             .get(
                 retry::Json,
-                Ec2Provider::endpoint_for("dynamic/instance-identity/document"),
+                AwsProvider::endpoint_for("dynamic/instance-identity/document"),
             )
             .send()?
             .map(|instance_id_doc: InstanceIdDoc| instance_id_doc.region);
@@ -138,7 +138,7 @@ impl MetadataProvider for Ec2Provider {
 
     fn hostname(&self) -> Result<Option<String>> {
         self.client
-            .get(retry::Raw, Ec2Provider::endpoint_for("meta-data/hostname"))
+            .get(retry::Raw, AwsProvider::endpoint_for("meta-data/hostname"))
             .send()
     }
 

--- a/src/providers/gcp/mock_tests.rs
+++ b/src/providers/gcp/mock_tests.rs
@@ -1,6 +1,6 @@
 use errors::*;
 use mockito;
-use providers::gce;
+use providers::gcp;
 use providers::MetadataProvider;
 
 #[test]
@@ -8,7 +8,7 @@ fn basic_hostname() {
     let ep = "/instance/hostname";
     let hostname = "test-hostname";
 
-    let mut provider = gce::GceProvider::try_new().unwrap();
+    let mut provider = gcp::GcpProvider::try_new().unwrap();
     provider.client = provider.client.max_attempts(1);
 
     provider.hostname().unwrap_err();

--- a/src/providers/gcp/mod.rs
+++ b/src/providers/gcp/mod.rs
@@ -31,12 +31,12 @@ mod mock_tests;
 static HDR_METADATA_FLAVOR: &str = "metadata-flavor";
 
 #[derive(Clone, Debug)]
-pub struct GceProvider {
+pub struct GcpProvider {
     client: retry::Client,
 }
 
-impl GceProvider {
-    pub fn try_new() -> Result<GceProvider> {
+impl GcpProvider {
+    pub fn try_new() -> Result<GcpProvider> {
         let client = retry::Client::try_new()?
             .header(
                 HeaderName::from_static(HDR_METADATA_FLAVOR),
@@ -44,7 +44,7 @@ impl GceProvider {
             )
             .return_on_404(true);
 
-        Ok(GceProvider { client })
+        Ok(GcpProvider { client })
     }
 
     #[cfg(test)]
@@ -83,7 +83,7 @@ impl GceProvider {
             .clone()
             .get(
                 retry::Raw,
-                GceProvider::endpoint_for("instance/attributes/block-project-ssh-keys"),
+                GcpProvider::endpoint_for("instance/attributes/block-project-ssh-keys"),
             )
             .send()?;
 
@@ -102,7 +102,7 @@ impl GceProvider {
     fn fetch_ssh_keys(&self, key: &str) -> Result<Vec<String>> {
         let key_data: Option<String> = self
             .client
-            .get(retry::Raw, GceProvider::endpoint_for(key))
+            .get(retry::Raw, GcpProvider::endpoint_for(key))
             .send()?;
         if let Some(key_data) = key_data {
             let mut keys = Vec::new();
@@ -124,14 +124,14 @@ impl GceProvider {
     }
 }
 
-impl MetadataProvider for GceProvider {
+impl MetadataProvider for GcpProvider {
     fn attributes(&self) -> Result<HashMap<String, String>> {
         let mut out = HashMap::with_capacity(3);
 
         let add_value = |map: &mut HashMap<_, _>, key: &str, name| -> Result<()> {
             let value: Option<String> = self
                 .client
-                .get(retry::Raw, GceProvider::endpoint_for(name))
+                .get(retry::Raw, GcpProvider::endpoint_for(name))
                 .send()?;
 
             if let Some(value) = value {
@@ -160,7 +160,7 @@ impl MetadataProvider for GceProvider {
 
     fn hostname(&self) -> Result<Option<String>> {
         self.client
-            .get(retry::Raw, GceProvider::endpoint_for("instance/hostname"))
+            .get(retry::Raw, GcpProvider::endpoint_for("instance/hostname"))
             .send()
     }
 

--- a/src/providers/gcp/mod.rs
+++ b/src/providers/gcp/mod.rs
@@ -30,6 +30,11 @@ mod mock_tests;
 
 static HDR_METADATA_FLAVOR: &str = "metadata-flavor";
 
+#[cfg(not(feature = "cl-legacy"))]
+static ENV_PREFIX: &str = "GCP";
+#[cfg(feature = "cl-legacy")]
+static ENV_PREFIX: &str = "GCE";
+
 #[derive(Clone, Debug)]
 pub struct GcpProvider {
     client: retry::Client,
@@ -143,15 +148,19 @@ impl MetadataProvider for GcpProvider {
             Ok(())
         };
 
-        add_value(&mut out, "GCE_HOSTNAME", "instance/hostname")?;
         add_value(
             &mut out,
-            "GCE_IP_EXTERNAL_0",
+            &format!("{}_HOSTNAME", ENV_PREFIX),
+            "instance/hostname",
+        )?;
+        add_value(
+            &mut out,
+            &format!("{}_IP_EXTERNAL_0", ENV_PREFIX),
             "instance/network-interfaces/0/access-configs/0/external-ip",
         )?;
         add_value(
             &mut out,
-            "GCE_IP_LOCAL_0",
+            &format!("{}_IP_LOCAL_0", ENV_PREFIX),
             "instance/network-interfaces/0/ip",
         )?;
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -23,11 +23,11 @@
 //! function to fetch the metadata, and then add a match line in the top-level
 //! `fetch_metadata()` function in metadata.rs.
 
+pub mod aws;
 pub mod azure;
 pub mod cloudstack;
 pub mod digitalocean;
-pub mod ec2;
-pub mod gce;
+pub mod gcp;
 pub mod openstack;
 pub mod packet;
 pub mod vagrant_virtualbox;


### PR DESCRIPTION
https://github.com/coreos/fedora-coreos-tracker/issues/162

Requires https://github.com/coreos/coreos-metadata/pull/181.