### PR TITLE
providers: add an AzureStack stub

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -17,6 +17,7 @@ use crate::providers;
 use crate::providers::aliyun::AliyunProvider;
 use crate::providers::aws::AwsProvider;
 use crate::providers::azure::Azure;
+use crate::providers::azurestack::AzureStack;
 use crate::providers::cloudstack::configdrive::ConfigDrive;
 use crate::providers::cloudstack::network::CloudstackNetwork;
 use crate::providers::digitalocean::DigitalOceanProvider;
@@ -48,6 +49,7 @@ pub fn fetch_metadata(provider: &str) -> errors::Result<Box<dyn providers::Metad
         #[cfg(not(feature = "cl-legacy"))]
         "aws" => box_result!(AwsProvider::try_new()?),
         "azure" => box_result!(Azure::try_new()?),
+        "azurestack" => box_result!(AzureStack::new()),
         "cloudstack-metadata" => box_result!(CloudstackNetwork::try_new()?),
         "cloudstack-configdrive" => box_result!(ConfigDrive::try_new()?),
         "digitalocean" => box_result!(DigitalOceanProvider::try_new()?),

--- a/src/providers/aliyun/mod.rs
+++ b/src/providers/aliyun/mod.rs
@@ -6,11 +6,10 @@
 #[cfg(test)]
 use mockito;
 use openssh_keys::PublicKey;
-use slog_scope::{error, warn};
+use slog_scope::error;
 use std::collections::{BTreeSet, HashMap};
 
 use crate::errors::*;
-use crate::network;
 use crate::providers::MetadataProvider;
 use crate::retry;
 
@@ -171,19 +170,5 @@ impl MetadataProvider for AliyunProvider {
         }
 
         Ok(out)
-    }
-
-    fn networks(&self) -> Result<Vec<network::Interface>> {
-        Ok(vec![])
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn boot_checkin(&self) -> Result<()> {
-        warn!("boot check-in requested, but not supported on this platform");
-        Ok(())
     }
 }

--- a/src/providers/aws/mod.rs
+++ b/src/providers/aws/mod.rs
@@ -25,7 +25,6 @@ use serde_derive::Deserialize;
 use slog_scope::warn;
 
 use crate::errors::*;
-use crate::network;
 use crate::providers::MetadataProvider;
 use crate::retry;
 
@@ -233,19 +232,5 @@ impl MetadataProvider for AwsProvider {
                 })
                 .collect::<Result<Vec<_>>>()
         })?
-    }
-
-    fn networks(&self) -> Result<Vec<network::Interface>> {
-        Ok(vec![])
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn boot_checkin(&self) -> Result<()> {
-        warn!("boot check-in requested, but not supported on this platform");
-        Ok(())
     }
 }

--- a/src/providers/azure/mod.rs
+++ b/src/providers/azure/mod.rs
@@ -27,7 +27,6 @@ use slog_scope::warn;
 
 use self::crypto::x509;
 use crate::errors::*;
-use crate::network;
 use crate::providers::MetadataProvider;
 use crate::retry;
 
@@ -503,15 +502,6 @@ impl MetadataProvider for Azure {
 
         let key = self.get_ssh_pubkey(certs_endpoint)?;
         Ok(vec![key])
-    }
-
-    fn networks(&self) -> Result<Vec<network::Interface>> {
-        Ok(vec![])
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
     }
 
     fn boot_checkin(&self) -> Result<()> {

--- a/src/providers/azurestack/mod.rs
+++ b/src/providers/azurestack/mod.rs
@@ -1,0 +1,33 @@
+// Copyright 2020 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is a stub provider. Right now the AzureStack provider does
+// asbolutely nothing interesting.
+
+//! azurestack/azurestack metadata fetcher
+use crate::providers::MetadataProvider;
+
+use slog_scope::debug;
+
+#[derive(Clone, Copy, Debug)]
+pub struct AzureStack;
+
+impl AzureStack {
+    pub fn new() -> Self {
+        debug!("azure stack provider is a noop stub");
+        Self
+    }
+}
+
+impl MetadataProvider for AzureStack{}

--- a/src/providers/cloudstack/configdrive.rs
+++ b/src/providers/cloudstack/configdrive.rs
@@ -6,11 +6,10 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use openssh_keys::PublicKey;
-use slog_scope::{error, warn};
+use slog_scope::error;
 use tempfile::TempDir;
 
 use crate::errors::*;
-use crate::network;
 use crate::providers::MetadataProvider;
 
 const CONFIG_DRIVE_LABEL_1: &str = "config-2";
@@ -124,26 +123,8 @@ impl MetadataProvider for ConfigDrive {
         Ok(out)
     }
 
-    fn hostname(&self) -> Result<Option<String>> {
-        Ok(None)
-    }
-
     fn ssh_keys(&self) -> Result<Vec<PublicKey>> {
         self.fetch_publickeys()
-    }
-
-    fn networks(&self) -> Result<Vec<network::Interface>> {
-        Ok(vec![])
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn boot_checkin(&self) -> Result<()> {
-        warn!("boot check-in requested, but not supported on this platform");
-        Ok(())
     }
 }
 

--- a/src/providers/cloudstack/network.rs
+++ b/src/providers/cloudstack/network.rs
@@ -4,10 +4,8 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 
 use openssh_keys::PublicKey;
-use slog_scope::warn;
 
 use crate::errors::*;
-use crate::network;
 use crate::providers::MetadataProvider;
 use crate::retry;
 use crate::util;
@@ -93,19 +91,5 @@ impl MetadataProvider for CloudstackNetwork {
         } else {
             Ok(vec![])
         }
-    }
-
-    fn networks(&self) -> Result<Vec<network::Interface>> {
-        Ok(vec![])
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn boot_checkin(&self) -> Result<()> {
-        warn!("boot check-in requested, but not supported on this platform");
-        Ok(())
     }
 }

