### PR TITLE
Makefile: add checkin service files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,11 @@ PREFIX ?= /usr
 
 DEFAULT_INSTANCE ?= core
 
-units = $(addprefix systemd/,afterburn.service afterburn-sshkeys@.service)
+units = $(addprefix systemd/, \
+	afterburn-checkin.service \
+	afterburn-firstboot-checkin.service \
+	afterburn.service \
+	afterburn-sshkeys@.service)
 
 %.service: %.service.in
 	sed -e 's,@DEFAULT_INSTANCE@,'$(DEFAULT_INSTANCE)',' < $< > $@.tmp && mv $@.tmp $@


### PR DESCRIPTION
Add the checkin service unit files to the make target
`install-units`.

This is to keep the Makefile updated with the new units (added
in #201).

---

Just  a minor thing noticed earlier in passing.