### PR TITLE
ci: hook up to CoreOS CI

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,0 +1,7 @@
+// Documentation: https://github.com/coreos/coreos-ci/blob/master/README-upstream-ci.md
+
+cosaPod(buildroot: true) {
+    checkout scm
+
+    fcosBuild(make: true)
+}

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,18 @@ units = $(addprefix systemd/, \
 	afterburn.service \
 	afterburn-sshkeys@.service)
 
+.PHONY: all
+all: $(units)
+	cargo build --release
+
 %.service: %.service.in
 	sed -e 's,@DEFAULT_INSTANCE@,'$(DEFAULT_INSTANCE)',' < $< > $@.tmp && mv $@.tmp $@
 
-all:
-	cargo build --release
-
+.PHONY: install-units
 install-units: $(units)
 	for unit in $(units); do install -D --target-directory=$(DESTDIR)$(PREFIX)/lib/systemd/system/ $$unit; done
+
+.PHONY: install
+install: install-units
+	install -D -t ${DESTDIR}$(PREFIX)/lib/dracut/modules.d/30afterburn dracut/30afterburn/*
+	install -D -t ${DESTDIR}$(PREFIX)/bin target/release/afterburn


### PR DESCRIPTION
Run a basic FCOS build and kola run.

This doesn't really stress afterburn functionality itself, since CI only
uses qemu right now. Though it's prep for if/when we add testing on
`$cloud`.

(Or I could also imagine some kind of "mock" test harness where we're
still testing on QEMU, but we have some override knob to make afterburn
think it's on `$cloud` and check that it sets up e.g. hostnames or
metadata right.)

For now at least, it still sanity checks that we can compose it fine and
that e.g. the dracut module installs correctly.