### PR TITLE
cargo: switch to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "afterburn"
 repository = "https://github.com/coreos/afterburn"
 license = "Apache-2.0"
+edition = "2018"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,8 +55,8 @@ use clap::{App, Arg};
 use slog::Drain;
 use std::env;
 
-use errors::*;
-use metadata::fetch_metadata;
+use crate::errors::*;
+use crate::metadata::fetch_metadata;
 
 /// Path to kernel command-line (requires procfs mount).
 const CMDLINE_PATH: &str = "/proc/cmdline";

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use errors;
-use providers;
-use providers::aws::AwsProvider;
-use providers::azure::Azure;
-use providers::cloudstack::configdrive::ConfigDrive;
-use providers::cloudstack::network::CloudstackNetwork;
-use providers::digitalocean::DigitalOceanProvider;
-use providers::gcp::GcpProvider;
-use providers::openstack::network::OpenstackProvider;
-use providers::packet::PacketProvider;
-use providers::vagrant_virtualbox::VagrantVirtualboxProvider;
+use crate::errors;
+use crate::providers;
+use crate::providers::aws::AwsProvider;
+use crate::providers::azure::Azure;
+use crate::providers::cloudstack::configdrive::ConfigDrive;
+use crate::providers::cloudstack::network::CloudstackNetwork;
+use crate::providers::digitalocean::DigitalOceanProvider;
+use crate::providers::gcp::GcpProvider;
+use crate::providers::openstack::network::OpenstackProvider;
+use crate::providers::packet::PacketProvider;
+use crate::providers::vagrant_virtualbox::VagrantVirtualboxProvider;
 
 macro_rules! box_result {
     ($exp:expr) => {

--- a/src/network.rs
+++ b/src/network.rs
@@ -21,7 +21,7 @@ use std::net::IpAddr;
 use std::string::String;
 use std::string::ToString;
 
-use errors::*;
+use crate::errors::*;
 use ipnetwork::IpNetwork;
 
 pub const BONDING_MODE_BALANCE_RR: u32 = 0;

--- a/src/providers/aws/mock_tests.rs
+++ b/src/providers/aws/mock_tests.rs
@@ -1,11 +1,11 @@
-use errors::*;
+use crate::errors::*;
 use mockito;
-use providers::aws;
+use crate::providers::aws;
 
 #[test]
 fn test_aws_basic() {
     let ep = "/meta-data/public-keys";
-    let client = ::retry::Client::try_new()
+    let client = crate::retry::Client::try_new()
         .chain_err(|| "failed to create http client")
         .unwrap()
         .max_attempts(1)

--- a/src/providers/aws/mock_tests.rs
+++ b/src/providers/aws/mock_tests.rs
@@ -1,6 +1,6 @@
 use crate::errors::*;
-use mockito;
 use crate::providers::aws;
+use mockito;
 
 #[test]
 fn test_aws_basic() {

--- a/src/providers/aws/mod.rs
+++ b/src/providers/aws/mod.rs
@@ -21,10 +21,10 @@ use std::collections::HashMap;
 use mockito;
 use openssh_keys::PublicKey;
 
-use errors::*;
-use network;
-use providers::MetadataProvider;
-use retry;
+use crate::errors::*;
+use crate::network;
+use crate::providers::MetadataProvider;
+use crate::retry;
 
 #[cfg(test)]
 mod mock_tests;

--- a/src/providers/azure/crypto/mod.rs
+++ b/src/providers/azure/crypto/mod.rs
@@ -23,7 +23,7 @@ use openssl::x509::X509;
 
 use openssh_keys::PublicKey;
 
-use errors::*;
+use crate::errors::*;
 
 pub fn mangle_pem(x509: &X509) -> Result<String> {
     // get the pem

--- a/src/providers/azure/crypto/x509.rs
+++ b/src/providers/azure/crypto/x509.rs
@@ -23,7 +23,7 @@ use openssl::rsa::Rsa;
 use openssl::x509::extension;
 use openssl::x509::{X509Name, X509};
 
-use errors::*;
+use crate::errors::*;
 
 pub struct Config {
     rsa_bits: u32,

--- a/src/providers/azure/mock_tests.rs
+++ b/src/providers/azure/mock_tests.rs
@@ -1,5 +1,5 @@
-use mockito::{self, Matcher};
 use crate::providers::{azure, MetadataProvider};
+use mockito::{self, Matcher};
 
 fn mock_fab_version() -> mockito::Mock {
     let fab_version = "/?comp=versions";

--- a/src/providers/azure/mock_tests.rs
+++ b/src/providers/azure/mock_tests.rs
@@ -1,5 +1,5 @@
 use mockito::{self, Matcher};
-use providers::{azure, MetadataProvider};
+use crate::providers::{azure, MetadataProvider};
 
 fn mock_fab_version() -> mockito::Mock {
     let fab_version = "/?comp=versions";

--- a/src/providers/azure/mod.rs
+++ b/src/providers/azure/mod.rs
@@ -23,10 +23,10 @@ use openssh_keys::PublicKey;
 use reqwest::header::{HeaderName, HeaderValue};
 
 use self::crypto::x509;
-use errors::*;
-use network;
-use providers::MetadataProvider;
-use retry;
+use crate::errors::*;
+use crate::network;
+use crate::providers::MetadataProvider;
+use crate::retry;
 
 #[cfg(test)]
 mod mock_tests;
@@ -231,7 +231,7 @@ impl Azure {
 
     #[cfg(not(test))]
     fn get_fabric_address_from_dhcp() -> Result<IpAddr> {
-        let v = ::util::dns_lease_key_lookup("OPTION_245")?;
+        let v = crate::util::dns_lease_key_lookup("OPTION_245")?;
         // value is an 8 digit hex value. convert it to u32 and
         // then parse that into an ip. Ipv4Addr::from(u32)
         // performs conversion from big-endian

--- a/src/providers/cloudstack/configdrive.rs
+++ b/src/providers/cloudstack/configdrive.rs
@@ -9,9 +9,9 @@ use nix::mount;
 use openssh_keys::PublicKey;
 use tempdir::TempDir;
 
-use errors::*;
-use network;
-use providers::MetadataProvider;
+use crate::errors::*;
+use crate::network;
+use crate::providers::MetadataProvider;
 
 const CONFIG_DRIVE_LABEL_1: &str = "config-2";
 const CONFIG_DRIVE_LABEL_2: &str = "CONFIG-2";

--- a/src/providers/cloudstack/network.rs
+++ b/src/providers/cloudstack/network.rs
@@ -6,11 +6,11 @@ use std::time::Duration;
 
 use openssh_keys::PublicKey;
 
-use errors::*;
-use network;
-use providers::MetadataProvider;
-use retry;
-use util;
+use crate::errors::*;
+use crate::network;
+use crate::providers::MetadataProvider;
+use crate::retry;
+use crate::util;
 
 const SERVER_ADDRESS: &str = "SERVER_ADDRESS";
 

--- a/src/providers/digitalocean/mod.rs
+++ b/src/providers/digitalocean/mod.rs
@@ -23,10 +23,10 @@ use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 use openssh_keys::PublicKey;
 use pnet::util::MacAddr;
 
-use errors::*;
-use network;
-use providers::MetadataProvider;
-use retry;
+use crate::errors::*;
+use crate::network;
+use crate::providers::MetadataProvider;
+use crate::retry;
 
 #[derive(Clone, Deserialize)]
 struct Address {

--- a/src/providers/gcp/mock_tests.rs
+++ b/src/providers/gcp/mock_tests.rs
@@ -1,6 +1,6 @@
-use mockito;
 use crate::providers::gcp;
 use crate::providers::MetadataProvider;
+use mockito;
 
 #[test]
 fn basic_hostname() {

--- a/src/providers/gcp/mock_tests.rs
+++ b/src/providers/gcp/mock_tests.rs
@@ -1,6 +1,6 @@
 use mockito;
-use providers::gcp;
-use providers::MetadataProvider;
+use crate::providers::gcp;
+use crate::providers::MetadataProvider;
 
 #[test]
 fn basic_hostname() {

--- a/src/providers/gcp/mod.rs
+++ b/src/providers/gcp/mod.rs
@@ -20,10 +20,10 @@ use openssh_keys::PublicKey;
 use reqwest::header::{HeaderName, HeaderValue};
 use std::collections::HashMap;
 
-use errors::*;
-use network;
-use providers::MetadataProvider;
-use retry;
+use crate::errors::*;
+use crate::network;
+use crate::providers::MetadataProvider;
+use crate::retry;
 
 #[cfg(test)]
 mod mock_tests;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -40,8 +40,8 @@ use std::path::Path;
 use openssh_keys::PublicKey;
 use users::{self, User};
 
-use errors::*;
-use network;
+use crate::errors::*;
+use crate::network;
 
 #[cfg(not(feature = "cl-legacy"))]
 const ENV_PREFIX: &str = "AFTERBURN_";

--- a/src/providers/openstack/network.rs
+++ b/src/providers/openstack/network.rs
@@ -4,10 +4,10 @@ use std::collections::HashMap;
 
 use openssh_keys::PublicKey;
 
-use errors::*;
-use network;
-use providers::MetadataProvider;
-use retry;
+use crate::errors::*;
+use crate::network;
+use crate::providers::MetadataProvider;
+use crate::retry;
 
 const URL: &str = "http://169.254.169.254/latest/meta-data";
 

--- a/src/providers/packet/mock_tests.rs
+++ b/src/providers/packet/mock_tests.rs
@@ -1,5 +1,5 @@
 use mockito::{self, Matcher};
-use providers::{packet, MetadataProvider};
+use crate::providers::{packet, MetadataProvider};
 
 #[test]
 fn test_boot_checkin() {

--- a/src/providers/packet/mock_tests.rs
+++ b/src/providers/packet/mock_tests.rs
@@ -1,5 +1,5 @@
-use mockito::{self, Matcher};
 use crate::providers::{packet, MetadataProvider};
+use mockito::{self, Matcher};
 
 #[test]
 fn test_boot_checkin() {

--- a/src/providers/packet/mod.rs
+++ b/src/providers/packet/mod.rs
@@ -25,11 +25,11 @@ use std::str::FromStr;
 use openssh_keys::PublicKey;
 use pnet::util::MacAddr;
 
-use errors::*;
-use network::{self, Device, Interface, NetworkRoute, Section};
-use providers::MetadataProvider;
-use retry;
-use util;
+use crate::errors::*;
+use crate::network::{self, Device, Interface, NetworkRoute, Section};
+use crate::providers::MetadataProvider;
+use crate::retry;
+use crate::util;
 
 use ipnetwork::{self, IpNetwork, Ipv4Network, Ipv6Network};
 

--- a/src/providers/vagrant_virtualbox/mod.rs
+++ b/src/providers/vagrant_virtualbox/mod.rs
@@ -23,9 +23,9 @@ use hostname;
 use openssh_keys::PublicKey;
 use pnet;
 
-use errors::*;
-use network;
-use providers::MetadataProvider;
+use crate::errors::*;
+use crate::network;
+use crate::providers::MetadataProvider;
 
 #[derive(Clone, Copy, Debug)]
 pub struct VagrantVirtualboxProvider;

--- a/src/retry/client.rs
+++ b/src/retry/client.rs
@@ -30,13 +30,13 @@ use serde;
 use serde_json;
 use serde_xml_rs;
 
-use errors::*;
-use retry::Retry;
+use crate::errors::*;
+use crate::retry::Retry;
 
-use retry::raw_deserializer;
+use crate::retry::raw_deserializer;
 
 pub trait Deserializer {
-    fn deserialize<T, R>(&self, R) -> Result<T>
+    fn deserialize<T, R>(&self, r: R) -> Result<T>
     where
         T: for<'de> serde::Deserialize<'de>,
         R: Read;

--- a/src/retry/mod.rs
+++ b/src/retry/mod.rs
@@ -14,7 +14,7 @@
 
 //! retry is a generic function that retrys functions until they succeed.
 
-use errors::*;
+use crate::errors::*;
 use std::thread;
 use std::time::Duration;
 
@@ -59,7 +59,7 @@ impl Retry {
         self
     }
 
-    pub fn retry<F, R>(self, try: F) -> Result<R>
+    pub fn retry<F, R>(self, try_fn: F) -> Result<R>
     where
         F: Fn(u32) -> Result<R>,
     {
@@ -67,7 +67,7 @@ impl Retry {
         let mut attempts = 0;
 
         loop {
-            let res = try(attempts);
+            let res = try_fn(attempts);
 
             // if the result is ok, we don't need to try again
             if res.is_ok() {

--- a/src/retry/raw_deserializer.rs
+++ b/src/retry/raw_deserializer.rs
@@ -18,7 +18,7 @@ use std::result;
 
 use serde::de::{self, DeserializeOwned, Visitor};
 
-use errors::*;
+use crate::errors::*;
 
 pub struct RawDeserializer {
     s: String,

--- a/src/util/cmdline.rs
+++ b/src/util/cmdline.rs
@@ -19,7 +19,7 @@
 //!  handle separator quoting/escaping, list of values, and merging of repeated
 //!  flags.
 
-use errors::*;
+use crate::errors::*;
 use std::io::Read;
 use std::{fs, io};
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -14,9 +14,9 @@
 
 //! utility functions
 
-use errors::*;
+use crate::errors::*;
 use pnet;
-use retry;
+use crate::retry;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
 use std::path::Path;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -15,8 +15,8 @@
 //! utility functions
 
 use crate::errors::*;
-use pnet;
 use crate::retry;
+use pnet;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
 use std::path::Path;


### PR DESCRIPTION
This runs `cargo fix --edition` on the whole project, then switches it to 2018 edition.