### PR TITLE
Release 4.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "afterburn"
-version = "4.4.1"
+version = "4.4.2-alpha.0"
 dependencies = [
  "base64 0.12.3",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "afterburn"
-version = "4.4.1-alpha.0"
+version = "4.4.1"
 dependencies = [
  "base64 0.12.3",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml"]
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.4.1"
+version = "4.4.2-alpha.0"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml"]
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.4.1-alpha.0"
+version = "4.4.1"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Changes:
 * docs: rework README
 * provider/vagrant: do not loop back local system hostname
 * CONTRIBUTING: drop mailing list and IRC references
 * docs: explain initrd network arguments usage
 * cargo: exclude tool configs from crate
 * dracut: run hostname service on digitalocean
 * aws: support IMDSv2 for AWS metadata service
 * travis: bump to latest toolchain
 * github: create Dependabot config file
 * aws: change metadata version from 2009-04-04 to 2019-10-01