### PR TITLE
platform: add support for vultr

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,6 @@ The following platforms are supported, with a different set of features availabl
   - SSH Keys
 * vmware
   - Custom network command-line arguments
+* vultr
+  - Attributes
+  - SSH Keys

--- a/docs/usage/attributes.md
+++ b/docs/usage/attributes.md
@@ -89,6 +89,10 @@ Cloud providers with supported metadata endpoints and their respective attribute
   - AFTERBURN_PACKET_IPV4_PRIVATE_GATEWAY_0
   - AFTERBURN_PACKET_IPV6_PUBLIC_0
   - AFTERBURN_PACKET_IPV6_PUBLIC_GATEWAY_0
+* vultr
+  - AFTERBURN_VULTR_HOSTNAME
+  - AFTERBURN_VULTR_INSTANCE_ID
+  - AFTERBURN_VULTR_REGION_CODE
 
 Additionally, some attribute names are reserved for custom metadata providers.
 These can be safely used by external providers on platforms not supported by Afterburn:

--- a/docs/usage/legacy-attributes.md
+++ b/docs/usage/legacy-attributes.md
@@ -93,6 +93,12 @@ On legacy `coreos-metadata` versions, the supported cloud providers and their re
     - Attributes
       - COREOS_VAGRANT_VIRTUALBOX_PRIVATE_IPV4
       - COREOS_VAGRANT_VIRTUALBOX_HOSTNAME
+  - vultr
+    - SSH Keys
+    - Attributes
+      - COREOS_VULTR_HOSTNAME
+      - COREOS_VULTR_INSTANCE_ID
+      - COREOS_VULTR_REGION_CODE
 
 Additionally, some attribute names are reserved for usage by [custom metadata providers][custom-metadata].
 These can be safely used by external providers on a platform not supported by Afterburn:

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -29,6 +29,7 @@ use crate::providers::packet::PacketProvider;
 #[cfg(feature = "cl-legacy")]
 use crate::providers::vagrant_virtualbox::VagrantVirtualboxProvider;
 use crate::providers::vmware::VmwareProvider;
