### PR TITLE
azure: rework ready-state posting

### DIFF
--- a/src/providers/azure/goalstate.rs
+++ b/src/providers/azure/goalstate.rs
@@ -1,0 +1,120 @@
+//! Logic to interact with WireServer `goalstate` endpoint.
+
+use crate::errors::*;
+use serde_derive::Deserialize;
+
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct GoalState {
+    #[serde(rename = "Container")]
+    pub container: Container,
+    #[serde(rename = "Incarnation")]
+    incarnation: String,
+}
+
+impl GoalState {
+    /// Return the certificates endpoint (if any).
+    pub(crate) fn certs_endpoint(&self) -> Option<String> {
+        let role = match self.container.role_instance_list.role_instances.get(0) {
+            Some(r) => r,
+            None => return None,
+        };
+
+        role.configuration.certificates.clone()
+    }
+
+    /// Return this instance `ContainerId`.
+    pub(crate) fn container_id(&self) -> &str {
+        &self.container.container_id
+    }
+
+    /// Return this instance `InstanceId`.
+    pub(crate) fn instance_id(&self) -> Result<&str> {
+        Ok(&self
+            .container
+            .role_instance_list
+            .role_instances
+            .get(0)
+            .ok_or_else(|| "empty RoleInstanceList".to_string())?
+            .instance_id)
+    }
+
+    /// Return the current `Incarnation` count for this instance.
+    pub(crate) fn incarnation(&self) -> &str {
+        &self.incarnation
+    }
+}
+
+#[derive(Debug, Deserialize, Clone, Default)]
+pub(crate) struct Container {
+    #[serde(rename = "ContainerId")]
+    pub container_id: String,
+    #[serde(rename = "RoleInstanceList")]
+    pub role_instance_list: RoleInstanceList,
+}
+
+#[derive(Debug, Deserialize, Clone, Default)]
+pub(crate) struct RoleInstanceList {
+    #[serde(rename = "RoleInstance", default)]
+    pub role_instances: Vec<RoleInstance>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct RoleInstance {
+    #[serde(rename = "Configuration")]
+    pub configuration: Configuration,
+    #[serde(rename = "InstanceId")]
+    pub instance_id: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Configuration {
+    #[serde(rename = "Certificates")]
+    pub certificates: Option<String>,
+    #[serde(rename = "SharedConfig", default)]
+    pub shared_config: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct CertificatesFile {
+    #[serde(rename = "Data", default)]
+    pub data: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct SharedConfig {
+    #[serde(rename = "Incarnation")]
+    pub incarnation: Incarnation,
+    #[serde(rename = "Instances")]
+    pub instances: Instances,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Incarnation {
+    pub instance: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Instances {
+    #[serde(rename = "Instance", default)]
+    pub instances: Vec<Instance>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Instance {
+    pub id: String,
+    pub address: String,
+    #[serde(rename = "InputEndpoints")]
+    pub input_endpoints: InputEndpoints,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct InputEndpoints {
+    #[serde(rename = "Endpoint", default)]
+    pub endpoints: Vec<Endpoint>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Endpoint {
+    #[serde(rename = "loadBalancedPublicAddress", default)]
+    pub load_balanced_public_address: String,
+}


### PR DESCRIPTION
This refactors the Azure provider, in order to better report instance
ready-state to the WireServer.
In particular, it looks like the platform expects a matching
`GoalStateIncarnation` to be posted in ready-state requests.
For this reason, this stops caching the goalstate content when creating
the provider. Instead, the goalstate is now fetched just in time,
and the incarnation number is used when posting the ready-state.
This also ensures that on transient errors all the endpoints are retried
long enough.

Closes: https://github.com/coreos/afterburn/issues/459
Closes: https://github.com/coreos/afterburn/issues/461