### PR TITLE
tests/gcp: avoid flake

### DIFF
--- a/src/providers/gcp/mock_tests.rs
+++ b/src/providers/gcp/mock_tests.rs
@@ -10,8 +10,6 @@ fn basic_hostname() {
     let mut provider = gcp::GcpProvider::try_new().unwrap();
     provider.client = provider.client.max_attempts(1);
 
-    provider.hostname().unwrap_err();
-
     let _m = mockito::mock("GET", ep).with_status(503).create();
     provider.hostname().unwrap_err();
 
@@ -25,4 +23,7 @@ fn basic_hostname() {
     let _m = mockito::mock("GET", ep).with_status(404).create();
     let v = provider.hostname().unwrap();
     assert_eq!(v, None);
+
+    mockito::reset();
+    provider.hostname().unwrap_err();
 }


### PR DESCRIPTION
This moves around an error check and resets mockito state in order
to decrease the chance of flakes in other concurrent or subsequent
tests re-using the same endpoints.