### PR TITLE
aws: change metadata version from 2009-04-04 to 2019-10-01

### DIFF
--- a/src/providers/aws/mod.rs
+++ b/src/providers/aws/mod.rs
@@ -62,7 +62,7 @@ impl AwsProvider {
 
     #[cfg(not(test))]
     fn endpoint_for(key: &str) -> String {
-        const URL: &str = "http://169.254.169.254/2009-04-04";
+        const URL: &str = "http://169.254.169.254/2019-10-01";
         format!("{}/{}", URL, key)
     }
 


### PR DESCRIPTION
This changes updates the instance metadata version for AWS instances,
as mentioned in https://github.com/coreos/afterburn/issues/418.

The original proposed version is 2016-09-02, same as the latest version on official documentation: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html. However, after running `curl http://169.254.169.254` on an FCOS instance on AWS:

```
[core@ip-172-31-48-79 ~]$ curl http://169.254.169.254
1.0
2007-01-19
2007-03-01
2007-08-29
2007-10-10
2007-12-15
2008-02-01
2008-09-01
2009-04-04
2011-01-01
2011-05-01
2012-01-12
2014-02-25
2014-11-05
2015-10-20
2016-04-19
2016-06-30
2016-09-02
2018-03-28
2018-08-17
2018-09-24
2019-10-01
latest
```

The current latest version is 2019-10-01, and I've verified this version currently works with Afterburn. So this PR will update the version to 2019-10-01 instead. Also if we want to track the latest version we could change to `const URL: &str = "http://169.254.169.254/latest";`, but that has the possibility to break Afterburn if the latest version changes the API endpoints. Mock tests are not updated because the API items remain the same as 2009-04-04.

Closes: https://github.com/coreos/afterburn/issues/418
Signed-off-by: Allen Bai <abai@redhat.com>