### PR TITLE
providers: add a default catch-all provider

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -34,10 +34,4 @@ error_chain! {
         Reqwest(::reqwest::Error);
         XmlDeserialize(::serde_xml_rs::Error);
     }
-    errors {
-        UnknownProvider(p: String) {
-            description("unknown provider")
-            display("unknown provider '{}'", p)
-        }
-    }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -19,6 +19,7 @@ use crate::providers::aws::AwsProvider;
 use crate::providers::azure::Azure;
 use crate::providers::cloudstack::configdrive::ConfigDrive;
 use crate::providers::cloudstack::network::CloudstackNetwork;
+use crate::providers::default::DefaultProvider;
 use crate::providers::digitalocean::DigitalOceanProvider;
 use crate::providers::exoscale::ExoscaleProvider;
 use crate::providers::gcp::GcpProvider;
@@ -62,6 +63,22 @@ pub fn fetch_metadata(provider: &str) -> errors::Result<Box<dyn providers::Metad
         "openstack-metadata" => box_result!(OpenstackProvider::try_new()?),
         "packet" => box_result!(PacketProvider::try_new()?),
         "vagrant-virtualbox" => box_result!(VagrantVirtualboxProvider::new()),
-        _ => Err(errors::ErrorKind::UnknownProvider(provider.to_owned()).into()),
+        name => box_result!(DefaultProvider::try_new(name)?),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_missing_provider() {
+        assert!(fetch_metadata("").is_err());
+    }
+
+    #[test]
+    fn test_unknown_provider() {
+        let provider = fetch_metadata("non-existent").unwrap();
+        assert_eq!(provider.hostname().unwrap(), None);
     }
 }

--- a/src/providers/default/mod.rs
+++ b/src/providers/default/mod.rs
@@ -1,0 +1,65 @@
+//! Default provider.
+//!
+//! This is a generic provider which is used as a fallback whenever
+//! it is not possible to match to a relevant one. It is intended not
+//! to perform any actions nor to have any side effects.
+
+use std::collections::HashMap;
+
+use error_chain::bail;
+use openssh_keys::PublicKey;
+use slog_scope::warn;
+
+use crate::errors::*;
+use crate::network;
+use crate::providers::MetadataProvider;
+
+/// Default provider.
+#[derive(Clone, Debug)]
+pub struct DefaultProvider {
+    /// External provider name.
+    name: String,
+}
+
+impl DefaultProvider {
+    pub fn try_new(name: &str) -> Result<Self> {
+        if name.is_empty() {
+            bail!("empty provider name");
+        };
+
+        warn!(
+            "unknown provider '{}', using default provider instead",
+            name
+        );
+        let provider = Self {
+            name: name.to_string(),
+        };
+        Ok(provider)
+    }
+}
+
+impl MetadataProvider for DefaultProvider {
+    fn attributes(&self) -> Result<HashMap<String, String>> {
+        Ok(HashMap::new())
+    }
+
+    fn hostname(&self) -> Result<Option<String>> {
+        Ok(None)
+    }
+
+    fn ssh_keys(&self) -> Result<Vec<PublicKey>> {
+        Ok(vec![])
+    }
+
+    fn networks(&self) -> Result<Vec<network::Interface>> {
+        Ok(vec![])
+    }
+
+    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
+        Ok(vec![])
+    }
+
+    fn boot_checkin(&self) -> Result<()> {
+        Ok(())
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -27,6 +27,7 @@ pub mod aliyun;
 pub mod aws;
 pub mod azure;
 pub mod cloudstack;
+pub mod default;
 pub mod digitalocean;
 pub mod exoscale;
 pub mod gcp;


### PR DESCRIPTION
This adds a default provider for otherwise unknown platforms, which
prevents Afterburn from hard-failing but is otherwise intended to
be free of side-effects.