+use crate::providers::vultr::VultrProvider;
 
 macro_rules! box_result {
     ($exp:expr) => {
@@ -66,6 +67,7 @@ pub fn fetch_metadata(provider: &str) -> errors::Result<Box<dyn providers::Metad
         #[cfg(feature = "cl-legacy")]
         "vagrant-virtualbox" => box_result!(VagrantVirtualboxProvider::new()),
         "vmware" => box_result!(VmwareProvider::try_new()?),
+        "vultr" => box_result!(VultrProvider::try_new()?),
         _ => Err(errors::ErrorKind::UnknownProvider(provider.to_owned()).into()),
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -37,6 +37,7 @@ pub mod packet;
 #[cfg(feature = "cl-legacy")]
 pub mod vagrant_virtualbox;
 pub mod vmware;
+pub mod vultr;
 
 use crate::errors::*;
 use crate::network;

--- a/src/providers/vultr/mock_tests.rs
+++ b/src/providers/vultr/mock_tests.rs
@@ -1,0 +1,101 @@
+use crate::providers::vultr;
+use crate::providers::MetadataProvider;
+use mockito;
+
+#[test]
+fn test_hostname() {
+    let ep = "/hostname";
+    let hostname = "test-hostname";
+
+    let mut provider = vultr::VultrProvider::try_new().unwrap();
+    provider.client = provider.client.max_retries(0);
+
+    let _m = mockito::mock("GET", ep).with_status(503).create();
+    provider.hostname().unwrap_err();
+
+    let _m = mockito::mock("GET", ep)
+        .with_status(200)
+        .with_body(hostname)
+        .create();
+    let v = provider.hostname().unwrap();
+    assert_eq!(v, Some(hostname.to_string()));
+
+    let _m = mockito::mock("GET", ep).with_status(404).create();
+    let v = provider.hostname().unwrap();
+    assert_eq!(v, None);
+
+    let _m = mockito::mock("GET", ep)
+        .with_status(200)
+        .with_body("")
+        .create();
+    let v = provider.hostname().unwrap();
+    assert_eq!(v, None);
+
+    mockito::reset();
+    provider.hostname().unwrap_err();
+}
+
+#[test]
+fn test_pubkeys() {
+    let mut provider = vultr::VultrProvider::try_new().unwrap();
+    provider.client = provider.client.max_retries(0);
+
+    let _m_keys = mockito::mock("GET", "/public-keys")
+        .with_status(200)
+        .with_body("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCsXe6CfHl45kCIzMF92VhDf2NpBWUyS1+IiTtxm5a83mT9730Hb8xim7GYeJu47kiESw2DAN8vNJ/Irg0apZ217ah2rXXjPQuWYSXuEuap8yLBSjqw8exgqVj/kzW+YqmnHASxI13eoFDxTQQGzyqbqowvxu/5gQmDwBmNAa9bT809ziB/qmpS1mD6qyyFDpR23kUwu3TkgAbwMXBDoqK+pdwfaF9uo9XaLHNEH8lD5BZuG2BeDafm2o76DhNSo83MvcCPNXKLxu3BbX/FCMFO6O8RRqony4i91fEV1b8TbXrbJz1bwEYEnJRvmjnqI/389tQFeYvplXR2WdT9PCKyEAG+j8y6XgecIcdTqV/7gFfak1mp2S7mYHZDnXixsn3MjCP/cIxxJVDitKusnj1TdFqtSXl4tqGccbg/5Sqnt/EVSK4bGwwBxv/YmE0P9cbXLxuEVI0JYzgrQvC8TtUgd8kUu2jqi1/Yj9IWm3aFsl/hhh8YwYrv/gm8PV0TxkM= root@example1\n
+                   ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDj6FBVgkTt7/DB93VVLk6304Nx7WUjLBJDSCh38zjCimHUpeo9uYDxflfu2N1CLtrSImIKBVP/JRy9g7K4zmRAH/wXw2UxYziX+hZoFIpbW3GmYQqhjx2lDvIRXJI7blhHhTUNWX5f10lFAYOLqA9J859AB1w7ND09+MS3jQgSazCx17h+QZ0qQ6kLSfnXw9PMUOE1Xba9hD1nYj14ryTVj9jrFPMFuUfXdb/G9lsDJ+cGvdE2/RMuPfDmEdo04zvZ5fQJJKvS7OyAuYev4Y+JC8MhEr756ITDZ17yq4BEMo/8rNPxZ5Von/8xnvry+8/2C3ep9rZyHtCwpRb6WT6TndV2ddXKhEIneyd1XiOcWPJguHj5vSoMN3mo8k2PvznGauvxBstvpjUSFLQu869/ZQwyMnbQi3wnkJk5CpLXePXn1J9njocJjt8+SKGijmmIAsmYosx8gmmu3H1mvq9Wi0qqWDITMm+J24AZBEPBhwVrjhLZb5MKxylF6JFJJBs= root@example2")
+    .create();
+
+    let keys = provider.ssh_keys().unwrap();
+    assert_ne!(keys, vec![]);
+    assert_eq!(keys.len(), 2);
+
+    assert_eq!(keys[0].options, None);
+    assert_eq!(keys[0].comment, Some("root@example1".to_string()));
+
+    assert_eq!(keys[1].options, None);
+    assert_eq!(keys[1].comment, Some("root@example2".to_string()));
+
+    mockito::reset();
+    provider.ssh_keys().unwrap_err();
+}
+
+#[test]
+fn test_attributes() {
+    let instance_id = "test-instance-id";
+    let hostname = "test-hostname";
+    let regioncode = "test-regioncode";
+
+    let endpoints = maplit::btreemap! {
+        "/hostname" => hostname,
+        "/instanceid" => instance_id,
+        "/region/regioncode" => regioncode,
+    };
+
+    let mut mocks = Vec::with_capacity(endpoints.len());
+    for (endpoint, body) in endpoints {
+        let m = mockito::mock("GET", endpoint)
+            .with_status(200)
+            .with_body(body)
+            .create();
+        mocks.push(m)
+    }
+
+    let attributes = maplit::hashmap! {
+        "VULTR_INSTANCE_ID".to_string() => instance_id.to_string(),
+        "VULTR_HOSTNAME".to_string() => hostname.to_string(),
+        "VULTR_REGION_CODE".to_string() => regioncode.to_string(),
+    };
+
+    let client = crate::retry::Client::try_new()
+        .unwrap()
+        .max_retries(0)
+        .return_on_404(true);
+    let provider = vultr::VultrProvider { client };
+
+    let v = provider.attributes().unwrap();
+    assert_eq!(v, attributes);
+
+    mockito::reset();
+    provider.attributes().unwrap_err();
+}

--- a/src/providers/vultr/mod.rs
+++ b/src/providers/vultr/mod.rs
@@ -1,0 +1,148 @@
+// Copyright 2020 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! vultr provider metadata fetcher
+//! This provider is selected via the platform ID `vultr`.
+//! The metadata endpoint is documented at https://www.vultr.com/metadata/.
+
+#[cfg(test)]
+use mockito;
+use openssh_keys::PublicKey;
+use slog_scope::{error, warn};
+use std::collections::HashMap;
+
+use crate::errors::*;
+use crate::network;
+use crate::providers::MetadataProvider;
+use crate::retry;
+
+#[cfg(test)]
+mod mock_tests;
+
+#[derive(Clone, Debug)]
+pub struct VultrProvider {
+    client: retry::Client,
+}
+
+impl VultrProvider {
+    pub fn try_new() -> Result<VultrProvider> {
+        let client = retry::Client::try_new()?.return_on_404(true);
+
+        Ok(VultrProvider { client })
+    }
+
+    #[cfg(test)]
+    fn endpoint_for(name: &str) -> String {
+        let url = mockito::server_url();
+        format!("{}/{}", url, name)
+    }
+
+    #[cfg(not(test))]
+    fn endpoint_for(name: &str) -> String {
+        format!("http://169.254.169.254/v1/{}", name)
+    }
+
+    fn fetch_attribute(
+        &self,
+        map: &mut HashMap<String, String>,
+        key: &str,
+        endpoint: &str,
+    ) -> Result<()> {
+        let content: Option<String> = self
+            .client
+            .get(retry::Raw, Self::endpoint_for(endpoint))
+            .send()?;
+
+        if let Some(value) = content {
+            if !value.is_empty() {
+                map.insert(key.to_string(), value);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn fetch_ssh_keys(&self) -> Result<Vec<String>> {
+        let entries: Option<String> = self
+            .client
+            .get(retry::Raw, VultrProvider::endpoint_for("public-keys"))
+            .send()?;
+        let keys_list = entries.unwrap_or_default();
+
+        let mut keys = Vec::new();
+        for key in keys_list.lines() {
+            let key = key.to_string();
+            keys.push(key)
+        }
+
+        Ok(keys)
+    }
+
+    fn fetch_hostname(&self) -> Result<Option<String>> {
+        let value: Option<String> = self
+            .client
+            .get(retry::Raw, VultrProvider::endpoint_for("hostname"))
+            .send()?;
+
+        let hostname = value.unwrap_or_default();
+        if hostname.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(hostname))
+    }
+}
+
+impl MetadataProvider for VultrProvider {
+    fn attributes(&self) -> Result<HashMap<String, String>> {
+        let mut out = HashMap::with_capacity(3);
+
+        self.fetch_attribute(&mut out, "VULTR_HOSTNAME", "hostname")?;
+        self.fetch_attribute(&mut out, "VULTR_INSTANCE_ID", "instanceid")?;
+        self.fetch_attribute(&mut out, "VULTR_REGION_CODE", "region/regioncode")?;
+
+        Ok(out)
+    }
+
+    fn hostname(&self) -> Result<Option<String>> {
+        self.fetch_hostname()
+    }
+
+    fn ssh_keys(&self) -> Result<Vec<PublicKey>> {
+        let keys = self.fetch_ssh_keys()?;
+        let mut out = Vec::with_capacity(keys.len());
+        for key in keys {
+            match PublicKey::parse(&key) {
+                Ok(pk) => out.push(pk),
+                Err(e) => error!("failed to parse SSH Public Key: {}", e),
+            };
+        }
+
+        Ok(out)
+    }
+
+    fn networks(&self) -> Result<Vec<network::Interface>> {
+        Ok(vec![])
+    }
+
+    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
+        warn!("virtual network devices metadata requested, but not supported on this platform");
+        Ok(vec![])
+    }
+
+    fn boot_checkin(&self) -> Result<()> {
+        warn!("boot check-in requested, but not supported on this platform");
+        Ok(())
+    }
+}


### PR DESCRIPTION
This adds fetching attributes and ssh keys from vultr, and tests via mockito.

Fixes https://github.com/coreos/afterburn/issues/343