### PR TITLE
providers/ibmcloud: add support for Classic instance types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ clap = "2.33"
 error-chain = { version = "0.12", default-features = false }
 hostname = "0.2"
 ipnetwork = "^0.15.0"
+maplit = "^1.0.2"
 mime = "0.3"
 nix = "^0.15.0"
 openssh-keys = "^0.4.1"

--- a/src/providers/ibmcloud/classic.rs
+++ b/src/providers/ibmcloud/classic.rs
@@ -1,0 +1,220 @@
+//! Metadata fetcher for IBMCloud (Classic) instances.
+//!
+//! This provider supports the "Classic" infrastructure type on IBMCloud.
+//! It provides a config-drive as the only metadata source, whose layout
+//! follows the `cloud-init ConfigDrive v2` [datasource][configdrive], with
+//! the following details:
+//!  - disk filesystem label is `config-2` (lowercase)
+//!  - filesystem is `vfat`
+//!  - drive contains a single directory at `/openstack/latest/`
+//!  - content is exposed as JSON files called `meta_data.json`, `network_data.json`, and `vendor_data.json`.
+//!
+//! configdrive: https://cloudinit.readthedocs.io/en/latest/topics/datasources/configdrive.html
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::{Path, PathBuf};
+
+use error_chain::bail;
+use openssh_keys::PublicKey;
+use serde::Deserialize;
+use slog_scope::warn;
+use tempdir::TempDir;
+
+use crate::errors::*;
+use crate::network;
+use crate::providers::MetadataProvider;
+
+// Filesystem label for the Config Drive.
+static CONFIG_DRIVE_FS_LABEL: &str = "config-2";
+
+// Filesystem type for the Config Drive.
+static CONFIG_DRIVE_FS_TYPE: &str = "vfat";
+
+/// IBMCloud provider (Classic).
+#[derive(Debug)]
+pub struct ClassicProvider {
+    /// Path to the top directory of the mounted config-drive.
+    drive_path: PathBuf,
+    /// Temporary directory for own mountpoint (if any).
+    temp_dir: Option<TempDir>,
+}
+
+/// Partial object for `meta_data.json`
+#[derive(Debug, Deserialize)]
+pub struct MetaDataJSON {
+    /// Fully-Qualified Domain Name (FQDN).
+    #[serde(rename = "hostname")]
+    pub fqdn: String,
+    /// Local hostname.
+    #[serde(rename = "name")]
+    pub local_hostname: String,
+    /// Instance ID (UUID).
+    #[serde(rename = "uuid")]
+    pub instance_id: String,
+    /// SSH public keys.
+    pub public_keys: HashMap<String, String>,
+}
+
+impl ClassicProvider {
+    /// Try to build a new provider client.
+    ///
+    /// This internally tries to mount (and own) the config-drive.
+    pub fn try_new() -> Result<Self> {
+        let target =
+            TempDir::new("afterburn").chain_err(|| "failed to create temporary directory")?;
+        crate::util::mount_ro(
+            &Path::new("/dev/disk/by-label/").join(CONFIG_DRIVE_FS_LABEL),
+            target.path(),
+            CONFIG_DRIVE_FS_TYPE,
+            3, // maximum retries
+        )?;
+
+        let provider = Self {
+            drive_path: target.path().to_owned(),
+            temp_dir: Some(target),
+        };
+        Ok(provider)
+    }
+
+    /// Return the path to the metadata directory.
+    fn metadata_dir(&self) -> PathBuf {
+        let drive = self.drive_path.clone();
+        drive.join("openstack").join("latest")
+    }
+
+    /// Read and parse metadata file.
+    fn read_metadata(&self) -> Result<MetaDataJSON> {
+        let filename = self.metadata_dir().join("meta_data.json");
+        let file =
+            File::open(&filename).chain_err(|| format!("failed to open file '{:?}'", filename))?;
+        let bufrd = BufReader::new(file);
+        Self::parse_metadata(bufrd)
+    }
+
+    /// Parse metadata attributes.
+    ///
+    /// Metadata file contains a JSON object, corresponding to `MetaDataJSON`.
+    fn parse_metadata<T: Read>(input: BufReader<T>) -> Result<MetaDataJSON> {
+        serde_json::from_reader(input).chain_err(|| "failed parse JSON metadata")
+    }
+
+    /// Extract supported metadata values and convert to Afterburn attributes.
+    ///
+    /// The `AFTERBURN_` prefix is added later on, so it is not part of the
+    /// key-labels here.
+    fn known_attributes(metadata: MetaDataJSON) -> Result<HashMap<String, String>> {
+        if metadata.instance_id.is_empty() {
+            bail!("empty instance ID");
+        }
+
+        if metadata.local_hostname.is_empty() {
+            bail!("empty local hostname");
+        }
+
+        let attrs = maplit::hashmap! {
+            "IBMCLOUD_INSTANCE_ID".to_string() => metadata.instance_id,
+            "IBMCLOUD_LOCAL_HOSTNAME".to_string() => metadata.local_hostname,
+
+        };
+        Ok(attrs)
+    }
+}
+
+impl MetadataProvider for ClassicProvider {
+    fn attributes(&self) -> Result<HashMap<String, String>> {
+        let metadata = self.read_metadata()?;
+        Self::known_attributes(metadata)
+    }
+
+    fn hostname(&self) -> Result<Option<String>> {
+        let metadata = self.read_metadata()?;
+        let hostname = if metadata.local_hostname.is_empty() {
+            None
+        } else {
+            Some(metadata.local_hostname)
+        };
+        Ok(hostname)
+    }
+
+    fn ssh_keys(&self) -> Result<Vec<PublicKey>> {
+        warn!("cloud SSH keys requested, but not supported on this platform");
+        Ok(vec![])
+    }
+
+    fn networks(&self) -> Result<Vec<network::Interface>> {
+        warn!("network metadata requested, but not supported on this platform");
+        Ok(vec![])
+    }
+
+    fn network_devices(&self) -> Result<Vec<network::Device>> {
+        warn!("network devices metadata requested, but not supported on this platform");
+        Ok(vec![])
+    }
+
+    fn boot_checkin(&self) -> Result<()> {
+        warn!("boot check-in requested, but not supported on this platform");
+        Ok(())
+    }
+}
+
+impl Drop for ClassicProvider {
+    fn drop(&mut self) {
+        if let Some(ref mountpoint) = self.temp_dir {
+            if let Err(e) = crate::util::unmount(
+                mountpoint.path(),
+                3, // maximum retries
+            ) {
+                slog_scope::error!("failed to unmount ibmcloud (Classic) config-drive: {}", e);
+            };
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_basic_attributes() {
+        let metadata = r#"
+{
+  "hostname": "test_instance-classic.foo.cloud",
+  "name": "test_instance-classic",
+  "uuid": "3c9085db-3eba-4ef2-9d97-d3ffcff6fffe",
+  "public_keys": {
+    "1602320": "ssh-rsa AAAA foo@example.com"
+  }
+}
+"#;
+
+        let bufrd = BufReader::new(Cursor::new(metadata));
+        let parsed = ClassicProvider::parse_metadata(bufrd).unwrap();
+        assert_eq!(parsed.instance_id, "3c9085db-3eba-4ef2-9d97-d3ffcff6fffe",);
+        assert_eq!(parsed.local_hostname, "test_instance-classic",);
+
+        let attrs = ClassicProvider::known_attributes(parsed).unwrap();
+        assert_eq!(attrs.len(), 2);
+        assert_eq!(
+            attrs.get("IBMCLOUD_INSTANCE_ID"),
+            Some(&"3c9085db-3eba-4ef2-9d97-d3ffcff6fffe".to_string())
+        );
+        assert_eq!(
+            attrs.get("IBMCLOUD_LOCAL_HOSTNAME"),
+            Some(&"test_instance-classic".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_metadata_json() {
+        let fixture = File::open("./tests/fixtures/ibmcloud/classic/meta_data.json").unwrap();
+        let bufrd = BufReader::new(fixture);
+        let parsed = ClassicProvider::parse_metadata(bufrd).unwrap();
+
+        assert!(!parsed.instance_id.is_empty());
+        assert!(!parsed.local_hostname.is_empty());
+        assert!(!parsed.public_keys.is_empty());
+    }
+}

--- a/src/providers/ibmcloud/gen2.rs
+++ b/src/providers/ibmcloud/gen2.rs
@@ -148,9 +148,9 @@ impl MetadataProvider for G2Provider {
 
 impl Drop for G2Provider {
     fn drop(&mut self) {
-        if self.temp_dir.is_some() {
+        if let Some(ref mountpoint) = self.temp_dir {
             if let Err(e) = crate::util::unmount(
-                &self.metadata_dir(),
+                mountpoint.path(),
                 3, // maximum retries
             ) {
                 slog_scope::error!("failed to unmount IBM Cloud (Gen2) config-drive: {}", e);

--- a/src/providers/ibmcloud/mod.rs
+++ b/src/providers/ibmcloud/mod.rs
@@ -3,22 +3,27 @@
 //! IBMCloud supports multiple kind of compute nodes, with different
 //! features and peculiarities.
 
-// TODO(lucab): this allows adding 'classic' and 'vpc-gen1' instances too
-//  via auto-detection, if there is a need for that in the future.
+// TODO(lucab): this allows adding 'vpc-gen1' instances too via auto-detection,
+//  if there is a need for that in the future.
 
 use crate::errors::Result;
 use crate::providers;
 
+mod classic;
 mod gen2;
 
 /// Build a new client for IBMCloud.
 ///
 /// This internally tries to autodetect the infrastructure type
 /// and mount the relevant config-drive.
+/// Auto-detection order: Gen2, classic (possibly later: Gen1).
 pub fn try_autodetect() -> Result<Box<dyn providers::MetadataProvider>> {
-    // Auto-detection order: Gen2 (possibly later: classic, Gen1).
     slog_scope::trace!("trying to autodetect ibmcloud infrastructure type");
 
+    // TODO(lucab): make auto-detection parallel (and cancellable), otherwise
+    //  Classic may suffer some noticeable delay.
+
+    // First try: Gen2.
     match gen2::G2Provider::try_new() {
         Ok(g2) => {
             slog_scope::info!("found metadata for VPC-Gen2 instance");
@@ -26,6 +31,17 @@ pub fn try_autodetect() -> Result<Box<dyn providers::MetadataProvider>> {
         }
         Err(e) => {
             slog_scope::debug!("ibmcloud VPC-Gen2 autodetection failed: {}", e);
+        }
+    };
+
+    // Second try: Classic.
+    match classic::ClassicProvider::try_new() {
+        Ok(classic) => {
+            slog_scope::info!("found metadata for Classic instance");
+            return Ok(Box::new(classic));
+        }
+        Err(e) => {
+            slog_scope::debug!("ibmcloud Classic autodetection failed: {}", e);
         }
     };
 

--- a/tests/fixtures/ibmcloud/classic/meta_data.json
+++ b/tests/fixtures/ibmcloud/classic/meta_data.json
@@ -1,0 +1,11 @@
+{
+  "hostname": "rh-lbruno-classic01.example.cloud",
+  "name": "rh-lbruno-classic01",
+  "uuid": "3c9085db-3eba-4ef2-9d97-d3ffcff6fffe",
+  "random_seed": "YWJjCg==",
+  "crypt_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ.....",
+  "configuration_token": "eyJhbGciO...CI6IkpXVCJ9.eyJyZX...k5OX0.MWJmYmYxZGQzNW...gzYzk4OWU0Ng",
+  "public_keys": {
+    "1602320": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCsWcDA7X5ZhXZ0Wil5aqJEvyuDkKuX1yBh0MhS4iFkODpS+yqhXUEdc/sDrk3zV+hHBh7nB9tlPzy9lp5A0cOXFpkzW79vdSZiZ94h2vg9aTgzi/D8NeOlfkCPgZjF6Mqa2g3kK0GhUzxrOY3d+GEK49ec9KRTLmk0qSx2XXwZx7ZdXNGetFR0XtuGKrK1BuK7KnkySdKgSFx4wdSuXznoi/WyhId+WpM2lRqEsol5yoRiHn4fzSR03NQG79dIIaSIvD0Rd9tSEWwJz/ZMGvGtkMYL3bqbG+4OQfDmhhjHER4S1chA+SlCvuqYcbxWB4VVWqMQhNBIOfhpFMoVCTJg9pw1bM7s/IHfmDDa0357nP8J3Ll6+MWoh6/ExrM8TQfZ8zLVgDUVktFIgE1Y88mLhM0obNWvPy1cKh+Ut9iIqsmnAmvChsU+/pJnmilCTZvOLJnxdBBpzVav2OnqtuWLaIYeZz1Bvc49ptujZvBiArsQBmnkMJDF2zmJxWjc8gDX3rPkMh+BWwXpSiI2ufrQNnzmlfdky6mxEy35wZvvC+YldM23XPZxuvqIR6GeQ4LtE0tLpY7TP/TayTcqxKcmrWZjZxKiEVn8eRYpGMUoYEBfHawZwcFJtzUSg8BySwpeLEzmlVn29qi7BRmFa8VDIvQChIeR7UmRCJvR5Ynltw== luca.bruno@coreos.com"
+  }
+}


### PR DESCRIPTION
This adds initial metadata support for IBM Cloud Classic instance
types.
Right now it only supports extracting attributes and exposing the
hostname.