### PR TITLE
travis: bump to latest toolchain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,10 @@ jobs:
         - rustup component add clippy
       script:
         - cargo test --features cl-legacy
-        - cargo clippy --features cl-legacy -- -D warnings;
+        - cargo clippy --features cl-legacy -- -D warnings
     - name: "Lints with pinned toolchain"
       arch: amd64
-      rust: 1.42.0
+      rust: 1.44.0
       before_script:
         - rustup component add clippy
         - rustup component add rustfmt

--- a/src/providers/digitalocean/mod.rs
+++ b/src/providers/digitalocean/mod.rs
@@ -18,7 +18,6 @@ use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 
-use ipnetwork;
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 use openssh_keys::PublicKey;
 use pnet_base::MacAddr;

--- a/src/providers/vagrant_virtualbox/mod.rs
+++ b/src/providers/vagrant_virtualbox/mod.rs
@@ -19,9 +19,7 @@ use std::net::IpAddr;
 use std::thread;
 use std::time::Duration;
 
-use hostname;
 use openssh_keys::PublicKey;
-use pnet_datalink;
 use slog_scope::{info, warn};
 
 use crate::errors::*;

--- a/src/retry/client.rs
+++ b/src/retry/client.rs
@@ -26,10 +26,6 @@ use std::time::Duration;
 use reqwest::{self, blocking, header, Method};
 use slog_scope::info;
 
-use serde;
-use serde_json;
-use serde_xml_rs;
-
 use crate::errors::*;
 use crate::retry::Retry;
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -16,7 +16,6 @@
 
 use crate::errors::*;
 use crate::retry;
-use pnet_datalink;
 use slog_scope::{debug, trace};
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read};


### PR DESCRIPTION
This fixes some clippy warnings and bumps Travis toolchain to latest stable.