### PR TITLE
systemd: unify provider overriding via env

### DIFF
--- a/systemd/afterburn-checkin.service
+++ b/systemd/afterburn-checkin.service
@@ -4,7 +4,8 @@ ConditionKernelCommandLine=|ignition.platform.id=azure
 After=boot-complete.target
 
 [Service]
-ExecStart=/usr/bin/afterburn --cmdline --check-in
+Environment=AFTERBURN_OPT_PROVIDER=--cmdline
+ExecStart=/usr/bin/afterburn ${AFTERBURN_OPT_PROVIDER} --check-in
 Type=oneshot
 RemainAfterExit=yes
 

--- a/systemd/afterburn-firstboot-checkin.service
+++ b/systemd/afterburn-firstboot-checkin.service
@@ -5,7 +5,8 @@ ConditionFirstBoot=yes
 After=boot-complete.target
 
 [Service]
-ExecStart=/usr/bin/afterburn --cmdline --check-in
+Environment=AFTERBURN_OPT_PROVIDER=--cmdline
+ExecStart=/usr/bin/afterburn ${AFTERBURN_OPT_PROVIDER} --check-in
 Type=oneshot
 RemainAfterExit=yes
 


### PR DESCRIPTION
This unifies all non-initramfs units so that the provider flag
can be always overridden via `${AFTERBURN_OPT_PROVIDER}`.