### PR TITLE
network: clean up virtual netdev logic

### DIFF
--- a/src/providers/aliyun/mod.rs
+++ b/src/providers/aliyun/mod.rs
@@ -177,7 +177,8 @@ impl MetadataProvider for AliyunProvider {
         Ok(vec![])
     }
 
-    fn network_devices(&self) -> Result<Vec<network::Device>> {
+    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
+        warn!("virtual network devices metadata requested, but not supported on this platform");
         Ok(vec![])
     }
 

--- a/src/providers/aws/mod.rs
+++ b/src/providers/aws/mod.rs
@@ -189,7 +189,8 @@ impl MetadataProvider for AwsProvider {
         Ok(vec![])
     }
 
-    fn network_devices(&self) -> Result<Vec<network::Device>> {
+    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
+        warn!("virtual network devices metadata requested, but not supported on this platform");
         Ok(vec![])
     }
 

--- a/src/providers/azure/mod.rs
+++ b/src/providers/azure/mod.rs
@@ -22,6 +22,8 @@ use std::net::IpAddr;
 use openssh_keys::PublicKey;
 use reqwest::header::{HeaderName, HeaderValue};
 use serde_derive::Deserialize;
+use slog_scope::warn;
+
 
 use self::crypto::x509;
 use crate::errors::*;
@@ -234,12 +236,10 @@ impl Azure {
 
     #[cfg(not(test))]
     fn get_fabric_address() -> IpAddr {
-        use slog_scope::{info, warn};
-
         // try to fetch from dhcp, else use fallback; this is similar to what WALinuxAgent does
         Azure::get_fabric_address_from_dhcp().unwrap_or_else(|e| {
             warn!("Failed to get fabric address from DHCP: {}", e);
-            info!("Using fallback address");
+            slog_scope::info!("Using fallback address");
             IpAddr::from(FALLBACK_WIRESERVER_ADDR)
         })
     }
@@ -494,7 +494,8 @@ impl MetadataProvider for Azure {
         Ok(vec![])
     }
 
-    fn network_devices(&self) -> Result<Vec<network::Device>> {
+    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
+        warn!("virtual network devices metadata requested, but not supported on this platform");
         Ok(vec![])
     }
 

--- a/src/providers/cloudstack/configdrive.rs
+++ b/src/providers/cloudstack/configdrive.rs
@@ -134,7 +134,8 @@ impl MetadataProvider for ConfigDrive {
         Ok(vec![])
     }
 
-    fn network_devices(&self) -> Result<Vec<network::Device>> {
+    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
+        warn!("virtual network devices metadata requested, but not supported on this platform");
         Ok(vec![])
     }
 

--- a/src/providers/cloudstack/network.rs
+++ b/src/providers/cloudstack/network.rs
@@ -99,7 +99,8 @@ impl MetadataProvider for CloudstackNetwork {
         Ok(vec![])
     }
 
-    fn network_devices(&self) -> Result<Vec<network::Device>> {
+    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
+        warn!("virtual network devices metadata requested, but not supported on this platform");
         Ok(vec![])
     }
 

--- a/src/providers/digitalocean/mod.rs
+++ b/src/providers/digitalocean/mod.rs
@@ -295,7 +295,8 @@ impl MetadataProvider for DigitalOceanProvider {
         self.parse_network()
     }
 
-    fn network_devices(&self) -> Result<Vec<network::Device>> {
+    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
+        warn!("virtual network devices metadata requested, but not supported on this platform");
         Ok(vec![])
     }
 

--- a/src/providers/gcp/mod.rs
+++ b/src/providers/gcp/mod.rs
@@ -194,7 +194,8 @@ impl MetadataProvider for GcpProvider {
         Ok(vec![])
     }
 
-    fn network_devices(&self) -> Result<Vec<network::Device>> {
+    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
+        warn!("virtual network devices metadata requested, but not supported on this platform");
         Ok(vec![])
     }
 

--- a/src/providers/ibmcloud/classic.rs
+++ b/src/providers/ibmcloud/classic.rs
@@ -148,8 +148,8 @@ impl MetadataProvider for ClassicProvider {
         Ok(vec![])
     }
 
-    fn network_devices(&self) -> Result<Vec<network::Device>> {
-        warn!("network devices metadata requested, but not supported on this platform");
+    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
+        warn!("virtual network devices metadata requested, but not supported on this platform");
         Ok(vec![])
     }
 

--- a/src/providers/ibmcloud/gen2.rs
+++ b/src/providers/ibmcloud/gen2.rs
@@ -135,8 +135,8 @@ impl MetadataProvider for G2Provider {
         Ok(vec![])
     }
 
-    fn network_devices(&self) -> Result<Vec<network::Device>> {
-        warn!("network devices metadata requested, but not supported on this platform");
+    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
+        warn!("virtual network devices metadata requested, but not supported on this platform");
         Ok(vec![])
     }
 

--- a/src/providers/openstack/network.rs
+++ b/src/providers/openstack/network.rs
@@ -102,7 +102,8 @@ impl MetadataProvider for OpenstackProvider {
         Ok(vec![])
     }
 
-    fn network_devices(&self) -> Result<Vec<network::Device>> {
+    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
+        warn!("virtual network devices metadata requested, but not supported on this platform");
         Ok(vec![])
     }
 

--- a/src/providers/vagrant_virtualbox/mod.rs
+++ b/src/providers/vagrant_virtualbox/mod.rs
@@ -96,7 +96,8 @@ impl MetadataProvider for VagrantVirtualboxProvider {
         Ok(vec![])
     }
 
-    fn network_devices(&self) -> Result<Vec<network::Device>> {
+    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
+        warn!("virtual network devices metadata requested, but not supported on this platform");
         Ok(vec![])
     }
 


### PR DESCRIPTION
This performs a cleanup of the network logic related to virtual interfaces,
drawing a more clean line between metadata and `systemd.netdev` details.
It also makes the "virtual" detail more explicit to avoid confusion with
physically attached devices.