### PR TITLE
Release 4.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "afterburn"
-version = "4.3.0-alpha.0"
+version = "4.3.0"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "afterburn"
-version = "4.3.0"
+version = "4.3.1-alpha.0"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.3.0-alpha.0"
+version = "4.3.0"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.3.0"
+version = "4.3.1-alpha.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Changes:
 * sshkeys: fix missing directory on empty set
 * providers: add metadata support for `ibmcloud` (IBM Cloud VPC Gen2)
 * providers/ibmcloud: add support for Classic instance types
 * ibmcloud/classic: source network configuration from metadata
 * docs: minor fixes
 * network: clean up interface logic
 * network: clean up virtual netdev logic
 * retry: cleanup and test max-retries
 * github: add release-checklist template
 * cloudstack-configdrive: cleanup mounting and umounting logic
 * providers: rework to speed up negative tests
 * main: drop extern crate declarations

Ref: https://github.com/coreos/afterburn/issues/320