### PR TITLE
[WIP] providers: add experimental initrd network bootstrap

### DIFF
--- a/dracut/30afterburn/afterburn-net-bootstrap.service
+++ b/dracut/30afterburn/afterburn-net-bootstrap.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Afterburn network bootstrapping
+# IBM Cloud (Classic) has no DHCP.
+ConditionKernelCommandLine=|ignition.platform.id=ibmcloud-classic
+
+Before=ignition-fetch.service
+
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
+[Service]
+ExecStart=/usr/bin/afterburn exp rd-net-bootstrap --cmdline
+Type=oneshot

--- a/dracut/30afterburn/module-setup.sh
+++ b/dracut/30afterburn/module-setup.sh
@@ -16,9 +16,14 @@ install() {
     inst_simple "$moddir/afterburn-hostname.service" \
         "$systemdutildir/system/afterburn-hostname.service"
 
+    inst_simple "$moddir/afterburn-net-bootstrap.service" \
+        "$systemdutildir/system/afterburn-net-bootstrap.service"
+
     # We want the afterburn-hostname to be firstboot only, so Ignition-provided
     # hostname changes do not get overwritten on subsequent boots
-
     mkdir -p "$initdir/$systemdsystemunitdir/ignition-complete.target.requires"
     ln -s "../afterburn-hostname.service" "$initdir/$systemdsystemunitdir/ignition-complete.target.requires/afterburn-hostname.service"
+
+    mkdir -p "$initdir/$systemdsystemunitdir/ignition-fetch.service.requires"
+    ln -s "../afterburn-net-boostrap.service" "$initdir/$systemdsystemunitdir/ignition-fetch.service.requires/afterburn-net-bootstrap.service"
 }

--- a/src/cli/exp.rs
+++ b/src/cli/exp.rs
@@ -1,0 +1,58 @@
+//! `exp` CLI sub-command.
+
+use crate::errors::*;
+use crate::metadata;
+use clap::ArgMatches;
+use error_chain::bail;
+
+#[derive(Debug)]
+pub enum CliExp {
+    NetBootstrap(CliNetBootstrap),
+}
+
+impl CliExp {
+    /// Parse sub-command into configuration.
+    pub(crate) fn parse(app_matches: &ArgMatches) -> Result<super::CliConfig> {
+        if app_matches.subcommand_name().is_none() {
+            bail!("missing exp subcommand");
+        }
+
+        let cfg = match app_matches.subcommand() {
+            ("rd-net-bootstrap", Some(matches)) => CliNetBootstrap::parse(matches)?,
+            (x, _) => unreachable!("unrecognized exp subcommand '{}'", x),
+        };
+
+        Ok(super::CliConfig::Exp(cfg))
+    }
+
+    // Run sub-command.
+    pub(crate) fn run(&self) -> Result<()> {
+        match self {
+            CliExp::NetBootstrap(cmd) => cmd.run()?,
+        };
+        Ok(())
+    }
+}
+
+/// Sub-command for network bootstrap.
+#[derive(Debug)]
+pub struct CliNetBootstrap {
+    platform: String,
+}
+
+impl CliNetBootstrap {
+    /// Parse sub-command into configuration.
+    pub(crate) fn parse(matches: &ArgMatches) -> Result<CliExp> {
+        let platform = super::parse_provider(matches)?;
+
+        let cfg = Self { platform };
+        Ok(CliExp::NetBootstrap(cfg))
+    }
+
+    /// Run the sub-command.
+    pub(crate) fn run(&self) -> Result<()> {
+        let provider = metadata::fetch_metadata(&self.platform)?;
+        provider.rd_net_bootstrap()?;
+        Ok(())
+    }
+}

--- a/src/cli/multi.rs
+++ b/src/cli/multi.rs
@@ -1,9 +1,7 @@
 //! `multi` CLI sub-command.
 
-use super::CMDLINE_PATH;
 use crate::errors::*;
 use crate::metadata;
