### PR TITLE
Release coreos-metadata 3.1.2 to add deprecation notice to crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "coreos-metadata"
-version = "3.1.1-alpha.0"
+version = "3.1.2-alpha.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "coreos-metadata"
-version = "3.1.2-alpha.0"
+version = "3.1.2"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud-provider metadata agent"
-version = "3.1.2-alpha.0"
+version = "3.1.2"
 readme = "DEPRECATED.md"
 
 [badges]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud-provider metadata agent"
-version = "3.1.1-alpha.0"
+version = "3.1.2-alpha.0"
 
 [[bin]]
 name = "coreos-metadata"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud-provider metadata agent"
 version = "3.1.2-alpha.0"
+readme = "DEPRECATED.md"
+
+[badges]
+maintenance = { status = "deprecated" }
 
 [[bin]]
 name = "coreos-metadata"

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -1,0 +1,4 @@
+# coreos-metadata is now Afterburn
+
+Future releases of this crate will be published under the name
+[*afterburn*](https://crates.io/crates/afterburn).


### PR DESCRIPTION
I'll push the tag after the PR merges, but I'm not planning to create a GitHub Release.