### PR TITLE
Release 3.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "coreos-metadata"
-version = "3.2.0"
+version = "3.2.1-alpha.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "coreos-metadata"
-version = "3.1.1-alpha.0"
+version = "3.2.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud-provider metadata agent"
-version = "3.2.0-alpha.0"
+version = "3.2.0"
 
 [[bin]]
 name = "coreos-metadata"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud-provider metadata agent"
-version = "3.1.1-alpha.0"
+version = "3.2.0-alpha.0"
 
 [[bin]]
 name = "coreos-metadata"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud-provider metadata agent"
-version = "3.2.0"
+version = "3.2.1-alpha.0"
 
 [[bin]]
 name = "coreos-metadata"


### PR DESCRIPTION
Changes:
 * introduce a "cl-legacy" feature flag for backward compatibility with ContainerLinux
 * drop merging of authorized_keys.d into authorized_keys in non-legacy mode
 * util/cmdline: rename "OEM ID" to "Platform ID" in non-legacy mode
 * providers: rename ec2 -> aws, gce -> gcp in non-legacy mode

Bugfixes:
 * providers/gce: fix panic fetching metadata

Misc: 
 * providers/gce: add basic hostname mock-test
 * rustfmt whole project