### PR TITLE
metadata: add `dyn` to remove warning

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -33,7 +33,7 @@ macro_rules! box_result {
 /// `fetch_metadata` is the generic, top-level function that is used by the main
 /// function to fetch metadata. The configured provider is passed in and this
 /// function dispatches the call to the correct provider-specific fetch function
-pub fn fetch_metadata(provider: &str) -> errors::Result<Box<providers::MetadataProvider>> {
+pub fn fetch_metadata(provider: &str) -> errors::Result<Box<dyn providers::MetadataProvider>> {
     match provider {
         #[cfg(not(feature = "cl-legacy"))]
         "aws" => box_result!(AwsProvider::try_new()?),


### PR DESCRIPTION
Minor fix:
Add `dyn` to remove warning: trait objects without an explicit `dyn` are deprecated

Signed-off-by: Allen Bai <abai@redhat.com>