### PR TITLE
systemd: enable sshkeys unit on supported platforms

### DIFF
--- a/systemd/afterburn-sshkeys@.service.in
+++ b/systemd/afterburn-sshkeys@.service.in
@@ -1,5 +1,10 @@
 [Unit]
 Description=Afterburn (SSH Keys)
+ConditionKernelCommandLine=|ignition.platform.id=aws
+ConditionKernelCommandLine=|ignition.platform.id=azure
+ConditionKernelCommandLine=|ignition.platform.id=digitalocean
+ConditionKernelCommandLine=|ignition.platform.id=gcp
+ConditionKernelCommandLine=|ignition.platform.id=packet
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Add ConditionKernelCommandLine triggering conditions so that
the afterburn-sshkeys@.service unit is enabled only when recognized
cloud platforms are specified through `ignition.platform.id`.

For now, these platforms are `azure` and `packet` which are
currently supported in the `afterburn-checkin` and
`afterburn-firstboot-checkin` services.

Part of: https://github.com/coreos/fedora-coreos-tracker/issues/4