### PR TITLE
bump rust version from 1.39.0 to 1.40.0 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
   - 1.42.0  # pinned toolchain for clippy
-  - 1.39.0  # minimum supported toolchain
+  - 1.40.0  # minimum supported toolchain (https://github.com/rust-lang/rust/pull/63803)
   - stable
   - beta
   - nightly


### PR DESCRIPTION
Current CI is unable to handle `#[cfg(doctest)]` tag in the code and throwing the following error:
```
error[E0658]: `cfg(doctest)` is experimental and subject to change
```
For more information: (https://travis-ci.org/github/coreos/afterburn/jobs/677790013#L412)

[This](https://github.com/rust-lang/rust/pull/63803) PR fixes the above issue which is present in the rust  `v1.40.0` release.