### PR TITLE
cargo: update cargo-release metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,11 @@ version = "4.3.1-alpha.0"
 
 [package.metadata.release]
 sign-commit = true
-upload-doc = false
 disable-push = true
 disable-publish = true
 pre-release-commit-message = "cargo: Afterburn release {{version}}"
-pro-release-commit-message = "cargo: development version bump"
+post-release-commit-message = "cargo: development version bump"
 tag-message = "Afterburn v{{version}}"
-tag-prefix = "v"
 
 [[bin]]
 name = "afterburn"


### PR DESCRIPTION
This updates the metadata for latest cargo-release version.

Ref: https://github.com/sunng87/cargo-release/releases/tag/v0.13.0