-use error_chain::bail;
 
 #[derive(Debug)]
 pub struct CliMulti {
@@ -18,7 +16,7 @@ pub struct CliMulti {
 impl CliMulti {
     /// Parse flags for the `multi` sub-command.
     pub(crate) fn parse(matches: &clap::ArgMatches) -> Result<super::CliConfig> {
-        let provider = Self::parse_provider(matches)?;
+        let provider = super::parse_provider(matches)?;
 
         let multi = Self {
             attributes_file: matches.value_of("attributes").map(String::from),
@@ -40,18 +38,6 @@ impl CliMulti {
         }
 
         Ok(super::CliConfig::Multi(multi))
-    }
-
-    /// Parse provider ID from flag or kargs.
-    fn parse_provider(matches: &clap::ArgMatches) -> Result<String> {
-        let provider = match (matches.value_of("provider"), matches.is_present("cmdline")) {
-            (Some(provider), false) => String::from(provider),
-            (None, true) => crate::util::get_platform(CMDLINE_PATH)?,
-            (None, false) => bail!("must set either --provider or --cmdline"),
-            (Some(_), true) => bail!("cannot process both --provider and --cmdline"),
-        };
-
-        Ok(provider)
     }
 
     /// Run the `multi` sub-command.

--- a/src/network/ip_cli.rs
+++ b/src/network/ip_cli.rs
@@ -1,0 +1,61 @@
+//! Helpers for shelling out to the `ip` command.
+
+use crate::errors::*;
+use error_chain::bail;
+use ipnetwork::IpNetwork;
+use slog_scope::trace;
+use std::process::Command;
+
+/// Create a new interface.
+#[allow(dead_code)]
+pub(crate) fn ip_link_add(dev_name: &str, mac_addr: &str) -> Result<()> {
+    let link_type = "ether";
+    let mut cmd = Command::new("ip");
+    cmd.args(&["link", "add"])
+        .arg(&dev_name)
+        .arg("address")
+        .arg(&mac_addr)
+        .args(&["type", link_type]);
+    try_exec(cmd).chain_err(|| "'ip link add' failed")
+}
+
+/// Bring up a named interface.
+pub(crate) fn ip_link_set_up(dev_name: &str) -> Result<()> {
+    let mut cmd = Command::new("ip");
+    cmd.args(&["link", "set"])
+        .args(&["dev", dev_name])
+        .arg("up");
+    try_exec(cmd).chain_err(|| "'ip link set up' failed")
+}
+
+/// Add an address to an interface.
+pub(crate) fn ip_address_add(dev_name: &str, ip_addr: &IpNetwork) -> Result<()> {
+    let mut cmd = Command::new("ip");
+    cmd.args(&["address", "add"])
+        .arg(ip_addr.to_string())
+        .args(&["dev", dev_name]);
+    try_exec(cmd).chain_err(|| "'ip address add' failed")
+}
+
+/// Add a route.
+pub(crate) fn ip_route_add(route: &super::NetworkRoute) -> Result<()> {
+    let mut cmd = Command::new("ip");
+    cmd.args(&["route", "add"])
+        .arg(&route.destination.to_string())
+        .args(&["via", &route.gateway.to_string()]);
+    try_exec(cmd).chain_err(|| "'ip route add' failed")
+}
+
+/// Try to execute, and log stderr on failure.
+fn try_exec(cmd: Command) -> Result<()> {
+    let mut cmd = cmd;
+    trace!("{:?}", &cmd);
+
+    let output = cmd.output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("{}", stderr);
+    };
+
+    Ok(())
+}

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -25,6 +25,7 @@ use std::string::String;
 use std::string::ToString;
 
 mod ip_cli;
+pub mod utils;
 
 pub const BONDING_MODE_BALANCE_RR: u32 = 0;
 pub const BONDING_MODE_ACTIVE_BACKUP: u32 = 1;

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -24,6 +24,8 @@ use std::net::IpAddr;
 use std::string::String;
 use std::string::ToString;
 
+mod ip_cli;
+
 pub const BONDING_MODE_BALANCE_RR: u32 = 0;
 pub const BONDING_MODE_ACTIVE_BACKUP: u32 = 1;
 pub const BONDING_MODE_BALANCE_XOR: u32 = 2;
@@ -176,6 +178,29 @@ impl Interface {
         }
 
         config
+    }
+
+    /// Bring up interfaces and apply network configuration via `ip`.
+    pub fn ip_apply(&self) -> Result<()> {
+        let name = match self.name {
+            Some(ref n) => n,
+            None => bail!("missing interface name"),
+        };
+
+        // Bring up.
+        ip_cli::ip_link_set_up(&name)?;
+
+        // Add addresses.
+        for ip_addr in &self.ip_addresses {
+            ip_cli::ip_address_add(&name, ip_addr)?;
+        }
+
+        // Add routes
+        for route in &self.routes {
+            ip_cli::ip_route_add(route)?;
+        }
+
+        Ok(())
     }
 }
 

--- a/src/network/utils.rs
+++ b/src/network/utils.rs
@@ -1,0 +1,35 @@
+/// Misc network-related helpers.
+use crate::errors::*;
+use std::io::Write;
+use std::net::IpAddr;
+
+/// Write nameservers in `resolv.conf` format.
+pub(crate) fn write_resolvconf<T>(writer: &mut T, nameservers: &[IpAddr]) -> Result<()>
+where
+    T: Write,
+{
+    slog_scope::trace!("writing {} nameservers", nameservers.len());
+
+    for ns in nameservers {
+        let entry = format!("nameserver {}\n", ns);
+        writer.write_all(&entry.as_bytes())?;
+        writer.flush()?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_write_resolvconf() {
+        let nameservers = vec![IpAddr::from([4, 4, 4, 4]), IpAddr::from([8, 8, 8, 8])];
+        let expected = "nameserver 4.4.4.4\nnameserver 8.8.8.8\n";
+        let mut buf = vec![];
+
+        write_resolvconf(&mut buf, &nameservers).unwrap();
+        assert_eq!(buf, expected.as_bytes());
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -35,16 +35,15 @@ pub mod openstack;
 pub mod packet;
 pub mod vagrant_virtualbox;
 
+use crate::errors::*;
+use crate::network;
+use openssh_keys::PublicKey;
+use slog_scope::warn;
 use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::prelude::*;
 use std::path::Path;
-
-use openssh_keys::PublicKey;
 use users::{self, User};
-
-use crate::errors::*;
-use crate::network;
 
 #[cfg(not(feature = "cl-legacy"))]
 const ENV_PREFIX: &str = "AFTERBURN_";
@@ -182,6 +181,12 @@ pub trait MetadataProvider {
     ///
     /// netdev: https://www.freedesktop.org/software/systemd/man/systemd.netdev.html
     fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>>;
+
+    /// Bootstrap initramfs networking.
+    fn rd_net_bootstrap(&self) -> Result<()> {
+        warn!("initramfs network bootstrap requested, but not supported on this platform");
+        Ok(())
+    }
 
     fn write_attributes(&self, attributes_file_path: String) -> Result<()> {
         let mut attributes_file = create_file(&attributes_file_path)?;


### PR DESCRIPTION
This adds initial/experimental support for bootstrapping the network
in the initrd. It is meant to support weird cloud providers where
DHCP is not available or not usable.
This feature is currently reachable as a dedicated `exp rd-net-bootstrap`
subcommand.
The first provider where this logic is required is `ibmcloud-classic`.