--- a/src/providers/digitalocean/mod.rs
+++ b/src/providers/digitalocean/mod.rs
@@ -22,7 +22,6 @@ use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 use openssh_keys::PublicKey;
 use pnet_base::MacAddr;
 use serde_derive::Deserialize;
-use slog_scope::warn;
 
 use crate::errors::*;
 use crate::network;
@@ -292,15 +291,5 @@ impl MetadataProvider for DigitalOceanProvider {
 
     fn networks(&self) -> Result<Vec<network::Interface>> {
         self.parse_network()
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn boot_checkin(&self) -> Result<()> {
-        warn!("boot check-in requested, but not supported on this platform");
-        Ok(())
     }
 }

--- a/src/providers/exoscale/mod.rs
+++ b/src/providers/exoscale/mod.rs
@@ -19,10 +19,8 @@
 use std::collections::HashMap;
 
 use openssh_keys::PublicKey;
-use slog_scope::warn;
 
 use crate::errors::*;
-use crate::network;
 use crate::providers::MetadataProvider;
 use crate::retry;
 
@@ -105,19 +103,5 @@ impl MetadataProvider for ExoscaleProvider {
         Ok(keys
             .map(|s| PublicKey::read_keys(s.as_bytes()))
             .unwrap_or_else(|| Ok(vec![]))?)
-    }
-
-    fn networks(&self) -> Result<Vec<network::Interface>> {
-        Ok(vec![])
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn boot_checkin(&self) -> Result<()> {
-        warn!("boot check-in requested, but not supported on this platform");
-        Ok(())
     }
 }

--- a/src/providers/gcp/mod.rs
+++ b/src/providers/gcp/mod.rs
@@ -18,11 +18,9 @@
 use mockito;
 use openssh_keys::PublicKey;
 use reqwest::header::{HeaderName, HeaderValue};
-use slog_scope::warn;
 use std::collections::HashMap;
 
 use crate::errors::*;
-use crate::network;
 use crate::providers::MetadataProvider;
 use crate::retry;
 
@@ -188,19 +186,5 @@ impl MetadataProvider for GcpProvider {
         }
 
         Ok(out)
-    }
-
-    fn networks(&self) -> Result<Vec<network::Interface>> {
-        Ok(vec![])
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn boot_checkin(&self) -> Result<()> {
-        warn!("boot check-in requested, but not supported on this platform");
-        Ok(())
     }
 }

--- a/src/providers/ibmcloud/mod.rs
+++ b/src/providers/ibmcloud/mod.rs
@@ -15,12 +15,9 @@ use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 
-use openssh_keys::PublicKey;
-use slog_scope::warn;
 use tempfile::TempDir;
 
 use crate::errors::*;
-use crate::network;
 use crate::providers::MetadataProvider;
 
 const CONFIG_DRIVE_LABEL: &str = "cidata";
