### PR TITLE
providers: rework to speed up negative tests

### DIFF
--- a/src/providers/azure/mock_tests.rs
+++ b/src/providers/azure/mock_tests.rs
@@ -90,7 +90,10 @@ fn test_boot_checkin() {
     r.unwrap();
 
     mockito::reset();
-    azure::Azure::try_new().unwrap_err();
+
+    // Check error logic, but fail fast without re-trying.
+    let client = crate::retry::Client::try_new().unwrap().max_attempts(1);
+    azure::Azure::fetch_content(Some(client)).unwrap_err();
 }
 
 #[test]
@@ -117,7 +120,10 @@ fn test_hostname() {
     assert_eq!(hostname, testname);
 
     mockito::reset();
-    azure::Azure::try_new().unwrap_err();
+
+    // Check error logic, but fail fast without re-trying.
+    let client = crate::retry::Client::try_new().unwrap().max_attempts(1);
+    azure::Azure::fetch_content(Some(client)).unwrap_err();
 }
 
 #[test]
@@ -145,5 +151,8 @@ fn test_vmsize() {
     assert_eq!(vmsize, testvmsize);
 
     mockito::reset();
-    azure::Azure::try_new().unwrap_err();
+
+    // Check error logic, but fail fast without re-trying.
+    let client = crate::retry::Client::try_new().unwrap().max_attempts(1);
+    azure::Azure::fetch_content(Some(client)).unwrap_err();
 }

--- a/src/providers/packet/mock_tests.rs
+++ b/src/providers/packet/mock_tests.rs
@@ -35,7 +35,10 @@ fn test_boot_checkin() {
     r.unwrap();
 
     mockito::reset();
-    provider.boot_checkin().unwrap_err();
+
+    // Check error logic, but fail fast without re-trying.
+    let client = crate::retry::Client::try_new().unwrap().max_attempts(1);
+    packet::PacketProvider::fetch_content(Some(client)).unwrap_err();
 }
 
 #[test]
@@ -73,5 +76,8 @@ fn test_packet_attributes() {
     assert_eq!(v, attributes);
 
     mockito::reset();
-    packet::PacketProvider::try_new().unwrap_err();
+
+    // Check error logic, but fail fast without re-trying.
+    let client = crate::retry::Client::try_new().unwrap().max_attempts(1);
+    packet::PacketProvider::fetch_content(Some(client)).unwrap_err();
 }


### PR DESCRIPTION
This refactors Azure and Packet logic in order to inject a custom client.
This allows speeding up negative tests by skipping retries and
backoff timeouts.