### PR TITLE
dracut: add afterburn dracut module

### DIFF
--- a/dracut/30afterburn/afterburn-hostname.service
+++ b/dracut/30afterburn/afterburn-hostname.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Afterburn Hostname
+# Azure needs to fetch the hostname in the initramfs
+ConditionKernelCommandLine=|ignition.platform.id=azure
+
+# We order this service after sysroot has been mounted
+# but before ignition-files stage has run, so ignition can
+# overwrite the configured hostname with e.g. a static one
+# Also order after ignition-remount-sysroot just for
+# safety for systems that mount /sysroot ro
+After=initrd-root-fs.target
+Before=ignition-files.service
+
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
+[Service]
+ExecStart=/usr/bin/afterburn --cmdline --hostname=/sysroot/etc/hostname
+Type=oneshot

--- a/dracut/30afterburn/module-setup.sh
+++ b/dracut/30afterburn/module-setup.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+check() {
+    return 0
+}
+
+depends() {
+    echo systemd network
+}
+
+install() {
+    inst_multiple afterburn
+
+    inst_simple "$moddir/afterburn-hostname.service" \
+        "$systemdutildir/system/afterburn-hostname.service"
+
+    # We want the afterburn-hostname to be firstboot only, so Ignition-provided
+    # hostname changes do not get overwritten on subsequent boots
+
+    mkdir -p "$initdir/$systemdsystemunitdir/ignition-complete.target.requires"
+    ln -s "../afterburn-hostname.service" "$initdir/$systemdsystemunitdir/ignition-complete.target.requires/afterburn-hostname.service"
+}


### PR DESCRIPTION
Add dracut module to run afterburn in the initramfs, and add an
initial service to fetch hostname on necessary providers (Azure).

