### PR TITLE
Release 4.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "afterburn"
-version = "4.0.0"
+version = "4.0.1-alpha.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "afterburn"
-version = "3.1.1-alpha.0"
+version = "4.0.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.0.0"
+version = "4.0.1-alpha.0"
 
 [[bin]]
 name = "afterburn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.0.0-alpha.0"
+version = "4.0.0"
 
 [[bin]]
 name = "afterburn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "3.1.1-alpha.0"
+version = "4.0.0-alpha.0"
 
 [[bin]]
 name = "afterburn"


### PR DESCRIPTION
Changes:
 * rename project from coreos-metadata to Afterburn
 * introduce a `cl-legacy` feature flag for backward compatibility with Container Linux
 * change metadata attribute prefix from `COREOS_` to `AFTERBURN_` in non-legacy mode
 * read `ignition.platform.id` kernel argument instead of `coreos.oem.id` in non-legacy mode
 * drop merging of `authorized_keys.d` into `authorized_keys` in non-legacy mode
 * providers: rename `ec2` -> `aws`, `gce` -> `gcp` in non-legacy mode

Bugfixes:
 * providers/gce: fix panic fetching metadata

Misc: 
 * providers/gce: add basic hostname mock-test
 * rustfmt whole project