### PR TITLE
providers: setup network kernel arguments in initrd

### DIFF
--- a/dracut/30afterburn/afterburn-network-kargs.service
+++ b/dracut/30afterburn/afterburn-network-kargs.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Afterburn Initrd Setup Network Kernel Arguments
+
+# This service may produce additional kargs fragments,
+# which are then consumed by dracut-cmdline(8).
+DefaultDependencies=no
+Before=dracut-cmdline.service
+Before=ignition-fetch.service
+After=systemd-journald.socket
+
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
+[Service]
+Environment=AFTERBURN_OPT_PROVIDER=--cmdline
+# AFTERBURN_NETWORK_KARGS_DEFAULT must be set externally by distributions.
+# If unset, variable expansion results in a missing argument and service
+# hard-failure, on purpose.
+ExecStart=/usr/bin/afterburn exp rd-network-kargs ${AFTERBURN_OPT_PROVIDER} --default-value $AFTERBURN_NETWORK_KARGS_DEFAULT
+Type=oneshot

--- a/dracut/30afterburn/module-setup.sh
+++ b/dracut/30afterburn/module-setup.sh
@@ -16,9 +16,12 @@ install() {
     inst_simple "$moddir/afterburn-hostname.service" \
         "$systemdutildir/system/afterburn-hostname.service"
 
-    # We want the afterburn-hostname to be firstboot only, so Ignition-provided
-    # hostname changes do not get overwritten on subsequent boots
+    inst_simple "$moddir/afterburn-network-kargs.service" \
+        "$systemdutildir/system/afterburn-network-kargs.service"
 
+    # These services are only run once on first-boot, so they piggyback
+    # on Ignition completion target.
     mkdir -p "$initdir/$systemdsystemunitdir/ignition-complete.target.requires"
     ln -s "../afterburn-hostname.service" "$initdir/$systemdsystemunitdir/ignition-complete.target.requires/afterburn-hostname.service"
+    ln -s "../afterburn-network-kargs.service" "$initdir/$systemdsystemunitdir/ignition-complete.target.requires/afterburn-network-kargs.service"
 }

