### PR TITLE
dracut: run hostname service on digitalocean

### DIFF
--- a/dracut/30afterburn/afterburn-hostname.service
+++ b/dracut/30afterburn/afterburn-hostname.service
@@ -1,8 +1,10 @@
 [Unit]
 Description=Afterburn Hostname
-# Azure needs to fetch the hostname in the initramfs
+# These platforms do not provide the hostname via DHCP
+# options, thus it needs to be fetched from the metadata
+# and statically applied on first-boot.
 ConditionKernelCommandLine=|ignition.platform.id=azure
-# Exoscale needs to fetch the hostname in the initramfs
+ConditionKernelCommandLine=|ignition.platform.id=digitalocean
 ConditionKernelCommandLine=|ignition.platform.id=exoscale
 
 # We order this service after sysroot has been mounted


### PR DESCRIPTION
The DHCP Offer on DigitalOcean nodes booted from custom images does
not seem to contain the hostname, which is instead available by
querying the metadata endpoint.
This adds the platform condition to the afterburn-hostname service
in order to let it run on DigitalOcean too.

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/538