### PR TITLE
providers: mark vagrant-virtualbox as legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,5 @@ The following platforms are supported, with a different set of features availabl
   - Attributes
   - First-boot check-in
   - SSH Keys
-* vagrant-virtualbox
-  - Attributes
 * vmware
   - Custom network command-line arguments

--- a/docs/usage/attributes.md
+++ b/docs/usage/attributes.md
@@ -89,9 +89,6 @@ Cloud providers with supported metadata endpoints and their respective attribute
   - AFTERBURN_PACKET_IPV4_PRIVATE_GATEWAY_0
   - AFTERBURN_PACKET_IPV6_PUBLIC_0
   - AFTERBURN_PACKET_IPV6_PUBLIC_GATEWAY_0
-* vagrant-virtualbox
-  - AFTERBURN_VAGRANT_VIRTUALBOX_PRIVATE_IPV4
-  - AFTERBURN_VAGRANT_VIRTUALBOX_HOSTNAME
 
 Additionally, some attribute names are reserved for custom metadata providers.
 These can be safely used by external providers on platforms not supported by Afterburn:

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -26,6 +26,7 @@ use crate::providers::ibmcloud::IBMGen2Provider;
 use crate::providers::ibmcloud_classic::IBMClassicProvider;
 use crate::providers::openstack::network::OpenstackProvider;
 use crate::providers::packet::PacketProvider;
+#[cfg(feature = "cl-legacy")]
 use crate::providers::vagrant_virtualbox::VagrantVirtualboxProvider;
 use crate::providers::vmware::VmwareProvider;
 
@@ -62,6 +63,7 @@ pub fn fetch_metadata(provider: &str) -> errors::Result<Box<dyn providers::Metad
         "ibmcloud-classic" => box_result!(IBMClassicProvider::try_new()?),
         "openstack-metadata" => box_result!(OpenstackProvider::try_new()?),
         "packet" => box_result!(PacketProvider::try_new()?),
+        #[cfg(feature = "cl-legacy")]
         "vagrant-virtualbox" => box_result!(VagrantVirtualboxProvider::new()),
         "vmware" => box_result!(VmwareProvider::try_new()?),
         _ => Err(errors::ErrorKind::UnknownProvider(provider.to_owned()).into()),

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -34,6 +34,7 @@ pub mod ibmcloud;
 pub mod ibmcloud_classic;
 pub mod openstack;
 pub mod packet;
+#[cfg(feature = "cl-legacy")]
 pub mod vagrant_virtualbox;
 pub mod vmware;
 


### PR DESCRIPTION
This demotes the "vagrant-virtualbox" provider to legacy only, as
the whole platform was a Container Linux hack that has not been
carried on.

Ref: https://github.com/coreos/afterburn/pull/443#issuecomment-650130910