--- a/src/cli/exp.rs
+++ b/src/cli/exp.rs
@@ -1,0 +1,74 @@
+//! `exp` CLI sub-command.
+
+use crate::errors::*;
+use crate::{initrd, util};
+use clap::ArgMatches;
+use error_chain::bail;
+
+/// Experimental subcommands.
+#[derive(Debug)]
+pub enum CliExp {
+    RdNetworkKargs(CliRdNetworkKargs),
+}
+
+impl CliExp {
+    /// Parse sub-command into configuration.
+    pub(crate) fn parse(app_matches: &ArgMatches) -> Result<super::CliConfig> {
+        if app_matches.subcommand_name().is_none() {
+            bail!("missing subcommand for 'exp'");
+        }
+
+        let cfg = match app_matches.subcommand() {
+            ("rd-network-kargs", Some(matches)) => CliRdNetworkKargs::parse(matches)?,
+            (x, _) => unreachable!("unrecognized subcommand for 'exp': '{}'", x),
+        };
+
+        Ok(super::CliConfig::Exp(cfg))
+    }
+
+    // Run sub-command.
+    pub(crate) fn run(&self) -> Result<()> {
+        match self {
+            CliExp::RdNetworkKargs(cmd) => cmd.run()?,
+        };
+        Ok(())
+    }
+}
+
+/// Sub-command for network kernel arguments.
+#[derive(Debug)]
+pub struct CliRdNetworkKargs {
+    platform: String,
+    default_kargs: String,
+}
+
+impl CliRdNetworkKargs {
+    /// Parse sub-command into configuration.
+    pub(crate) fn parse(matches: &ArgMatches) -> Result<CliExp> {
+        let platform = super::parse_provider(matches)?;
+        let default_kargs = matches
+            .value_of("default-value")
+            .ok_or_else(|| "missing network kargs default value")?
+            .to_string();
+
+        let cfg = Self {
+            platform,
+            default_kargs,
+        };
+        Ok(CliExp::RdNetworkKargs(cfg))
+    }
+
+    /// Run the sub-command.
+    pub(crate) fn run(&self) -> Result<()> {
+        if util::has_network_kargs(super::CMDLINE_PATH)? {
+            slog_scope::warn!("kernel cmdline already specifies network arguments, skipping");
+            return Ok(());
+        };
+
+        let provider_kargs = initrd::fetch_network_kargs(&self.platform)?;
+        let kargs = provider_kargs
+            .as_ref()
+            .unwrap_or_else(|| &self.default_kargs);
+        initrd::write_network_kargs(kargs)
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,8 +2,10 @@
 
 use crate::errors::*;
 use clap::{crate_version, App, Arg, ArgMatches, SubCommand};
+use error_chain::bail;
 use slog_scope::trace;
 
+mod exp;
 mod multi;
 
 /// Path to kernel command-line (requires procfs mount).
@@ -13,6 +15,7 @@ const CMDLINE_PATH: &str = "/proc/cmdline";
 #[derive(Debug)]
 pub(crate) enum CliConfig {
     Multi(multi::CliMulti),
+    Exp(exp::CliExp),
 }
 
 impl CliConfig {
@@ -20,6 +23,7 @@ impl CliConfig {
     pub fn parse_subcommands(app_matches: ArgMatches) -> Result<Self> {
         let cfg = match app_matches.subcommand() {
             ("multi", Some(matches)) => multi::CliMulti::parse(matches)?,
+            ("exp", Some(matches)) => exp::CliExp::parse(matches)?,
             (x, _) => unreachable!("unrecognized subcommand '{}'", x),
         };
 
@@ -30,6 +34,7 @@ impl CliConfig {
     pub fn run(self) -> Result<()> {
         match self {
             CliConfig::Multi(cmd) => cmd.run(),
+            CliConfig::Exp(cmd) => cmd.run(),
         }
     }
 }
@@ -44,62 +49,105 @@ pub(crate) fn parse_args(argv: impl IntoIterator<Item = String>) -> Result<CliCo
     Ok(cfg)
 }
 
+/// Parse provider ID from flag or kargs.
+fn parse_provider(matches: &clap::ArgMatches) -> Result<String> {
+    let provider = match (matches.value_of("provider"), matches.is_present("cmdline")) {
+        (Some(provider), false) => String::from(provider),
+        (None, true) => crate::util::get_platform(CMDLINE_PATH)?,
+        (None, false) => bail!("must set either --provider or --cmdline"),
+        (Some(_), true) => bail!("cannot process both --provider and --cmdline"),
+    };
+
+    Ok(provider)
+}
+
 /// CLI setup, covering all sub-commands and arguments.
 fn cli_setup<'a, 'b>() -> App<'a, 'b> {
     // NOTE(lucab): due to legacy translation there can't be global arguments
     //  here, i.e. a sub-command is always expected first.
-    App::new("Afterburn").version(crate_version!()).subcommand(
-        SubCommand::with_name("multi")
-            .about("Perform multiple tasks in a single call")
-            .arg(
-                Arg::with_name("legacy-cli")
-                    .long("legacy-cli")
-                    .help("Whether this command was translated from legacy CLI args")
-                    .hidden(true),
-            )
-            .arg(
-                Arg::with_name("provider")
-                    .long("provider")
-                    .help("The name of the cloud provider")
-                    .global(true)
-                    .takes_value(true),
-            )
-            .arg(
-                Arg::with_name("cmdline")
-                    .long("cmdline")
-                    .global(true)
-                    .help("Read the cloud provider from the kernel cmdline"),
-            )
-            .arg(
-                Arg::with_name("attributes")
-                    .long("attributes")
-                    .help("The file into which the metadata attributes are written")
-                    .takes_value(true),
-            )
-            .arg(
-                Arg::with_name("check-in")
-                    .long("check-in")
-                    .help("Check-in this instance boot with the cloud provider"),
-            )
-            .arg(
-                Arg::with_name("hostname")
-                    .long("hostname")
-                    .help("The file into which the hostname should be written")
-                    .takes_value(true),
-            )
-            .arg(
-                Arg::with_name("network-units")
-                    .long("network-units")
-                    .help("The directory into which network units are written")
-                    .takes_value(true),
-            )
-            .arg(
-                Arg::with_name("ssh-keys")
-                    .long("ssh-keys")
-                    .help("Update SSH keys for the given user")
-                    .takes_value(true),
-            ),
-    )
+    App::new("Afterburn")
+        .version(crate_version!())
+        .subcommand(
+            SubCommand::with_name("multi")
+                .about("Perform multiple tasks in a single call")
+                .arg(
+                    Arg::with_name("legacy-cli")
+                        .long("legacy-cli")
+                        .help("Whether this command was translated from legacy CLI args")
+                        .hidden(true),
+                )
+                .arg(
+                    Arg::with_name("provider")
+                        .long("provider")
+                        .help("The name of the cloud provider")
+                        .global(true)
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("cmdline")
+                        .long("cmdline")
+                        .global(true)
+                        .help("Read the cloud provider from the kernel cmdline"),
+                )
+                .arg(
+                    Arg::with_name("attributes")
+                        .long("attributes")
+                        .help("The file into which the metadata attributes are written")
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("check-in")
+                        .long("check-in")
+                        .help("Check-in this instance boot with the cloud provider"),
+                )
+                .arg(
+                    Arg::with_name("hostname")
+                        .long("hostname")
+                        .help("The file into which the hostname should be written")
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("network-units")
+                        .long("network-units")
+                        .help("The directory into which network units are written")
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("ssh-keys")
+                        .long("ssh-keys")
+                        .help("Update SSH keys for the given user")
+                        .takes_value(true),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("exp")
+                .about("experimental subcommands")
+                .subcommand(
+                    SubCommand::with_name("rd-network-kargs")
+                        .about("Supplement initrd with network configuration kargs")
+                        .arg(
+                            Arg::with_name("cmdline")
+                                .long("cmdline")
+                                .global(true)
+                                .help("Read the cloud provider from the kernel cmdline"),
+                        )
+                        .arg(
+                            Arg::with_name("provider")
+                                .long("provider")
+                                .help("The name of the cloud provider")
+                                .global(true)
+                                .takes_value(true),
+                        )
+                        .arg(
+                            Arg::with_name("default-value")
+                                .long("default-value")
+                                .help("Default value for network kargs fallback")
+                                .required(true)
+                                .takes_value(true)
+                                .empty_values(true),
+                        ),
+                ),
+        )
 }
 
 /// Translate command-line arguments from legacy mode.
@@ -139,8 +187,6 @@ fn translate_legacy_args(cli: impl IntoIterator<Item = String>) -> impl Iterator
     })
 }
 
-impl CliConfig {}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -167,7 +213,11 @@ mod tests {
             .map(ToString::to_string)
             .collect();
 
-        parse_args(legacy).unwrap();
+        let cmd = parse_args(legacy).unwrap();
+        match cmd {
+            CliConfig::Multi(_) => {}
+            x => panic!("unexpected cmd: {:?}", x),
+        };
     }
 
     #[test]
@@ -183,7 +233,11 @@ mod tests {
             .map(ToString::to_string)
             .collect();
 
-        parse_args(args).unwrap();
+        let cmd = parse_args(args).unwrap();
+        match cmd {
+            CliConfig::Multi(_) => {}
+            x => panic!("unexpected cmd: {:?}", x),
+        };
     }
 
     #[test]
@@ -193,6 +247,81 @@ mod tests {
             .map(ToString::to_string)
             .collect();
 
-        parse_args(args).unwrap();
+        let cmd = parse_args(args).unwrap();
+        match cmd {
+            CliConfig::Multi(_) => {}
+            x => panic!("unexpected cmd: {:?}", x),
+        };
+    }
+
+    #[test]
+    fn test_exp_cmd() {
+        let args: Vec<_> = [
+            "afterburn",
+            "exp",
+            "rd-network-kargs",
+            "--provider",
+            "gcp",
+            "--default-value",
+            "ip=dhcp",
+        ]
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+
+        let cmd = parse_args(args).unwrap();
+        let subcmd = match cmd {
+            CliConfig::Exp(v) => v,
+            x => panic!("unexpected cmd: {:?}", x),
+        };
+
+        match subcmd {
+            exp::CliExp::RdNetworkKargs(_) => {}
+            #[allow(unreachable_patterns)]
+            x => panic!("unexpected 'exp' sub-command: {:?}", x),
+        };
+    }
+
+    #[test]
+    fn test_default_net_kargs() {
+        // Missing flag.
+        let t1: Vec<_> = ["afterburn", "exp", "rd-network-kargs", "--provider", "gcp"]
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+
+        // Missing flag value.
+        let t2: Vec<_> = [
+            "afterburn",
+            "exp",
+            "rd-network-kargs",
+            "--provider",
+            "gcp",
+            "--default-value",
+        ]
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+
+        for args in vec![t1, t2] {
+            let input = format!("{:?}", args);
+            parse_args(args).expect_err(&input);
+        }
+
+        // Empty flag value.
+        let t3: Vec<_> = [
+            "afterburn",
+            "exp",
+            "rd-network-kargs",
+            "--provider",
+            "gcp",
+            "--default-value",
+            "",
+        ]
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+
+        parse_args(t3).unwrap();
     }
 }

--- a/src/cli/multi.rs
+++ b/src/cli/multi.rs
@@ -1,9 +1,7 @@
 //! `multi` CLI sub-command.
 
-use super::CMDLINE_PATH;
 use crate::errors::*;
 use crate::metadata;
-use error_chain::bail;
 
 #[derive(Debug)]
 pub struct CliMulti {
@@ -18,7 +16,7 @@ pub struct CliMulti {
 impl CliMulti {
     /// Parse flags for the `multi` sub-command.
     pub(crate) fn parse(matches: &clap::ArgMatches) -> Result<super::CliConfig> {
-        let provider = Self::parse_provider(matches)?;
+        let provider = super::parse_provider(matches)?;
 
         let multi = Self {
             attributes_file: matches.value_of("attributes").map(String::from),
@@ -40,18 +38,6 @@ impl CliMulti {
         }
 
         Ok(super::CliConfig::Multi(multi))
-    }
-
-    /// Parse provider ID from flag or kargs.
-    fn parse_provider(matches: &clap::ArgMatches) -> Result<String> {
-        let provider = match (matches.value_of("provider"), matches.is_present("cmdline")) {
-            (Some(provider), false) => String::from(provider),
-            (None, true) => crate::util::get_platform(CMDLINE_PATH)?,
-            (None, false) => bail!("must set either --provider or --cmdline"),
-            (Some(_), true) => bail!("cannot process both --provider and --cmdline"),
-        };
-
-        Ok(provider)
     }
 
     /// Run the `multi` sub-command.

--- a/src/initrd/mod.rs
+++ b/src/initrd/mod.rs
@@ -1,0 +1,33 @@
+/// Agent logic running at early boot.
+///
+/// This is run early-on in initrd, possibly before networking and other
+/// services are configured, so it may not be able to use all usual metadata
+/// fetcher.
+use crate::errors::*;
+
+use std::fs::File;
+use std::io::Write;
+
+/// Path to cmdline.d fragment for network kernel arguments.
+static KARGS_PATH: &str = "/etc/cmdline.d/50-afterburn-network-kargs.conf";
+
+/// Fetch network kargs for the given provider.
+pub(crate) fn fetch_network_kargs(provider: &str) -> Result<Option<String>> {
+    match provider {
+        // TODO(lucab): wire-in vmware guestinfo logic.
+        "vmware" => Ok(None),
+        _ => Ok(None),
+    }
+}
+
+/// Write network kargs into a cmdline.d fragment.
+pub(crate) fn write_network_kargs(kargs: &str) -> Result<()> {
+    let mut fragment_file =
+        File::create(KARGS_PATH).chain_err(|| format!("failed to create file {:?}", KARGS_PATH))?;
+
+    fragment_file
+        .write_all(kargs.as_bytes())
+        .chain_err(|| "failed to write network arguments fragment")?;
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@
 
 mod cli;
 mod errors;
+mod initrd;
 mod metadata;
 mod network;
 mod providers;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -37,6 +37,8 @@ pub mod packet;
 pub mod vagrant_virtualbox;
 pub mod vmware;
 
+use crate::errors::*;
+use crate::network;
 use libsystemd::logging;
 use openssh_keys::PublicKey;
 use slog_scope::warn;
@@ -45,9 +47,6 @@ use std::fs::{self, File};
 use std::io::prelude::*;
 use std::path::Path;
 use users::{self, User};
-
-use crate::errors::*;
-use crate::network;
 
 #[cfg(not(feature = "cl-legacy"))]
 const ENV_PREFIX: &str = "AFTERBURN_";
@@ -207,6 +206,11 @@ pub trait MetadataProvider {
     ///
     /// netdev: https://www.freedesktop.org/software/systemd/man/systemd.netdev.html
     fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>>;
+
+    /// Return custom initrd network kernel arguments, if any.
+    fn rd_network_kargs(&self) -> Result<Option<String>> {
+        Ok(None)
+    }
 
     fn write_attributes(&self, attributes_file_path: String) -> Result<()> {
         let mut attributes_file = create_file(&attributes_file_path)?;

--- a/src/providers/vmware/mod.rs
+++ b/src/providers/vmware/mod.rs
@@ -42,6 +42,10 @@ impl MetadataProvider for VmwareProvider {
         Ok(vec![])
     }
 
+    fn rd_network_kargs(&self) -> Result<Option<String>> {
+        Ok(self.guestinfo_net_kargs.clone())
+    }
+
     fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
         warn!("virtual network devices metadata requested, but not supported on this platform");
         Ok(vec![])


### PR DESCRIPTION
This adds initial/experimental support for providing supplemental
network kernel arguments in the initrd.
It is meant to support environment where custom network kargs may
be provided via a back-channel.
Such arguments are only retrieved and applied on first boot, and
their format is defined by dracut [0].
The feature is currently reachable as a dedicated subcommand,
but this does not contain any platform-specific implementation.

[0] https://mirrors.edge.kernel.org/pub/linux/utils/boot/dracut/dracut.html#_network