### PR TITLE
Release 4.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "afterburn"
-version = "4.4.2-alpha.0"
+version = "4.4.2"
 dependencies = [
  "base64 0.12.3",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "afterburn"
-version = "4.4.2"
+version = "4.4.3-alpha.0"
 dependencies = [
  "base64 0.12.3",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml"]
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.4.2-alpha.0"
+version = "4.4.2"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml"]
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.4.2"
+version = "4.4.3-alpha.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Changes:
 * providers/azure: do not fail on keyless instances
 * providers/vmware: fix CPU detection (vmw_backdoor 0.1.3 bugfix)
 * providers: mark vagrant-virtualbox as legacy
 * github: release checklist cleanups
