### PR TITLE
Release 4.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "afterburn"
-version = "4.3.3-alpha.0"
+version = "4.3.3"
 dependencies = [
  "base64 0.12.0",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "afterburn"
-version = "4.3.3"
+version = "4.3.4-alpha.0"
 dependencies = [
  "base64 0.12.0",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.3.3-alpha.0"
+version = "4.3.3"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.3.3"
+version = "4.3.4-alpha.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Changes:
  * sshkeys: send structured info to journald
 * ci: test a secondary arch on Travis
 * ci: rust version from 1.39.0 to 1.40.0 
 * makefile: tweak install step
 * providers: add vmware
 * util/cmdline: add helpers for detecting network kargs
 * afterburn: minor cleanups
 * ci: hook up to CoreOS CI