### PR TITLE
cargo: prepare for next minor release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "afterburn"
-version = "4.1.4-alpha.0"
+version = "4.2.0-alpha.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.1.4-alpha.0"
+version = "4.2.0-alpha.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
A minor bump in order to get ready for the next release, which will contain:
 * a new platform (`aliyun`) https://github.com/coreos/afterburn/pull/283
 * instance type attributes https://github.com/coreos/afterburn/pull/278