### PR TITLE
providers: add vmware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,7 @@ dependencies = [
  "tempfile",
  "update-ssh-keys",
  "users",
+ "vmw_backdoor",
 ]
 
 [[package]]
@@ -1568,6 +1569,19 @@ name = "version_check"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+
+[[package]]
+name = "vmw_backdoor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96046ba681815732119358af55ebd277d694d866a88c5db05869f4eefa2f8072"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "thiserror",
+]
 
 [[package]]
 name = "void"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ slog-term = "^2.5"
 tempfile = "^3.1"
 update-ssh-keys = { version = "^0.6", optional = true }
 users = "^0.10"
+vmw_backdoor = "^0.1"
 
 [dependencies.slog]
 version = "^2.5"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -32,6 +32,7 @@ error_chain! {
         MacAddr(pnet_base::ParseMacAddrErr);
         OpensslStack(::openssl::error::ErrorStack);
         Reqwest(::reqwest::Error);
+        VmwBackdoor(vmw_backdoor::VmwError);
         XmlDeserialize(::serde_xml_rs::Error);
     }
     errors {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -27,6 +27,7 @@ use crate::providers::ibmcloud_classic::IBMClassicProvider;
 use crate::providers::openstack::network::OpenstackProvider;
 use crate::providers::packet::PacketProvider;
 use crate::providers::vagrant_virtualbox::VagrantVirtualboxProvider;
+use crate::providers::vmware::VmwareProvider;
 
 macro_rules! box_result {
     ($exp:expr) => {
@@ -62,6 +63,7 @@ pub fn fetch_metadata(provider: &str) -> errors::Result<Box<dyn providers::Metad
         "openstack-metadata" => box_result!(OpenstackProvider::try_new()?),
         "packet" => box_result!(PacketProvider::try_new()?),
         "vagrant-virtualbox" => box_result!(VagrantVirtualboxProvider::new()),
+        "vmware" => box_result!(VmwareProvider::try_new()?),
         _ => Err(errors::ErrorKind::UnknownProvider(provider.to_owned()).into()),
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -35,6 +35,7 @@ pub mod ibmcloud_classic;
 pub mod openstack;
 pub mod packet;
 pub mod vagrant_virtualbox;
+pub mod vmware;
 
 use std::collections::HashMap;
 use std::fs::{self, File};

--- a/src/providers/vmware/mod.rs
+++ b/src/providers/vmware/mod.rs
@@ -1,0 +1,70 @@
+//! VMware provider.
+//!
+//! This uses the guest->host backdoor protocol for introspection.
+
+use std::collections::HashMap;
+
+use error_chain::bail;
+use openssh_keys::PublicKey;
+use slog_scope::warn;
+
+use crate::errors::*;
+use crate::network;
+use crate::providers::MetadataProvider;
+
+/// VMware provider.
+#[derive(Clone, Debug)]
+pub struct VmwareProvider {
+    /// External network kargs for initrd.
+    guestinfo_net_kargs: Option<String>,
+}
+
+impl VmwareProvider {
+    pub fn try_new() -> Result<Self> {
+        if !vmw_backdoor::is_vmware_cpu() {
+            bail!("not running on VMWare CPU");
+        }
+
+        let mut backdoor = vmw_backdoor::probe_backdoor()?;
+        let mut erpc = backdoor.open_enhanced_chan()?;
+        let guestinfo_net_kargs = Self::get_net_kargs(&mut erpc)?;
+
+        let provider = Self {
+            guestinfo_net_kargs,
+        };
+        Ok(provider)
+    }
+
+    fn get_net_kargs(_erpc: &mut vmw_backdoor::EnhancedChan) -> Result<Option<String>> {
+        // TODO(lucab): pick a stable key name and implement this logic.
+        Ok(None)
+    }
+}
+
+impl MetadataProvider for VmwareProvider {
+    fn attributes(&self) -> Result<HashMap<String, String>> {
+        Ok(HashMap::new())
+    }
+
+    fn hostname(&self) -> Result<Option<String>> {
+        Ok(None)
+    }
+
+    fn ssh_keys(&self) -> Result<Vec<PublicKey>> {
+        Ok(vec![])
+    }
+
+    fn networks(&self) -> Result<Vec<network::Interface>> {
+        Ok(vec![])
+    }
+
+    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
+        warn!("virtual network devices metadata requested, but not supported on this platform");
+        Ok(vec![])
+    }
+
+    fn boot_checkin(&self) -> Result<()> {
+        warn!("boot check-in requested, but not supported on this platform");
+        Ok(())
+    }
+}


### PR DESCRIPTION
This adds a skeleton provider for the `vmware` platform. It brings
in library code to access the hypervisor back-channel, but it does
not currently retrieve any specific guestinfo property.