### PR TITLE
Release 4.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "afterburn"
-version = "4.3.2"
+version = "4.3.3-alpha.0"
 dependencies = [
  "base64 0.11.0",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "afterburn"
-version = "4.3.2-alpha.0"
+version = "4.3.2"
 dependencies = [
  "base64 0.11.0",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.3.2-alpha.0"
+version = "4.3.2"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.3.2"
+version = "4.3.3-alpha.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Changes:
 * cargo: relax dependencies micro versions 
 * cargo: switch from deprecated tempdir crate to tempfile
 * providers: add exoscale
 * providers: add ibmcloud-classic as a separate platform
 * providers/packet: add gateway attributes
 * util/mount: log intermediate errors