### PR TITLE
systemd: allow sshkeys service on aliyun

### DIFF
--- a/systemd/afterburn-sshkeys@.service.in
+++ b/systemd/afterburn-sshkeys@.service.in
@@ -4,6 +4,7 @@ Description=Afterburn (SSH Keys)
 # Platforms which support SSH keys but require selecting from multiple metadata
 # sources are not listed here; for those platforms, CT writes a drop-in which
 # adds the appropriate triggering condition and sets AFTERBURN_OPT_PROVIDER.
+ConditionKernelCommandLine=|ignition.platform.id=aliyun
 ConditionKernelCommandLine=|ignition.platform.id=aws
 ConditionKernelCommandLine=|ignition.platform.id=azure
 ConditionKernelCommandLine=|ignition.platform.id=digitalocean


### PR DESCRIPTION
This enables the Afterburn SSH Keys service on Alibaba Cloud by
default.