### PR TITLE
util/cmdline: add helpers for detecting network kargs

### DIFF
--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -24,7 +24,7 @@ use std::path::Path;
 use std::time::Duration;
 
 mod cmdline;
-pub use self::cmdline::get_platform;
+pub use self::cmdline::{get_platform, has_network_kargs};
 
 mod mount;
 pub(crate) use mount::{mount_ro, unmount};


### PR DESCRIPTION
This adds some logic for detecting the presence of network kargs
(currently, only `ip=`) on the kernel command-line.