### PR TITLE
ci: test a secondary arch on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,50 @@
+---
 language: rust
-rust:
-  - 1.42.0  # pinned toolchain for clippy
-  - 1.40.0  # minimum supported toolchain (https://github.com/rust-lang/rust/pull/63803)
-  - stable
-  - beta
-  - nightly
+os: linux
 
-matrix:
+jobs:
   allow_failures:
     - rust: nightly
-
-env:
-  global:
-    - CLIPPY_RUST_VERSION=1.42.0
-
-before_script:
-  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then
-      rustup component add clippy;
-    fi'
-
-script:
-  - cargo test
-  - cargo test --features cl-legacy
-  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then
-      cargo clippy -- -D warnings;
-    fi'
-  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then
-      cargo clippy --features cl-legacy -- -D warnings;
-    fi'
+  include:
+    - name: "Test with nightly toolchain"
+      arch: amd64
+      rust: nightly
+      script:
+        - cargo test
+    - name: "Test with stable toolchain"
+      arch: amd64
+      rust: stable
+      script:
+        - cargo test
+    - name: "Test with beta toolchain"
+      arch: amd64
+      rust: beta
+      script:
+        - cargo test
+    - name: "Test a secondary architecture (aarch64)"
+      arch: arm64
+      rust: stable
+      script:
+        - cargo test
+    - name: "Test with minimum supported toolchain"
+      arch: amd64
+      rust: 1.40.0
+      script:
+        - cargo test --release
+    - name: "Test CL legacy feature"
+      arch: amd64
+      rust: 1.42.0
+      before_script:
+        - rustup component add clippy
+      script:
+        - cargo test --features cl-legacy
+        - cargo clippy --features cl-legacy -- -D warnings;
+    - name: "Lints with pinned toolchain"
+      arch: amd64
+      rust: 1.42.0
+      before_script:
+        - rustup component add clippy
+        - rustup component add rustfmt
+      script:
+        - cargo clippy -- -D warnings
+        - cargo fmt -- --check -l

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = "4.3.3-alpha.0"
 dependencies = [
  "base64 0.12.0",
  "byteorder",
+ "cfg-if",
  "clap",
  "error-chain",
  "hostname",
@@ -53,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d663a8e9a99154b5fb793032533f6328da35e23aac63d5c152279aa8ba356825"
+checksum = "b585a98a234c46fc563103e9278c9391fde1f4e6850334da895d27edb9580f62"
 
 [[package]]
 name = "arrayref"
@@ -486,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"
+checksum = "8a0d737e0f947a1864e93d33fdef4af8445a00d1ed8dc0c8ddb73139ea6abf15"
 dependencies = [
  "libc",
 ]
@@ -533,9 +534,9 @@ checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 
 [[package]]
 name = "hyper"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6081100e960d9d74734659ffc9cc91daf1c0fc7aceb8eaa94ee1a3f5046f2e"
+checksum = "96816e1d921eca64d208a85aab4f7798455a8e34229ee5a88c935bdee1b78b14"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -830,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -898,18 +899,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7804a463a8d9572f13453c516a5faea534a2403d7ced2f0c7e100eeff072772c"
+checksum = "6f6a7f5eee6292c559c793430c55c00aea9d3b3d1905e855806ca4d7253426a2"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385322a45f2ecf3410c68d2a549a4a2685e8051d0f278e39743ff4e451cb9b3f"
+checksum = "8988430ce790d8682672117bc06dda364c0be32d3abd738234f19f3240bad99a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1080,9 +1081,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.3.6"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
+checksum = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1410,12 +1411,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "redox_syscall",
  "winapi 0.3.8",
 ]
 
@@ -1738,6 +1738,6 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5"
+checksum = "2bb76e5c421bbbeb8924c60c030331b345555024d56261dae8f3e786ed817c23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ lto = true
 [dependencies]
 base64 = "^0.12"
 byteorder = "^1.3"
+cfg-if = "^0.1"
 clap = "^2.33"
 error-chain = { version = "^0.12", default-features = false }
 hostname = "^0.3"

--- a/src/providers/vmware/amd64.rs
+++ b/src/providers/vmware/amd64.rs
@@ -1,0 +1,30 @@
+//! VMware provider on x86_64.
+//!
+//! This uses the guest->host backdoor protocol for introspection.
+
+use error_chain::bail;
+
+use super::VmwareProvider;
+use crate::errors::*;
+
+impl VmwareProvider {
+    pub fn try_new() -> Result<Self> {
+        if !vmw_backdoor::is_vmware_cpu() {
+            bail!("not running on VMWare CPU");
+        }
+
+        let mut backdoor = vmw_backdoor::probe_backdoor()?;
+        let mut erpc = backdoor.open_enhanced_chan()?;
+        let guestinfo_net_kargs = Self::get_net_kargs(&mut erpc)?;
+
+        let provider = Self {
+            guestinfo_net_kargs,
+        };
+        Ok(provider)
+    }
+
+    fn get_net_kargs(_erpc: &mut vmw_backdoor::EnhancedChan) -> Result<Option<String>> {
+        // TODO(lucab): pick a stable key name and implement this logic.
+        Ok(None)
+    }
+}

--- a/src/providers/vmware/unsupported.rs
+++ b/src/providers/vmware/unsupported.rs
@@ -1,0 +1,11 @@
+//! VMware provider on unsupported architectures.
+
+use super::VmwareProvider;
+use crate::errors::*;
+use error_chain::bail;
+
+impl VmwareProvider {
+    pub fn try_new() -> Result<Self> {
+        bail!("unsupported architecture");
+    }
+}


### PR DESCRIPTION
This fixes non-amd64 builds, and adds an `aarch64` run to Travis.