### PR TITLE
providers: fetch instance types for all providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ On CoreOS Container Linux, the supported providers and metadata are [somewhat di
       - AFTERBURN_OPENSTACK_IPV4_LOCAL
       - AFTERBURN_OPENSTACK_IPV4_PUBLIC
       - AFTERBURN_OPENSTACK_INSTANCE_ID
+      - AFTERBURN_OPENSTACK_INSTANCE_TYPE
   - packet
     - SSH Keys
     - Network Configs

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ On CoreOS Container Linux, the supported providers and metadata are [somewhat di
       - AFTERBURN_AWS_IPV4_PUBLIC
       - AFTERBURN_AWS_AVAILABILITY_ZONE
       - AFTERBURN_AWS_INSTANCE_ID
+      - AFTERBURN_AWS_INSTANCE_TYPE
       - AFTERBURN_AWS_REGION
   - azure
     - SSH Keys

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ On CoreOS Container Linux, the supported providers and metadata are [somewhat di
       - AFTERBURN_GCP_HOSTNAME
       - AFTERBURN_GCP_IP_EXTERNAL_0
       - AFTERBURN_GCP_IP_LOCAL_0
+      - AFTERBURN_GCP_MACHINE_TYPE
   - openstack-metadata
     - SSH Keys
     - Attributes

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ On CoreOS Container Linux, the supported providers and metadata are [somewhat di
     - Attributes
       - AFTERBURN_AZURE_IPV4_DYNAMIC
       - AFTERBURN_AZURE_IPV4_VIRTUAL
+      - AFTERBURN_AZURE_SKU
   - cloudstack-configdrive
     - SSH Keys
     - Attributes

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ On CoreOS Container Linux, the supported providers and metadata are [somewhat di
     - Attributes
       - AFTERBURN_AZURE_IPV4_DYNAMIC
       - AFTERBURN_AZURE_IPV4_VIRTUAL
-      - AFTERBURN_AZURE_SKU
+      - AFTERBURN_AZURE_VMSIZE
   - cloudstack-configdrive
     - SSH Keys
     - Attributes

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ On CoreOS Container Linux, the supported providers and metadata are [somewhat di
     - Network Configs
     - Attributes
       - AFTERBURN_PACKET_HOSTNAME
+      - AFTERBURN_PACKET_PLAN
       - AFTERBURN_PACKET_IPV4_PUBLIC_0
       - AFTERBURN_PACKET_IPV4_PRIVATE_0
       - AFTERBURN_PACKET_IPV6_PUBLIC_0

--- a/docs/container-linux-legacy.md
+++ b/docs/container-linux-legacy.md
@@ -17,6 +17,7 @@ On Container Linux, the supported cloud providers and their respective metadata 
     - Attributes
       - COREOS_AZURE_IPV4_DYNAMIC
       - COREOS_AZURE_IPV4_VIRTUAL
+      - COREOS_AZURE_VMSIZE
   - cloudstack-configdrive
     - SSH Keys
     - Attributes
@@ -59,6 +60,7 @@ On Container Linux, the supported cloud providers and their respective metadata 
       - COREOS_EC2_IPV4_PUBLIC
       - COREOS_EC2_AVAILABILITY_ZONE
       - COREOS_EC2_INSTANCE_ID
+      - COREOS_EC2_INSTANCE_TYPE
       - COREOS_EC2_REGION
   - gce
     - SSH Keys
@@ -66,6 +68,7 @@ On Container Linux, the supported cloud providers and their respective metadata 
       - COREOS_GCE_HOSTNAME
       - COREOS_GCE_IP_EXTERNAL_0
       - COREOS_GCE_IP_LOCAL_0
+      - COREOS_GCE_MACHINE_TYPE
   - openstack-metadata
     - SSH Keys
     - Attributes
@@ -73,11 +76,13 @@ On Container Linux, the supported cloud providers and their respective metadata 
       - COREOS_OPENSTACK_IPV4_LOCAL
       - COREOS_OPENSTACK_IPV4_PUBLIC
       - COREOS_OPENSTACK_INSTANCE_ID
+      - COREOS_OPENSTACK_INSTANCE_TYPE
   - packet
     - SSH Keys
     - Network Configs
     - Attributes
       - COREOS_PACKET_HOSTNAME
+      - COREOS_PACKET_PLAN
       - COREOS_PACKET_IPV4_PUBLIC_0
       - COREOS_PACKET_IPV4_PRIVATE_0
       - COREOS_PACKET_IPV6_PUBLIC_0

--- a/src/providers/aws/mock_tests.rs
+++ b/src/providers/aws/mock_tests.rs
@@ -1,13 +1,7 @@
 use crate::errors::*;
 use crate::providers::aws;
 use mockito;
-use std::collections::HashMap;
 use crate::providers::MetadataProvider;
-
-#[cfg(not(feature = "cl-legacy"))]
-static ENV_PREFIX: &str = "AWS";
-#[cfg(feature = "cl-legacy")]
-static ENV_PREFIX: &str = "EC2";
 
 #[test]
 fn test_aws_basic() {
@@ -35,40 +29,46 @@ fn test_aws_basic() {
 
 #[test]
 fn test_aws_attributes() {
-    let ep_instance_id = "/meta-data/instance-id";
     let instance_id = "test-instance-id";
-
-    let ep_instance_type = "/meta-data/instance-type";
     let instance_type = "test-instance-type";
-
-    let ep_ipv4_local = "/meta-data/local-ipv4";
     let ipv4_local = "test-ipv4-local";
-
-    let ep_ipv4_public = "/meta-data/public-ipv4";
     let ipv4_public = "test-ipv4-public";
-
-    let ep_availability_zone = "/meta-data/placement/availability-zone";
     let availability_zone = "test-availability-zone";
-
-    let ep_hostname = "/meta-data/hostname";
     let hostname = "test-hostname";
-
-    let ep_public_hostname = "/meta-data/public-hostname";
     let public_hostname = "test-public-hostname";
-
-    let ep_region = "/dynamic/instance-identity/document";
-    let instance_id_doc = "{\"region\": \"test-region\"}";
+    let instance_id_doc = r#"{"region": "test-region"}"#;
     let region = "test-region";
 
-    let mut attributes:HashMap<String, String> = HashMap::new();
-    attributes.insert(format!("{}_INSTANCE_ID", ENV_PREFIX), String::from(instance_id));
-    attributes.insert(format!("{}_INSTANCE_TYPE", ENV_PREFIX), String::from(instance_type));
-    attributes.insert(format!("{}_IPV4_LOCAL", ENV_PREFIX), String::from(ipv4_local));
-    attributes.insert(format!("{}_IPV4_PUBLIC", ENV_PREFIX), String::from(ipv4_public));
-    attributes.insert(format!("{}_AVAILABILITY_ZONE", ENV_PREFIX), String::from(availability_zone));
-    attributes.insert(format!("{}_HOSTNAME", ENV_PREFIX), String::from(hostname));
-    attributes.insert(format!("{}_PUBLIC_HOSTNAME", ENV_PREFIX), String::from(public_hostname));
-    attributes.insert(format!("{}_REGION", ENV_PREFIX), String::from(region));
+    let endpoints = maplit::btreemap! {
+        "/meta-data/instance-id" => instance_id,
+        "/meta-data/instance-type" => instance_type,
+        "/meta-data/local-ipv4" => ipv4_local,
+        "/meta-data/public-ipv4" => ipv4_public,
+        "/meta-data/placement/availability-zone" => availability_zone,
+        "/meta-data/hostname" => hostname,
+        "/meta-data/public-hostname" => public_hostname,
+        "/dynamic/instance-identity/document" => instance_id_doc,
+    };
+
+    let mut mocks = Vec::with_capacity(endpoints.len());
+    for (endpoint, body) in endpoints {
+        let m = mockito::mock("GET", endpoint)
+            .with_status(200)
+            .with_body(body)
+            .create();
+        mocks.push(m);
+    }
+
+    let attributes = maplit::hashmap! {
+        format!("{}_INSTANCE_ID", aws::ENV_PREFIX) => String::from(instance_id),
+        format!("{}_INSTANCE_TYPE", aws::ENV_PREFIX) => String::from(instance_type),
+        format!("{}_IPV4_LOCAL", aws::ENV_PREFIX) => String::from(ipv4_local),
+        format!("{}_IPV4_PUBLIC", aws::ENV_PREFIX) => String::from(ipv4_public),
+        format!("{}_AVAILABILITY_ZONE", aws::ENV_PREFIX) => String::from(availability_zone),
+        format!("{}_HOSTNAME", aws::ENV_PREFIX) => String::from(hostname),
+        format!("{}_PUBLIC_HOSTNAME", aws::ENV_PREFIX) => String::from(public_hostname),
+        format!("{}_REGION", aws::ENV_PREFIX) => String::from(region),
+    };
 
     let client = crate::retry::Client::try_new()
         .chain_err(|| "failed to create http client")
@@ -77,40 +77,9 @@ fn test_aws_attributes() {
         .return_on_404(true);
     let provider = aws::AwsProvider { client };
 
-    let _m = mockito::mock("GET", ep_instance_id)
-        .with_status(200)
-        .with_body(instance_id)
-        .create();
-    let _m = mockito::mock("GET", ep_instance_type)
-        .with_status(200)
-        .with_body(instance_type)
-        .create();
-    let _m = mockito::mock("GET", ep_ipv4_local)
-        .with_status(200)
-        .with_body(ipv4_local)
-        .create();
-    let _m = mockito::mock("GET", ep_ipv4_public)
-        .with_status(200)
-        .with_body(ipv4_public)
-        .create();
-    let _m = mockito::mock("GET", ep_availability_zone)
-        .with_status(200)
-        .with_body(availability_zone)
-        .create();
-    let _m = mockito::mock("GET", ep_hostname)
-        .with_status(200)
-        .with_body(hostname)
-        .create();
-    let _m = mockito::mock("GET", ep_public_hostname)
-        .with_status(200)
-        .with_body(public_hostname)
-        .create();
-    let _m = mockito::mock("GET", ep_region)
-        .with_status(200)
-        .with_body(instance_id_doc)
-        .create();
-
     let v = provider.attributes().unwrap();
-
     assert_eq!(v, attributes);
+
+    mockito::reset();
+    provider.attributes().unwrap_err();
 }

--- a/src/providers/aws/mock_tests.rs
+++ b/src/providers/aws/mock_tests.rs
@@ -25,6 +25,9 @@ fn test_aws_basic() {
     let _m = mockito::mock("GET", ep).with_status(404).create();
     let v = provider.fetch_ssh_keys().unwrap();
     assert_eq!(v.len(), 0);
+
+    mockito::reset();
+    provider.fetch_ssh_keys().unwrap_err();
 }
 
 #[test]
@@ -60,14 +63,14 @@ fn test_aws_attributes() {
     }
 
     let attributes = maplit::hashmap! {
-        format!("{}_INSTANCE_ID", aws::ENV_PREFIX) => String::from(instance_id),
-        format!("{}_INSTANCE_TYPE", aws::ENV_PREFIX) => String::from(instance_type),
-        format!("{}_IPV4_LOCAL", aws::ENV_PREFIX) => String::from(ipv4_local),
-        format!("{}_IPV4_PUBLIC", aws::ENV_PREFIX) => String::from(ipv4_public),
-        format!("{}_AVAILABILITY_ZONE", aws::ENV_PREFIX) => String::from(availability_zone),
-        format!("{}_HOSTNAME", aws::ENV_PREFIX) => String::from(hostname),
-        format!("{}_PUBLIC_HOSTNAME", aws::ENV_PREFIX) => String::from(public_hostname),
-        format!("{}_REGION", aws::ENV_PREFIX) => String::from(region),
+        format!("{}_INSTANCE_ID", aws::ENV_PREFIX) => instance_id.to_string(),
+        format!("{}_INSTANCE_TYPE", aws::ENV_PREFIX) => instance_type.to_string(),
+        format!("{}_IPV4_LOCAL", aws::ENV_PREFIX) => ipv4_local.to_string(),
+        format!("{}_IPV4_PUBLIC", aws::ENV_PREFIX) => ipv4_public.to_string(),
+        format!("{}_AVAILABILITY_ZONE", aws::ENV_PREFIX) => availability_zone.to_string(),
+        format!("{}_HOSTNAME", aws::ENV_PREFIX) => hostname.to_string(),
+        format!("{}_PUBLIC_HOSTNAME", aws::ENV_PREFIX) => public_hostname.to_string(),
+        format!("{}_REGION", aws::ENV_PREFIX) => region.to_string(),
     };
 
     let client = crate::retry::Client::try_new()

--- a/src/providers/aws/mock_tests.rs
+++ b/src/providers/aws/mock_tests.rs
@@ -1,6 +1,13 @@
 use crate::errors::*;
 use crate::providers::aws;
 use mockito;
+use std::collections::HashMap;
+use crate::providers::MetadataProvider;
+
+#[cfg(not(feature = "cl-legacy"))]
+static ENV_PREFIX: &str = "AWS";
+#[cfg(feature = "cl-legacy")]
+static ENV_PREFIX: &str = "EC2";
 
 #[test]
 fn test_aws_basic() {
@@ -24,4 +31,86 @@ fn test_aws_basic() {
     let _m = mockito::mock("GET", ep).with_status(404).create();
     let v = provider.fetch_ssh_keys().unwrap();
     assert_eq!(v.len(), 0);
+}
+
+#[test]
+fn test_attributes_fetching() {
+    let ep_instance_id = "/meta-data/instance-id";
+    let instance_id = "test-instance-id";
+
+    let ep_instance_type = "/meta-data/instance-type";
+    let instance_type = "test-instance-type";
+
+    let ep_ipv4_local = "/meta-data/local-ipv4";
+    let ipv4_local = "test-ipv4-local";
+
+    let ep_ipv4_public = "/meta-data/public-ipv4";
+    let ipv4_public = "test-ipv4-public";
+
+    let ep_availability_zone = "/meta-data/placement/availability-zone";
+    let availability_zone = "test-availability-zone";
+
+    let ep_hostname = "/meta-data/hostname";
+    let hostname = "test-hostname";
+
+    let ep_public_hostname = "/meta-data/public-hostname";
+    let public_hostname = "test-public-hostname";
+
+    let ep_region = "/dynamic/instance-identity/document";
+    let instance_id_doc = "{\"region\": \"test-region\"}";
+    let region = "test-region";
+
+    let mut attributes:HashMap<String, String> = HashMap::new();
+    attributes.insert(format!("{}_INSTANCE_ID", ENV_PREFIX), String::from(instance_id));
+    attributes.insert(format!("{}_INSTANCE_TYPE", ENV_PREFIX), String::from(instance_type));
+    attributes.insert(format!("{}_IPV4_LOCAL", ENV_PREFIX), String::from(ipv4_local));
+    attributes.insert(format!("{}_IPV4_PUBLIC", ENV_PREFIX), String::from(ipv4_public));
+    attributes.insert(format!("{}_AVAILABILITY_ZONE", ENV_PREFIX), String::from(availability_zone));
+    attributes.insert(format!("{}_HOSTNAME", ENV_PREFIX), String::from(hostname));
+    attributes.insert(format!("{}_PUBLIC_HOSTNAME", ENV_PREFIX), String::from(public_hostname));
+    attributes.insert(format!("{}_REGION", ENV_PREFIX), String::from(region));
+
+    let client = crate::retry::Client::try_new()
+        .chain_err(|| "failed to create http client")
+        .unwrap()
+        .max_attempts(1)
+        .return_on_404(true);
+    let provider = aws::AwsProvider { client };
+
+    let _m = mockito::mock("GET", ep_instance_id)
+        .with_status(200)
+        .with_body(instance_id)
+        .create();
+    let _m = mockito::mock("GET", ep_instance_type)
+        .with_status(200)
+        .with_body(instance_type)
+        .create();
+    let _m = mockito::mock("GET", ep_ipv4_local)
+        .with_status(200)
+        .with_body(ipv4_local)
+        .create();
+    let _m = mockito::mock("GET", ep_ipv4_public)
+        .with_status(200)
+        .with_body(ipv4_public)
+        .create();
+    let _m = mockito::mock("GET", ep_availability_zone)
+        .with_status(200)
+        .with_body(availability_zone)
+        .create();
+    let _m = mockito::mock("GET", ep_hostname)
+        .with_status(200)
+        .with_body(hostname)
+        .create();
+    let _m = mockito::mock("GET", ep_public_hostname)
+        .with_status(200)
+        .with_body(public_hostname)
+        .create();
+    let _m = mockito::mock("GET", ep_region)
+        .with_status(200)
+        .with_body(instance_id_doc)
+        .create();
+
+    let v = provider.attributes().unwrap();
+
+    assert_eq!(v, attributes);
 }

--- a/src/providers/aws/mock_tests.rs
+++ b/src/providers/aws/mock_tests.rs
@@ -34,7 +34,7 @@ fn test_aws_basic() {
 }
 
 #[test]
-fn test_attributes_fetching() {
+fn test_aws_attributes() {
     let ep_instance_id = "/meta-data/instance-id";
     let instance_id = "test-instance-id";
 

--- a/src/providers/aws/mod.rs
+++ b/src/providers/aws/mod.rs
@@ -122,6 +122,11 @@ impl MetadataProvider for AwsProvider {
         )?;
         add_value(
             &mut out,
+            &format!("{}_INSTANCE_TYPE", ENV_PREFIX),
+            "meta-data/instance-type",
+        )?;
+        add_value(
+            &mut out,
             &format!("{}_IPV4_LOCAL", ENV_PREFIX),
             "meta-data/local-ipv4",
         )?;

--- a/src/providers/azure/mock_tests.rs
+++ b/src/providers/azure/mock_tests.rs
@@ -113,3 +113,28 @@ fn test_hostname() {
     let hostname = r.unwrap();
     assert_eq!(hostname, testname);
 }
+
+#[test]
+fn test_vmsize() {
+    let m_version = mock_fab_version();
+    let m_goalstate = mock_goalstate();
+
+    let testvmsize = "testvmsize";
+    let endpoint = "/metadata/instance/compute/vmSize?api-version=2017-08-01&format=text";
+    let m_vmsize = mockito::mock("GET", endpoint)
+        .match_header("Metadata", "true")
+        .with_body(testvmsize)
+        .with_status(200)
+        .create();
+
+    let provider = azure::Azure::try_new();
+    let attributes = provider.unwrap().attributes().unwrap();
+    let r = attributes.get("AZURE_VMSIZE");
+
+    m_version.assert();
+    m_goalstate.assert();
+
+    m_vmsize.assert();
+    let vmsize = r.unwrap();
+    assert_eq!(vmsize, testvmsize);
+}

--- a/src/providers/azure/mock_tests.rs
+++ b/src/providers/azure/mock_tests.rs
@@ -88,6 +88,9 @@ fn test_boot_checkin() {
     m_goalstate.assert();
     m_health.assert();
     r.unwrap();
+
+    mockito::reset();
+    azure::Azure::try_new().unwrap_err();
 }
 
 #[test]
@@ -112,6 +115,9 @@ fn test_hostname() {
     m_hostname.assert();
     let hostname = r.unwrap();
     assert_eq!(hostname, testname);
+
+    mockito::reset();
+    azure::Azure::try_new().unwrap_err();
 }
 
 #[test]
@@ -137,4 +143,7 @@ fn test_vmsize() {
     m_vmsize.assert();
     let vmsize = r.unwrap();
     assert_eq!(vmsize, testvmsize);
+
+    mockito::reset();
+    azure::Azure::try_new().unwrap_err();
 }

--- a/src/providers/azure/mod.rs
+++ b/src/providers/azure/mod.rs
@@ -18,8 +18,6 @@ mod crypto;
 
 use std::collections::HashMap;
 use std::net::IpAddr;
-#[cfg(not(test))]
-use std::net::SocketAddr;
 
 use openssh_keys::PublicKey;
 use reqwest::header::{HeaderName, HeaderValue};
@@ -367,6 +365,8 @@ impl Azure {
 
     #[cfg(not(test))]
     fn get_attributes(&self) -> Result<Attributes> {
+        use std::net::SocketAddr;
+
         let endpoint = &self.goal_state.container.role_instance_list.role_instances[0]
             .configuration
             .shared_config;

--- a/src/providers/azure/mod.rs
+++ b/src/providers/azure/mod.rs
@@ -17,7 +17,9 @@
 mod crypto;
 
 use std::collections::HashMap;
-use std::net::{IpAddr, SocketAddr};
+use std::net::IpAddr;
+#[cfg(not(test))]
+use std::net::SocketAddr;
 
 use openssh_keys::PublicKey;
 use reqwest::header::{HeaderName, HeaderValue};
@@ -355,6 +357,15 @@ impl Azure {
         Ok(ssh_pubkey)
     }
 
+    #[cfg(test)]
+    fn get_attributes(&self) -> Result<Attributes> {
+        Ok(Attributes{
+            virtual_ipv4: Some(Azure::get_fabric_address()),
+            dynamic_ipv4: Some(Azure::get_fabric_address()),
+        })
+    }
+
+    #[cfg(not(test))]
     fn get_attributes(&self) -> Result<Attributes> {
         let endpoint = &self.goal_state.container.role_instance_list.role_instances[0]
             .configuration

--- a/src/providers/gcp/mock_tests.rs
+++ b/src/providers/gcp/mock_tests.rs
@@ -1,6 +1,12 @@
 use crate::providers::gcp;
 use crate::providers::MetadataProvider;
+use std::collections::HashMap;
 use mockito;
+
+#[cfg(not(feature = "cl-legacy"))]
+static ENV_PREFIX: &str = "GCP";
+#[cfg(feature = "cl-legacy")]
+static ENV_PREFIX: &str = "GCE";
 
 #[test]
 fn basic_hostname() {
@@ -26,4 +32,49 @@ fn basic_hostname() {
 
     mockito::reset();
     provider.hostname().unwrap_err();
+}
+
+#[test]
+fn basic_attributes() {
+    let ep_hostname = "/instance/hostname";
+    let hostname = "test-hostname";
+
+    let ep_ip_external = "/instance/network-interfaces/0/access-configs/0/external-ip";
+    let ip_external = "test-ip-external";
+
+    let ep_ip_local = "/instance/network-interfaces/0/ip";
+    let ip_local = "test-ip-local";
+
+    let ep_machine_type = "/instance/machine-type";
+    let machine_type = "test-machine-type";
+
+    let mut attributes:HashMap<String, String> = HashMap::new();
+    attributes.insert(format!("{}_HOSTNAME", ENV_PREFIX), String::from(hostname));
+    attributes.insert(format!("{}_IP_EXTERNAL_0", ENV_PREFIX), String::from(ip_external));
+    attributes.insert(format!("{}_IP_LOCAL_0", ENV_PREFIX), String::from(ip_local));
+    attributes.insert(format!("{}_MACHINE_TYPE", ENV_PREFIX), String::from(machine_type));
+
+    let mut provider = gcp::GcpProvider::try_new().unwrap();
+    provider.client = provider.client.max_attempts(1);
+
+    let _m = mockito::mock("GET", ep_hostname)
+        .with_status(200)
+        .with_body(hostname)
+        .create();
+    let _m = mockito::mock("GET", ep_ip_external)
+        .with_status(200)
+        .with_body(ip_external)
+        .create();
+    let _m = mockito::mock("GET", ep_ip_local)
+        .with_status(200)
+        .with_body(ip_local)
+        .create();
+    let _m = mockito::mock("GET", ep_machine_type)
+        .with_status(200)
+        .with_body(machine_type)
+        .create();
+
+    let v = provider.attributes().unwrap();
+
+    assert_eq!(v, attributes);
 }

--- a/src/providers/gcp/mock_tests.rs
+++ b/src/providers/gcp/mock_tests.rs
@@ -51,10 +51,10 @@ fn basic_attributes() {
     }
 
     let attributes = maplit::hashmap! {
-        format!("{}_HOSTNAME", gcp::ENV_PREFIX) => String::from(hostname),
-        format!("{}_IP_EXTERNAL_0", gcp::ENV_PREFIX) => String::from(ip_external),
-        format!("{}_IP_LOCAL_0", gcp::ENV_PREFIX) => String::from(ip_local),
-        format!("{}_MACHINE_TYPE", gcp::ENV_PREFIX) => String::from(machine_type),
+        format!("{}_HOSTNAME", gcp::ENV_PREFIX) => hostname.to_string(),
+        format!("{}_IP_EXTERNAL_0", gcp::ENV_PREFIX) => ip_external.to_string(),
+        format!("{}_IP_LOCAL_0", gcp::ENV_PREFIX) => ip_local.to_string(),
+        format!("{}_MACHINE_TYPE", gcp::ENV_PREFIX) => machine_type.to_string(),
     };
 
     let client = crate::retry::Client::try_new()

--- a/src/providers/gcp/mod.rs
+++ b/src/providers/gcp/mod.rs
@@ -131,7 +131,7 @@ impl GcpProvider {
 
 impl MetadataProvider for GcpProvider {
     fn attributes(&self) -> Result<HashMap<String, String>> {
-        let mut out = HashMap::with_capacity(3);
+        let mut out = HashMap::with_capacity(4);
 
         let add_value = |map: &mut HashMap<_, _>, key: &str, name| -> Result<()> {
             let value: Option<String> = self

--- a/src/providers/gcp/mod.rs
+++ b/src/providers/gcp/mod.rs
@@ -163,6 +163,11 @@ impl MetadataProvider for GcpProvider {
             &format!("{}_IP_LOCAL_0", ENV_PREFIX),
             "instance/network-interfaces/0/ip",
         )?;
+        add_value(
+            &mut out,
+            &format!("{}_MACHINE_TYPE", ENV_PREFIX),
+            "instance/machine-type",
+        )?;
 
         Ok(out)
     }

--- a/src/providers/openstack/network.rs
+++ b/src/providers/openstack/network.rs
@@ -73,6 +73,7 @@ impl MetadataProvider for OpenstackProvider {
 
         add_value(&mut out, "OPENSTACK_HOSTNAME", "hostname")?;
         add_value(&mut out, "OPENSTACK_INSTANCE_ID", "instance-id")?;
+        add_value(&mut out, "OPENSTACK_INSTANCE_TYPE", "instance-type")?;
         add_value(&mut out, "OPENSTACK_IPV4_LOCAL", "local-ipv4")?;
         add_value(&mut out, "OPENSTACK_IPV4_PUBLIC", "public-ipv4")?;
 

--- a/src/providers/packet/mock_tests.rs
+++ b/src/providers/packet/mock_tests.rs
@@ -33,6 +33,9 @@ fn test_boot_checkin() {
     let r = provider.boot_checkin();
     mock.assert();
     r.unwrap();
+
+    mockito::reset();
+    provider.boot_checkin().unwrap_err();
 }
 
 #[test]
@@ -53,14 +56,10 @@ fn test_packet_attributes() {
         "phone_home_url": "test-url"
     }"#;
 
-    let hostname = "test-hostname";
-    let phone_home_url = "test-url";
-    let plan = "test-plan";
-
     let attributes = maplit::hashmap! {
-        format!("PACKET_HOSTNAME") => String::from(hostname),
-        format!("PACKET_PHONE_HOME_URL") => String::from(phone_home_url),
-        format!("PACKET_PLAN") => String::from(plan),
+        "PACKET_HOSTNAME".to_string() => "test-hostname".to_string(),
+        "PACKET_PHONE_HOME_URL".to_string() => "test-url".to_string(),
+        "PACKET_PLAN".to_string() => "test-plan".to_string(),
     };
 
     let _m = mockito::mock("GET", "/metadata")
@@ -72,4 +71,7 @@ fn test_packet_attributes() {
     let v = provider.attributes().unwrap();
 
     assert_eq!(v, attributes);
+
+    mockito::reset();
+    packet::PacketProvider::try_new().unwrap_err();
 }

--- a/src/providers/packet/mock_tests.rs
+++ b/src/providers/packet/mock_tests.rs
@@ -1,6 +1,5 @@
 use crate::providers::{packet, MetadataProvider};
 use mockito::{self, Matcher};
-use std::collections::HashMap;
 
 #[test]
 fn test_boot_checkin() {
@@ -38,30 +37,31 @@ fn test_boot_checkin() {
 
 #[test]
 fn test_packet_attributes() {
-    let metadata = "{
-        \"id\": \"test-id\",
-        \"hostname\": \"test-hostname\",
-        \"iqn\": \"test-iqn\",
-        \"plan\": \"test-plan\",
-        \"facility\": \"test-facility\",
-        \"tags\": [],
-        \"ssh_keys\": [],
-        \"network\": {
-            \"interfaces\": [],
-            \"addresses\": [],
-            \"bonding\": { \"mode\": 0 }
+    let metadata = r#"{
+        "id": "test-id",
+        "hostname": "test-hostname",
+        "iqn": "test-iqn",
+        "plan": "test-plan",
+        "facility": "test-facility",
+        "tags": [],
+        "ssh_keys": [],
+        "network": {
+            "interfaces": [],
+            "addresses": [],
+            "bonding": { "mode": 0 }
         },
-        \"phone_home_url\": \"test-url\"
-    }";
+        "phone_home_url": "test-url"
+    }"#;
 
     let hostname = "test-hostname";
     let phone_home_url = "test-url";
     let plan = "test-plan";
 
-    let mut attributes:HashMap<String, String> = HashMap::new();
-    attributes.insert(format!("PACKET_HOSTNAME"), String::from(hostname));
-    attributes.insert(format!("PACKET_PHONE_HOME_URL"), String::from(phone_home_url));
-    attributes.insert(format!("PACKET_PLAN"), String::from(plan));
+    let attributes = maplit::hashmap! {
+        format!("PACKET_HOSTNAME") => String::from(hostname),
+        format!("PACKET_PHONE_HOME_URL") => String::from(phone_home_url),
+        format!("PACKET_PLAN") => String::from(plan),
+    };
 
     let _m = mockito::mock("GET", "/metadata")
         .with_status(200)

--- a/src/providers/packet/mod.rs
+++ b/src/providers/packet/mod.rs
@@ -87,6 +87,23 @@ pub struct PacketProvider {
 }
 
 impl PacketProvider {
+    #[cfg(test)]
+    pub fn try_new() -> Result<PacketProvider> {
+        let client = retry::Client::try_new()?;
+        let url = mockito::server_url();
+
+        let data: PacketData = client
+            .get(
+                retry::Json,
+                format!("{}/metadata", url),
+            )
+            .send()?
+            .ok_or("not found")?;
+
+        Ok(PacketProvider { data })
+    }
+
+    #[cfg(not(test))]
     pub fn try_new() -> Result<PacketProvider> {
         let client = retry::Client::try_new()?;
 

--- a/src/providers/packet/mod.rs
+++ b/src/providers/packet/mod.rs
@@ -144,6 +144,7 @@ impl PacketProvider {
             "PACKET_PHONE_HOME_URL".to_owned(),
             self.data.phone_home_url.clone(),
         ));
+        attrs.push(("PACKET_PLAN".to_owned(), self.data.plan.clone()));
         Ok(attrs)
     }
 


### PR DESCRIPTION
Fetch instance-type from cloud providers.

Closes: https://github.com/coreos/afterburn/issues/277
Signed-off-by: Zonggen (Allen) Bai <abai@redhat.com> 