### PR TITLE
dracut: relabel the hostname file

### DIFF
--- a/dracut/30afterburn/afterburn-hostname.service
+++ b/dracut/30afterburn/afterburn-hostname.service
@@ -16,4 +16,9 @@ OnFailureJobMode=isolate
 
 [Service]
 ExecStart=/usr/bin/afterburn --cmdline --hostname=/sysroot/etc/hostname
+# Add hack to mark the file as needing relabelling, as the hostname
+# file dropped by afterburn will be unlabelled causing SELinux denials.
+# see: https://github.com/coreos/ignition/issues/635
+ExecStart=/bin/sh -c 'mkdir -p /run/tmpfiles.d'
+ExecStart=/bin/sh -c 'echo "z /etc/hostname - - -" > /run/tmpfiles.d/hostname-relabel.conf'
 Type=oneshot


### PR DESCRIPTION
Mark the file as needing relabelling, otherwise the hostname
file written to by the afterburn-hostname.service will get
SELinux denials.

This is somewhat of a hack. Eventually we want to relabel in the initrd. See: https://github.com/coreos/coreos-assembler/pull/551#issuecomment-500852247

cc @jlebon 