@@ -125,26 +122,6 @@ impl MetadataProvider for IBMGen2Provider {
         let metadata = self.read_metadata()?;
         let hostname = metadata.get("local-hostname").map(String::from);
         Ok(hostname)
-    }
-
-    fn ssh_keys(&self) -> Result<Vec<PublicKey>> {
-        warn!("cloud SSH keys requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn networks(&self) -> Result<Vec<network::Interface>> {
-        warn!("network metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn boot_checkin(&self) -> Result<()> {
-        warn!("boot check-in requested, but not supported on this platform");
-        Ok(())
     }
 }
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -26,6 +26,7 @@
 pub mod aliyun;
 pub mod aws;
 pub mod azure;
+pub mod azurestack;
 pub mod cloudstack;
 pub mod digitalocean;
 pub mod exoscale;
@@ -195,11 +196,28 @@ fn write_ssh_keys(user: User, ssh_keys: Vec<PublicKey>) -> Result<()> {
 }
 
 pub trait MetadataProvider {
-    fn attributes(&self) -> Result<HashMap<String, String>>;
-    fn hostname(&self) -> Result<Option<String>>;
-    fn ssh_keys(&self) -> Result<Vec<PublicKey>>;
-    fn networks(&self) -> Result<Vec<network::Interface>>;
-    fn boot_checkin(&self) -> Result<()>;
+    fn attributes(&self) -> Result<HashMap<String, String>> {
+        let attributes = maplit::hashmap! { };
+        Ok(attributes)
+    }
+
+    fn hostname(&self) -> Result<Option<String>> {
+        Ok(None)
+    }
+
+    fn ssh_keys(&self) -> Result<Vec<PublicKey>> {
+        warn!("ssh-keys requested, but not supported on this platform");
+        Ok(vec![])
+    }
+
+    fn networks(&self) -> Result<Vec<network::Interface>> {
+        Ok(vec![])
+    }
+
+    fn boot_checkin(&self) -> Result<()> {
+        warn!("boot check-in requested, but not supported on this platform");
+        Ok(())
+    }
 
     /// Return a list of virtual network devices for this machine.
     ///
@@ -207,7 +225,9 @@ pub trait MetadataProvider {
     /// configuration fragments.
     ///
     /// netdev: https://www.freedesktop.org/software/systemd/man/systemd.netdev.html
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>>;
+    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
+        Ok(vec![])
+    }
 
     /// Return custom initrd network kernel arguments, if any.
     fn rd_network_kargs(&self) -> Result<Option<String>> {

--- a/src/providers/openstack/network.rs
+++ b/src/providers/openstack/network.rs
@@ -3,10 +3,8 @@
 use std::collections::HashMap;
 
 use openssh_keys::PublicKey;
-use slog_scope::warn;
 
 use crate::errors::*;
-use crate::network;
 use crate::providers::MetadataProvider;
 use crate::retry;
 
@@ -96,19 +94,5 @@ impl MetadataProvider for OpenstackProvider {
         }
 
         Ok(out)
-    }
-
-    fn networks(&self) -> Result<Vec<network::Interface>> {
-        Ok(vec![])
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn boot_checkin(&self) -> Result<()> {
-        warn!("boot check-in requested, but not supported on this platform");
-        Ok(())
     }
 }

--- a/src/providers/vagrant_virtualbox/mod.rs
+++ b/src/providers/vagrant_virtualbox/mod.rs
@@ -79,25 +79,7 @@ impl MetadataProvider for VagrantVirtualboxProvider {
         Ok(attributes)
     }
 
-    fn hostname(&self) -> Result<Option<String>> {
-        Ok(None)
-    }
-
     fn ssh_keys(&self) -> Result<Vec<PublicKey>> {
         Ok(vec![])
-    }
-
-    fn networks(&self) -> Result<Vec<network::Interface>> {
-        Ok(vec![])
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn boot_checkin(&self) -> Result<()> {
-        warn!("boot check-in requested, but not supported on this platform");
-        Ok(())
     }
 }

--- a/src/providers/vmware/mod.rs
+++ b/src/providers/vmware/mod.rs
@@ -2,11 +2,7 @@
 
 use std::collections::HashMap;
 
-use openssh_keys::PublicKey;
-use slog_scope::warn;
-
 use crate::errors::*;
-use crate::network;
 use crate::providers::MetadataProvider;
 
 /// VMware provider.
@@ -30,29 +26,7 @@ impl MetadataProvider for VmwareProvider {
         Ok(HashMap::new())
     }
 
-    fn hostname(&self) -> Result<Option<String>> {
-        Ok(None)
-    }
-
-    fn ssh_keys(&self) -> Result<Vec<PublicKey>> {
-        Ok(vec![])
-    }
-
-    fn networks(&self) -> Result<Vec<network::Interface>> {
-        Ok(vec![])
-    }
-
     fn rd_network_kargs(&self) -> Result<Option<String>> {
         Ok(self.guestinfo_net_kargs.clone())
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn boot_checkin(&self) -> Result<()> {
-        warn!("boot check-in requested, but not supported on this platform");
-        Ok(())
     }
 }

--- a/src/providers/vultr/mod.rs
+++ b/src/providers/vultr/mod.rs
@@ -19,11 +19,10 @@
 #[cfg(test)]
 use mockito;
 use openssh_keys::PublicKey;
-use slog_scope::{error, warn};
+use slog_scope::error;
 use std::collections::HashMap;
 
 use crate::errors::*;
-use crate::network;
 use crate::providers::MetadataProvider;
 use crate::retry;
 
@@ -130,19 +129,5 @@ impl MetadataProvider for VultrProvider {
         }
 
         Ok(out)
-    }
-
-    fn networks(&self) -> Result<Vec<network::Interface>> {
-        Ok(vec![])
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn boot_checkin(&self) -> Result<()> {
-        warn!("boot check-in requested, but not supported on this platform");
-        Ok(())
     }
 }


### PR DESCRIPTION
Stub out AzureStack wire-framing in anticipation of working on AzureStack in the near future. This stub out should allow exploration on the AzureStack platform. 

As a platform AzureStack does not provide either a meta-data service nor does it provide a useful OVF XML the utility of Afterburn is a pretty much a noop for AzureStack.

Signed-off-by: Ben Howard <ben.howard@redhat.com>