### PR TITLE
cli: introduce sub-commands

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,198 @@
+//! Command-line arguments parsing.
+
+use crate::errors::*;
+use clap::{crate_version, App, Arg, ArgMatches, SubCommand};
+use slog_scope::trace;
+
+mod multi;
+
+/// Path to kernel command-line (requires procfs mount).
+const CMDLINE_PATH: &str = "/proc/cmdline";
+
+/// CLI sub-commands configuration.
+#[derive(Debug)]
+pub(crate) enum CliConfig {
+    Multi(multi::CliMulti),
+}
+
+impl CliConfig {
+    /// Parse CLI sub-commands into configuration.
+    pub fn parse_subcommands(app_matches: ArgMatches) -> Result<Self> {
+        let cfg = match app_matches.subcommand() {
+            ("multi", Some(matches)) => multi::CliMulti::parse(matches)?,
+            (x, _) => unreachable!("unrecognized subcommand '{}'", x),
+        };
+
+        Ok(cfg)
+    }
+
+    /// Run the relevant CLI sub-command.
+    pub fn run(self) -> Result<()> {
+        match self {
+            CliConfig::Multi(cmd) => cmd.run(),
+        }
+    }
+}
+
+/// Parse command-line arguments into CLI configuration.
+pub(crate) fn parse_args(argv: impl IntoIterator<Item = String>) -> Result<CliConfig> {
+    let args = translate_legacy_args(argv);
+    let matches = cli_setup().get_matches_from_safe(args)?;
+
+    let cfg = CliConfig::parse_subcommands(matches)?;
+    trace!("cli configuration - {:?}", cfg);
+    Ok(cfg)
+}
+
+/// CLI setup, covering all sub-commands and arguments.
+fn cli_setup<'a, 'b>() -> App<'a, 'b> {
+    // NOTE(lucab): due to legacy translation there can't be global arguments
+    //  here, i.e. a sub-command is always expected first.
+    App::new("Afterburn").version(crate_version!()).subcommand(
+        SubCommand::with_name("multi")
+            .about("Perform multiple tasks in a single call")
+            .arg(
+                Arg::with_name("legacy-cli")
+                    .long("legacy-cli")
+                    .help("Whether this command was translated from legacy CLI args")
+                    .hidden(true),
+            )
+            .arg(
+                Arg::with_name("provider")
+                    .long("provider")
+                    .help("The name of the cloud provider")
+                    .global(true)
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::with_name("cmdline")
+                    .long("cmdline")
+                    .global(true)
+                    .help("Read the cloud provider from the kernel cmdline"),
+            )
+            .arg(
+                Arg::with_name("attributes")
+                    .long("attributes")
+                    .help("The file into which the metadata attributes are written")
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::with_name("check-in")
+                    .long("check-in")
+                    .help("Check-in this instance boot with the cloud provider"),
+            )
+            .arg(
+                Arg::with_name("hostname")
+                    .long("hostname")
+                    .help("The file into which the hostname should be written")
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::with_name("network-units")
+                    .long("network-units")
+                    .help("The directory into which network units are written")
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::with_name("ssh-keys")
+                    .long("ssh-keys")
+                    .help("Update SSH keys for the given user")
+                    .takes_value(true),
+            ),
+    )
+}
+
+/// Translate command-line arguments from legacy mode.
+///
+/// In legacy mode there are no sub-commands, and single-dash (Golang-style)
+/// arguments are allowed too.
+fn translate_legacy_args(cli: impl IntoIterator<Item = String>) -> impl Iterator<Item = String> {
+    // Process the first two arguments and check whether there is a sub-command (normal mode)
+    // or not (legacy mode).
+    let mut argv = cli.into_iter();
+    let argv_0 = argv.next().unwrap_or_else(|| "afterburn".to_string());
+    let argv_1 = argv.next();
+    let legacy_mode = match argv_1 {
+        Some(ref arg) => arg.starts_with('-'),
+        None => true,
+    };
+
+    // Inject back the first two arguments, plus the `multi` sub-command with a legacy marker.
+    let mut new_argv = vec![argv_0];
+    if let Some(arg) = argv_1 {
+        new_argv.push(arg);
+    }
+    if legacy_mode {
+        new_argv.insert(1, "multi".to_string());
+        new_argv.insert(2, "--legacy-cli".to_string());
+    }
+    let argv = new_argv.into_iter().chain(argv);
+
+    // Do some pre-processing on the command line arguments so that legacy
+    // Go-style arguments are supported for backwards compatibility.
+    argv.map(move |arg| {
+        if legacy_mode && arg.starts_with('-') && !arg.starts_with("--") && arg.len() > 2 {
+            format!("-{}", arg)
+        } else {
+            arg
+        }
+    })
+}
+
+impl CliConfig {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_translate_legacy_args() {
+        let legacy: Vec<_> = ["afterburn", "-ssh-keys"]
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+
+        let translated: Vec<_> = translate_legacy_args(legacy).collect();
+        assert_eq!(translated[0], "afterburn".to_string());
+        assert_eq!(translated[1], "multi".to_string());
+        assert_eq!(translated[2], "--legacy-cli".to_string());
+        assert_eq!(translated[3], "--ssh-keys".to_string());
+        assert_eq!(translated.len(), 4);
+    }
+
+    #[test]
+    fn test_legacy_no_action() {
+        let legacy: Vec<_> = ["afterburn", "--provider", "azure"]
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+
+        parse_args(legacy).unwrap();
+    }
+
+    #[test]
+    fn test_no_args() {
+        let args = vec!["afterburn".to_string()];
+        parse_args(args).unwrap_err();
+    }
+
+    #[test]
+    fn test_basic_cli_args() {
+        let args: Vec<_> = ["afterburn", "--provider", "azure", "--check-in"]
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+
+        parse_args(args).unwrap();
+    }
+
+    #[test]
+    fn test_multi_cmd() {
+        let args: Vec<_> = ["afterburn", "multi", "--provider", "azure", "--check-in"]
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+
+        parse_args(args).unwrap();
+    }
+}

