### PR TITLE
Release 4.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "afterburn"
-version = "4.1.1"
+version = "4.1.2-alpha.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "afterburn"
-version = "4.1.1-alpha.0"
+version = "4.1.1"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.1.1"
+version = "4.1.2-alpha.0"
 
 [[bin]]
 name = "afterburn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.1.1-alpha.0"
+version = "4.1.1"
 
 [[bin]]
 name = "afterburn"


### PR DESCRIPTION
 * dracut: add afterburn dracut module
 * systemd: add comment to sshkeys@.service
 * systemd: enable sshkeys unit on supported platforms
 * cargo: use pnet_* subcrates
 * cargo: update dependencies to latest
 * Makefile: add checkin service files

Closes: https://github.com/coreos/afterburn/issues/229
