### PR TITLE
util/cmdline: rename "OEM ID" to "Platform ID"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -58,8 +58,8 @@ use std::env;
 use errors::*;
 use metadata::fetch_metadata;
 
+/// Path to kernel command-line (requires procfs mount).
 const CMDLINE_PATH: &str = "/proc/cmdline";
-const CMDLINE_OEM_FLAG: &str = "coreos.oem.id";
 
 #[derive(Debug)]
 struct Config {
@@ -199,7 +199,7 @@ fn init() -> Result<Config> {
             Some(provider) => String::from(provider),
             None => {
                 if matches.is_present("cmdline") {
-                    util::get_oem(CMDLINE_PATH, CMDLINE_OEM_FLAG)?
+                    util::get_platform(CMDLINE_PATH)?
                 } else {
                     return Err("Must set either --provider or --cmdline".into());
                 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -23,7 +23,7 @@ use std::path::Path;
 use std::time::Duration;
 
 mod cmdline;
-pub use self::cmdline::get_oem;
+pub use self::cmdline::get_platform;
 
 fn key_lookup_line(delim: char, key: &str, line: &str) -> Option<String> {
     match line.find(delim) {


### PR DESCRIPTION
This switches from "coreos.oem.id" to "ignition.platform.id" in
non-legacy mode. 

Ref: https://github.com/coreos/coreos-assembler/issues/428