### PR TITLE
*: drop extern crate declarations

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,6 +14,7 @@
 
 #![allow(deprecated)]
 
+use error_chain::error_chain;
 use reqwest::header;
 use serde_json;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,36 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate base64;
-#[macro_use]
-extern crate clap;
-#[macro_use]
-extern crate error_chain;
-extern crate hostname;
-extern crate ipnetwork;
-extern crate nix;
-extern crate openssh_keys;
-extern crate openssl;
-extern crate reqwest;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde;
-extern crate serde_json;
-extern crate serde_xml_rs;
-#[macro_use]
-extern crate slog;
-extern crate slog_async;
-extern crate slog_term;
 #[macro_use]
 extern crate slog_scope;
-extern crate tempdir;
-extern crate tempfile;
-#[cfg(feature = "cl-legacy")]
-extern crate update_ssh_keys;
-extern crate users;
-
-#[cfg(test)]
-extern crate mockito;
 
 mod errors;
 mod metadata;
@@ -50,8 +22,9 @@ mod providers;
 mod retry;
 mod util;
 
-use clap::{App, Arg};
-use slog::Drain;
+use clap::{crate_version, App, Arg};
+use error_chain::quick_main;
+use slog::{slog_o, Drain};
 use std::env;
 
 use crate::errors::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[macro_use]
-extern crate slog_scope;
-
 mod errors;
 mod metadata;
 mod network;
@@ -25,6 +22,7 @@ mod util;
 use clap::{crate_version, App, Arg};
 use error_chain::quick_main;
 use slog::{slog_o, Drain};
+use slog_scope::{debug, trace};
 use std::env;
 
 use crate::errors::*;

--- a/src/providers/aliyun/mod.rs
+++ b/src/providers/aliyun/mod.rs
@@ -6,6 +6,7 @@
 #[cfg(test)]
 use mockito;
 use openssh_keys::PublicKey;
+use slog_scope::{error, warn};
 use std::collections::{BTreeSet, HashMap};
 
 use crate::errors::*;

--- a/src/providers/aws/mock_tests.rs
+++ b/src/providers/aws/mock_tests.rs
@@ -1,7 +1,7 @@
 use crate::errors::*;
 use crate::providers::aws;
-use mockito;
 use crate::providers::MetadataProvider;
