### PR TITLE
systemd: schedule checkin after network target

### DIFF
--- a/systemd/afterburn-checkin.service
+++ b/systemd/afterburn-checkin.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Afterburn (Check In)
 ConditionKernelCommandLine=|ignition.platform.id=azure
+After=network.target
 After=boot-complete.target
 
 [Service]

--- a/systemd/afterburn-firstboot-checkin.service
+++ b/systemd/afterburn-firstboot-checkin.service
@@ -2,6 +2,7 @@
 Description=Afterburn (Firstboot Check In)
 ConditionKernelCommandLine=|ignition.platform.id=packet
 ConditionFirstBoot=yes
+After=network.target
 After=boot-complete.target
 
 [Service]


### PR DESCRIPTION
Cloud checkin requires networking to be already started, thus this
schedules checkin units after network target.
This adds no additional guarantees on network configuration status,
and afterburn still retries (with backoff) multiple times internally.