### PR TITLE
travis: bump minimum toolchain to 1.31

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
-  - 1.31.0  # pinned toolchain for clippy
-  - 1.29.0  # minimum supported toolchain
+  - 1.33.0  # pinned toolchain for clippy
+  - 1.31.0  # minimum supported toolchain
   - stable
   - beta
   - nightly
@@ -12,7 +12,7 @@ matrix:
 
 env:
   global:
-    - CLIPPY_RUST_VERSION=1.31.0
+    - CLIPPY_RUST_VERSION=1.33.0
 
 before_script:
   - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Afterburn
 
 [![Build Status](https://travis-ci.org/coreos/afterburn.svg?branch=master)](https://travis-ci.org/coreos/afterburn)
-![minimum rust 1.29](https://img.shields.io/badge/rust-1.29%2B-orange.svg)
+![minimum rust 1.31](https://img.shields.io/badge/rust-1.31%2B-orange.svg)
 
 This is a small utility, typically used in conjunction with [Ignition][ignition], which reads metadata from a given cloud-provider and applies it to the system.
 This can include adding SSH keys and writing cloud-specific attributes into an environment file (e.g. `/run/metadata/afterburn`), which can then be consumed by systemd service units via `EnvironmentFile=`.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(deprecated)]
+
 use reqwest::header;
 use serde_json;
 


### PR DESCRIPTION
This bumps minimum toolchain to 1.31, tracking latest RH devtools. A temporary deprecation whitelist is also put in place for https://github.com/rust-lang-nursery/error-chain/issues/254.