--- a/src/cli/multi.rs
+++ b/src/cli/multi.rs
@@ -1,0 +1,92 @@
+//! `multi` CLI sub-command.
+
+use super::CMDLINE_PATH;
+use crate::errors::*;
+use crate::metadata;
+use error_chain::bail;
+
+#[derive(Debug)]
+pub struct CliMulti {
+    attributes_file: Option<String>,
+    check_in: bool,
+    hostname_file: Option<String>,
+    network_units_dir: Option<String>,
+    provider: String,
+    ssh_keys_user: Option<String>,
+}
+
+impl CliMulti {
+    /// Parse flags for the `multi` sub-command.
+    pub(crate) fn parse(matches: &clap::ArgMatches) -> Result<super::CliConfig> {
+        let provider = Self::parse_provider(matches)?;
+
+        let multi = Self {
+            attributes_file: matches.value_of("attributes").map(String::from),
+            check_in: matches.is_present("check-in"),
+            hostname_file: matches.value_of("hostname").map(String::from),
+            network_units_dir: matches.value_of("network-units").map(String::from),
+            provider,
+            ssh_keys_user: matches.value_of("ssh-keys").map(String::from),
+        };
+
+        if multi.attributes_file.is_none()
+            && multi.network_units_dir.is_none()
+            && !multi.check_in
+            && multi.ssh_keys_user.is_none()
+            && multi.hostname_file.is_none()
+            && multi.network_units_dir.is_none()
+        {
+            slog_scope::warn!("multi: no action specified");
+        }
+
+        Ok(super::CliConfig::Multi(multi))
+    }
+
+    /// Parse provider ID from flag or kargs.
+    fn parse_provider(matches: &clap::ArgMatches) -> Result<String> {
+        let provider = match (matches.value_of("provider"), matches.is_present("cmdline")) {
+            (Some(provider), false) => String::from(provider),
+            (None, true) => crate::util::get_platform(CMDLINE_PATH)?,
+            (None, false) => bail!("must set either --provider or --cmdline"),
+            (Some(_), true) => bail!("cannot process both --provider and --cmdline"),
+        };
+
+        Ok(provider)
+    }
+
+    /// Run the `multi` sub-command.
+    pub(crate) fn run(self) -> Result<()> {
+        // fetch the metadata from the configured provider
+        let metadata = metadata::fetch_metadata(&self.provider)
+            .chain_err(|| "fetching metadata from provider")?;
+
+        // write attributes if configured to do so
+        self.attributes_file
+            .map_or(Ok(()), |x| metadata.write_attributes(x))
+            .chain_err(|| "writing metadata attributes")?;
+
+        // write ssh keys if configured to do so
+        self.ssh_keys_user
+            .map_or(Ok(()), |x| metadata.write_ssh_keys(x))
+            .chain_err(|| "writing ssh keys")?;
+
+        // write hostname if configured to do so
+        self.hostname_file
+            .map_or(Ok(()), |x| metadata.write_hostname(x))
+            .chain_err(|| "writing hostname")?;
+
+        // write network units if configured to do so
+        self.network_units_dir
+            .map_or(Ok(()), |x| metadata.write_network_units(x))
+            .chain_err(|| "writing network units")?;
+
+        // perform boot check-in.
+        if self.check_in {
+            metadata
+                .boot_checkin()
+                .chain_err(|| "checking-in instance boot to cloud provider")?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,6 +23,7 @@ error_chain! {
     }
     foreign_links {
         Base64Decode(::base64::DecodeError);
+        Clap(clap::Error);
         HeaderValue(reqwest::header::InvalidHeaderValue);
         Io(::std::io::Error);
         IpNetwork(ipnetwork::IpNetworkError);


### PR DESCRIPTION
This refactors command-line arguments parsing, introducing sub-commands.
This will in turn make adding new logic and service units less invasive.

Current command-less mode is translated into a new `multi` command,
which can perform multiple actions at once depending on the flags
specified.