### PR TITLE
Release 4.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "afterburn"
-version = "4.1.0"
+version = "4.1.1-alpha.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "afterburn"
-version = "4.0.1-alpha.0"
+version = "4.1.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.1.0-alpha.0"
+version = "4.1.0"
 
 [[bin]]
 name = "afterburn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.1.0"
+version = "4.1.1-alpha.0"
 
 [[bin]]
 name = "afterburn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.0.1-alpha.0"
+version = "4.1.0-alpha.0"
 
 [[bin]]
 name = "afterburn"


### PR DESCRIPTION
* providers/azure: fetch hostname from metadata 
* add checkin service files for Azure and Packet
* metadata: accept "ec2" provider name only in legacy mode
* bump minimum toolchain to 1.31
* cargo: switch to 2018 edition
* update all dependencies to latest