### PR TITLE
providers/azure: fetch hostname from metadata 

### DIFF
--- a/src/providers/azure/mock_tests.rs
+++ b/src/providers/azure/mock_tests.rs
@@ -89,3 +89,27 @@ fn test_boot_checkin() {
     m_health.assert();
     r.unwrap();
 }
+
+#[test]
+fn test_hostname() {
+    let m_version = mock_fab_version();
+    let m_goalstate = mock_goalstate();
+
+    let testname = "testname";
+    let endpoint = "/metadata/instance/compute/name?api-version=2017-08-01&format=text";
+    let m_hostname = mockito::mock("GET", endpoint)
+        .match_header("Metadata", "true")
+        .with_body(testname)
+        .with_status(200)
+        .create();
+
+    let provider = azure::Azure::try_new();
+    let r = provider.unwrap().hostname().unwrap();
+
+    m_version.assert();
+    m_goalstate.assert();
+
+    m_hostname.assert();
+    let hostname = r.unwrap();
+    assert_eq!(hostname, testname);
+}

--- a/src/providers/azure/mock_tests.rs
+++ b/src/providers/azure/mock_tests.rs
@@ -1,8 +1,7 @@
 use mockito::{self, Matcher};
 use providers::{azure, MetadataProvider};
 
-#[test]
-fn test_boot_checkin() {
+fn mock_fab_version() -> mockito::Mock {
     let fab_version = "/?comp=versions";
     let ver_body = r#"<?xml version="1.0" encoding="utf-8"?>
 <Versions>
@@ -22,11 +21,14 @@ fn test_boot_checkin() {
     <Version>2010-28-10</Version>
   </Supported>
 </Versions>"#;
-    let m_version = mockito::mock("GET", fab_version)
+
+    mockito::mock("GET", fab_version)
         .with_body(ver_body)
         .with_status(200)
-        .create();
+        .create()
+}
 
+fn mock_goalstate() -> mockito::Mock {
     let fab_goalstate = "/machine/?comp=goalstate";
     let gs_body = r#"<?xml version="1.0" encoding="utf-8"?>
 <GoalState xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="goalstate10.xsd">
@@ -59,10 +61,17 @@ fn test_boot_checkin() {
   </Container>
 </GoalState>
 "#;
-    let m_goalstate = mockito::mock("GET", fab_goalstate)
+
+    mockito::mock("GET", fab_goalstate)
         .with_body(gs_body)
         .with_status(200)
-        .create();
+        .create()
+}
+
+#[test]
+fn test_boot_checkin() {
+    let m_version = mock_fab_version();
+    let m_goalstate = mock_goalstate();
 
     let fab_health = "/machine/?comp=health";
     let m_health = mockito::mock("POST", fab_health)

--- a/src/providers/azure/mod.rs
+++ b/src/providers/azure/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! azure metadata fetcher
+//! Azure provider, metadata and wireserver fetcher.
 
 mod crypto;
 
@@ -279,6 +279,17 @@ impl Azure {
         }
     }
 
+    #[cfg(test)]
+    fn metadata_endpoint() -> String {
+        mockito::server_url()
+    }
+
+    #[cfg(not(test))]
+    fn metadata_endpoint() -> String {
+        const URL: &str = "http://169.254.169.254";
+        URL.to_string()
+    }
+
     fn get_certs_endpoint(&self) -> Result<String> {
         // grab the certificates endpoint from the xml and return it
         let cert_endpoint: &str = &self.goal_state.container.role_instance_list.role_instances[0]
@@ -392,6 +403,21 @@ impl Azure {
             .ok_or_else(|| "empty RoleInstanceList".to_string())?
             .instance_id)
     }
+
+    fn fetch_hostname(&self) -> Result<Option<String>> {
+        const NAME_URL: &str = "metadata/instance/compute/name?api-version=2017-08-01&format=text";
+        let url = format!("{}/{}", Self::metadata_endpoint(), NAME_URL);
+
+        let name = retry::Client::try_new()?
+            .header(
+                HeaderName::from_static("metadata"),
+                HeaderValue::from_static("true"),
+            )
+            .get(retry::Raw, url)
+            .send()
+            .chain_err(|| "failed to get hostname")?;
+        Ok(name)
+    }
 }
 
 impl MetadataProvider for Azure {
@@ -411,7 +437,7 @@ impl MetadataProvider for Azure {
     }
 
     fn hostname(&self) -> Result<Option<String>> {
-        Ok(None)
+        self.fetch_hostname()
     }
 
     fn ssh_keys(&self) -> Result<Vec<PublicKey>> {


### PR DESCRIPTION
This implements fetching the machine name from Azure metadata.
 
Ref: https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service
Fixes #197 