+use mockito;
 
 #[test]
 fn test_aws_basic() {

--- a/src/providers/aws/mod.rs
+++ b/src/providers/aws/mod.rs
@@ -21,6 +21,7 @@ use std::collections::HashMap;
 use mockito;
 use openssh_keys::PublicKey;
 use serde_derive::Deserialize;
+use slog_scope::warn;
 
 use crate::errors::*;
 use crate::network;

--- a/src/providers/aws/mod.rs
+++ b/src/providers/aws/mod.rs
@@ -20,6 +20,7 @@ use std::collections::HashMap;
 #[cfg(test)]
 use mockito;
 use openssh_keys::PublicKey;
+use serde_derive::Deserialize;
 
 use crate::errors::*;
 use crate::network;

--- a/src/providers/azure/mod.rs
+++ b/src/providers/azure/mod.rs
@@ -21,6 +21,7 @@ use std::net::IpAddr;
 
 use openssh_keys::PublicKey;
 use reqwest::header::{HeaderName, HeaderValue};
+use serde_derive::Deserialize;
 
 use self::crypto::x509;
 use crate::errors::*;

--- a/src/providers/azure/mod.rs
+++ b/src/providers/azure/mod.rs
@@ -357,7 +357,7 @@ impl Azure {
 
     #[cfg(test)]
     fn get_attributes(&self) -> Result<Attributes> {
-        Ok(Attributes{
+        Ok(Attributes {
             virtual_ipv4: Some(Azure::get_fabric_address()),
             dynamic_ipv4: Some(Azure::get_fabric_address()),
         })
@@ -430,8 +430,9 @@ impl Azure {
         Ok(name)
     }
 
-    fn fetch_vmsize (&self) -> Result<String> {
-        const VMSIZE_URL: &str = "metadata/instance/compute/vmSize?api-version=2017-08-01&format=text";
+    fn fetch_vmsize(&self) -> Result<String> {
+        const VMSIZE_URL: &str =
+            "metadata/instance/compute/vmSize?api-version=2017-08-01&format=text";
         let url = format!("{}/{}", Self::metadata_endpoint(), VMSIZE_URL);
 
         let vmsize = retry::Client::try_new()?

--- a/src/providers/azure/mod.rs
+++ b/src/providers/azure/mod.rs
@@ -22,6 +22,7 @@ use std::net::IpAddr;
 use openssh_keys::PublicKey;
 use reqwest::header::{HeaderName, HeaderValue};
 use serde_derive::Deserialize;
+use slog_scope::{info, trace, warn};
 
 use self::crypto::x509;
 use crate::errors::*;

--- a/src/providers/cloudstack/configdrive.rs
+++ b/src/providers/cloudstack/configdrive.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 
 use nix::mount;
 use openssh_keys::PublicKey;
+use slog_scope::warn;
 use tempdir::TempDir;
 
 use crate::errors::*;

--- a/src/providers/cloudstack/network.rs
+++ b/src/providers/cloudstack/network.rs
@@ -5,6 +5,7 @@ use std::net::IpAddr;
 use std::time::Duration;
 
 use openssh_keys::PublicKey;
+use slog_scope::warn;
 
 use crate::errors::*;
 use crate::network;

--- a/src/providers/digitalocean/mod.rs
+++ b/src/providers/digitalocean/mod.rs
@@ -23,6 +23,7 @@ use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 use openssh_keys::PublicKey;
 use pnet_base::MacAddr;
 use serde_derive::Deserialize;
+use slog_scope::warn;
 
 use crate::errors::*;
 use crate::network;

--- a/src/providers/digitalocean/mod.rs
+++ b/src/providers/digitalocean/mod.rs
@@ -22,6 +22,7 @@ use ipnetwork;
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 use openssh_keys::PublicKey;
 use pnet_base::MacAddr;
+use serde_derive::Deserialize;
 
 use crate::errors::*;
 use crate::network;

--- a/src/providers/gcp/mod.rs
+++ b/src/providers/gcp/mod.rs
@@ -18,6 +18,7 @@
 use mockito;
 use openssh_keys::PublicKey;
 use reqwest::header::{HeaderName, HeaderValue};
+use slog_scope::warn;
 use std::collections::HashMap;
 
 use crate::errors::*;

--- a/src/providers/openstack/network.rs
+++ b/src/providers/openstack/network.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 
 use openssh_keys::PublicKey;
+use slog_scope::warn;
 
 use crate::errors::*;
 use crate::network;

--- a/src/providers/packet/mod.rs
+++ b/src/providers/packet/mod.rs
@@ -25,6 +25,7 @@ use std::str::FromStr;
 use openssh_keys::PublicKey;
 use pnet_base::MacAddr;
 use serde_derive::Deserialize;
+use slog_scope::warn;
 
 use crate::errors::*;
 use crate::network::{self, Device, Interface, NetworkRoute, Section};

--- a/src/providers/packet/mod.rs
+++ b/src/providers/packet/mod.rs
@@ -24,6 +24,7 @@ use std::str::FromStr;
 
 use openssh_keys::PublicKey;
 use pnet_base::MacAddr;
+use serde_derive::Deserialize;
 
 use crate::errors::*;
 use crate::network::{self, Device, Interface, NetworkRoute, Section};

--- a/src/providers/packet/mod.rs
+++ b/src/providers/packet/mod.rs
@@ -93,10 +93,7 @@ impl PacketProvider {
         let url = mockito::server_url();
 
         let data: PacketData = client
-            .get(
-                retry::Json,
-                format!("{}/metadata", url),
-            )
+            .get(retry::Json, format!("{}/metadata", url))
             .send()?
             .ok_or("not found")?;
 

--- a/src/providers/vagrant_virtualbox/mod.rs
+++ b/src/providers/vagrant_virtualbox/mod.rs
@@ -22,6 +22,7 @@ use std::time::Duration;
 use hostname;
 use openssh_keys::PublicKey;
 use pnet_datalink;
+use slog_scope::{info, warn};
 
 use crate::errors::*;
 use crate::network;

--- a/src/retry/client.rs
+++ b/src/retry/client.rs
@@ -25,6 +25,7 @@ use std::time::Duration;
 
 use reqwest::header;
 use reqwest::{self, Method, Request};
+use slog_scope::info;
 
 use serde;
 use serde_json;

--- a/src/util/cmdline.rs
+++ b/src/util/cmdline.rs
@@ -21,6 +21,7 @@
 
 use crate::errors::*;
 use error_chain::bail;
+use slog_scope::trace;
 use std::io::Read;
 use std::{fs, io};
 

--- a/src/util/cmdline.rs
+++ b/src/util/cmdline.rs
@@ -20,6 +20,7 @@
 //!  flags.
 
 use crate::errors::*;
+use error_chain::bail;
 use std::io::Read;
 use std::{fs, io};
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -17,6 +17,7 @@
 use crate::errors::*;
 use crate::retry;
 use pnet_datalink;
+use slog_scope::{debug, trace};
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
 use std::path::Path;


### PR DESCRIPTION
They're not required in Rust 2018.

The last commit is arguably not a net win, so we may want to drop it.