### PR TITLE
retry: cleanup and test max-retries

### DIFF
--- a/src/providers/aliyun/mock_tests.rs
+++ b/src/providers/aliyun/mock_tests.rs
@@ -8,7 +8,7 @@ fn basic_hostname() {
     let hostname = "test-hostname";
 
     let mut provider = aliyun::AliyunProvider::try_new().unwrap();
-    provider.client = provider.client.max_attempts(1);
+    provider.client = provider.client.max_retries(0);
 
     let _m = mockito::mock("GET", ep).with_status(503).create();
     provider.hostname().unwrap_err();
@@ -38,7 +38,7 @@ fn basic_hostname() {
 #[test]
 fn basic_pubkeys() {
     let mut provider = aliyun::AliyunProvider::try_new().unwrap();
-    provider.client = provider.client.max_attempts(1);
+    provider.client = provider.client.max_retries(0);
 
     // Setup two entries with identical content, in order to test de-dup.
     let _m_keys = mockito::mock("GET", "/public-keys/")
@@ -114,7 +114,7 @@ fn basic_attributes() {
 
     let client = crate::retry::Client::try_new()
         .unwrap()
-        .max_attempts(1)
+        .max_retries(0)
         .return_on_404(true);
     let provider = aliyun::AliyunProvider { client };
 

--- a/src/providers/aws/mock_tests.rs
+++ b/src/providers/aws/mock_tests.rs
@@ -9,7 +9,7 @@ fn test_aws_basic() {
     let client = crate::retry::Client::try_new()
         .chain_err(|| "failed to create http client")
         .unwrap()
-        .max_attempts(1)
+        .max_retries(0)
         .return_on_404(true);
     let provider = aws::AwsProvider { client };
 
@@ -76,7 +76,7 @@ fn test_aws_attributes() {
     let client = crate::retry::Client::try_new()
         .chain_err(|| "failed to create http client")
         .unwrap()
-        .max_attempts(1)
+        .max_retries(0)
         .return_on_404(true);
     let provider = aws::AwsProvider { client };
 

--- a/src/providers/azure/mock_tests.rs
+++ b/src/providers/azure/mock_tests.rs
@@ -92,7 +92,7 @@ fn test_boot_checkin() {
     mockito::reset();
 
     // Check error logic, but fail fast without re-trying.
-    let client = crate::retry::Client::try_new().unwrap().max_attempts(1);
+    let client = crate::retry::Client::try_new().unwrap().max_retries(0);
     azure::Azure::fetch_content(Some(client)).unwrap_err();
 }
 
@@ -122,7 +122,7 @@ fn test_hostname() {
     mockito::reset();
 
     // Check error logic, but fail fast without re-trying.
-    let client = crate::retry::Client::try_new().unwrap().max_attempts(1);
+    let client = crate::retry::Client::try_new().unwrap().max_retries(0);
     azure::Azure::fetch_content(Some(client)).unwrap_err();
 }
 
@@ -153,6 +153,6 @@ fn test_vmsize() {
     mockito::reset();
 
     // Check error logic, but fail fast without re-trying.
-    let client = crate::retry::Client::try_new().unwrap().max_attempts(1);
+    let client = crate::retry::Client::try_new().unwrap().max_retries(0);
     azure::Azure::fetch_content(Some(client)).unwrap_err();
 }

--- a/src/providers/azure/mod.rs
+++ b/src/providers/azure/mod.rs
@@ -22,7 +22,6 @@ use std::net::IpAddr;
 use openssh_keys::PublicKey;
 use reqwest::header::{HeaderName, HeaderValue};
 use serde_derive::Deserialize;
-use slog_scope::{info, trace, warn};
 
 use self::crypto::x509;
 use crate::errors::*;
@@ -235,6 +234,8 @@ impl Azure {
 
     #[cfg(not(test))]
     fn get_fabric_address() -> IpAddr {
+        use slog_scope::{info, warn};
+
         // try to fetch from dhcp, else use fallback; this is similar to what WALinuxAgent does
         Azure::get_fabric_address_from_dhcp().unwrap_or_else(|e| {
             warn!("Failed to get fabric address from DHCP: {}", e);
@@ -249,7 +250,7 @@ impl Azure {
         // value is an 8 digit hex value. convert it to u32 and
         // then parse that into an ip. Ipv4Addr::from(u32)
         // performs conversion from big-endian
-        trace!("found fabric address in hex - {:?}", v);
+        slog_scope::trace!("found fabric address in hex - {:?}", v);
         let dec = u32::from_str_radix(&v, 16)
             .chain_err(|| format!("failed to convert '{}' from hex", v))?;
         Ok(IpAddr::V4(dec.into()))

--- a/src/providers/cloudstack/network.rs
+++ b/src/providers/cloudstack/network.rs
@@ -2,7 +2,6 @@
 
 use std::collections::HashMap;
 use std::net::IpAddr;
-use std::time::Duration;
 
 use openssh_keys::PublicKey;
 use slog_scope::warn;
@@ -24,10 +23,7 @@ pub struct CloudstackNetwork {
 impl CloudstackNetwork {
     pub fn try_new() -> Result<CloudstackNetwork> {
         let server_address = CloudstackNetwork::get_dhcp_server_address()?;
-        let client = retry::Client::try_new()?
-            .initial_backoff(Duration::from_secs(1))
-            .max_backoff(Duration::from_secs(5))
-            .max_attempts(10);
+        let client = retry::Client::try_new()?;
 
         Ok(CloudstackNetwork {
             server_address,

--- a/src/providers/gcp/mock_tests.rs
+++ b/src/providers/gcp/mock_tests.rs
@@ -8,7 +8,7 @@ fn basic_hostname() {
     let hostname = "test-hostname";
 
     let mut provider = gcp::GcpProvider::try_new().unwrap();
-    provider.client = provider.client.max_attempts(1);
+    provider.client = provider.client.max_retries(0);
 
     let _m = mockito::mock("GET", ep).with_status(503).create();
     provider.hostname().unwrap_err();
@@ -59,7 +59,7 @@ fn basic_attributes() {
 
     let client = crate::retry::Client::try_new()
         .unwrap()
-        .max_attempts(1)
+        .max_retries(0)
         .return_on_404(true);
     let provider = gcp::GcpProvider { client };
 

--- a/src/providers/packet/mock_tests.rs
+++ b/src/providers/packet/mock_tests.rs
@@ -37,7 +37,7 @@ fn test_boot_checkin() {
     mockito::reset();
 
     // Check error logic, but fail fast without re-trying.
-    let client = crate::retry::Client::try_new().unwrap().max_attempts(1);
+    let client = crate::retry::Client::try_new().unwrap().max_retries(0);
     packet::PacketProvider::fetch_content(Some(client)).unwrap_err();
 }
 
@@ -78,6 +78,6 @@ fn test_packet_attributes() {
     mockito::reset();
 
     // Check error logic, but fail fast without re-trying.
-    let client = crate::retry::Client::try_new().unwrap().max_attempts(1);
+    let client = crate::retry::Client::try_new().unwrap().max_retries(0);
     packet::PacketProvider::fetch_content(Some(client)).unwrap_err();
 }

--- a/src/retry/client.rs
+++ b/src/retry/client.rs
@@ -119,19 +119,25 @@ impl Client {
         self
     }
 
+    #[allow(dead_code)]
     pub fn initial_backoff(mut self, initial_backoff: Duration) -> Self {
         self.retry = self.retry.initial_backoff(initial_backoff);
         self
     }
 
+    #[allow(dead_code)]
     pub fn max_backoff(mut self, max_backoff: Duration) -> Self {
         self.retry = self.retry.max_backoff(max_backoff);
         self
     }
 
-    /// max_attempts will panic if the argument is greater than 500
-    pub fn max_attempts(mut self, max_attempts: u32) -> Self {
-        self.retry = self.retry.max_attempts(max_attempts);
+    /// Maximum number of retries to attempt.
+    ///
+    /// If zero, only the initial request will be performed, with no
+    /// additional retries.
+    #[allow(dead_code)]
+    pub fn max_retries(mut self, retries: u8) -> Self {
+        self.retry = self.retry.max_retries(retries);
         self
     }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -27,7 +27,7 @@ mod cmdline;
 pub use self::cmdline::get_platform;
 
 mod mount;
-pub(crate) use mount::{unmount, mount_ro};
+pub(crate) use mount::{mount_ro, unmount};
 
 fn key_lookup_line(delim: char, key: &str, line: &str) -> Option<String> {
     match line.find(delim) {
@@ -62,7 +62,7 @@ pub fn dns_lease_key_lookup(key: &str) -> Result<String> {
     retry::Retry::new()
         .initial_backoff(Duration::from_millis(50))
         .max_backoff(Duration::from_millis(500))
-        .max_attempts(60)
+        .max_retries(60)
         .retry(|_| {
             for interface in interfaces.clone() {
                 trace!("looking at interface {:?}", interface);

--- a/src/util/mount.rs
+++ b/src/util/mount.rs
@@ -11,7 +11,7 @@ use std::process::Command;
 ///
 /// This can internally retry in case of transient errors.
 pub(crate) fn unmount(target: &Path, retries: u8) -> Result<()> {
-    let driver = retry::Retry::new().max_attempts(u32::from(retries));
+    let driver = retry::Retry::new().max_retries(retries);
     driver.retry(|attempt| {
         debug!(
             "Unmounting '{}': attempt #{}",
@@ -26,7 +26,7 @@ pub(crate) fn unmount(target: &Path, retries: u8) -> Result<()> {
 ///
 /// This can internally wait for udev events settling and retry in case of transient errors.
 pub(crate) fn mount_ro(source: &Path, target: &Path, fstype: &str, retries: u8) -> Result<()> {
-    let driver = retry::Retry::new().max_attempts(u32::from(retries));
+    let driver = retry::Retry::new().max_retries(retries);
     driver.retry(|attempt| {
         debug!("Mounting '{}': attempt #{}", source.display(), attempt + 1);
         let res = mount::mount(


### PR DESCRIPTION
This cleans up the max-retries logic, and add some tests to ensure it
works correctly.
In particular, it clarifies that the initial attempt is always performed
and caps the maximum number of retries to `u8::MAX`.