### PR TITLE
Release 4.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "afterburn"
-version = "4.5.0"
+version = "4.5.1-alpha.0"
 dependencies = [
  "base64 0.12.3",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "afterburn"
-version = "4.4.3-alpha.0"
+version = "4.5.0-alpha.0"
 dependencies = [
  "base64 0.12.3",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "afterburn"
-version = "4.5.0-alpha.0"
+version = "4.5.0"
 dependencies = [
  "base64 0.12.3",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml"]
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.4.3-alpha.0"
+version = "4.5.0-alpha.0"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml"]
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.5.0-alpha.0"
+version = "4.5.0"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml"]
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.5.0"
+version = "4.5.1-alpha.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Changes:
 * providers: add a new `openstack` platform
 * openstack: use config-drive by default and metadata API as fallback
 * azure: rework ready-state posting
 * azure: log a warning on network failure if non-root
 * providers: add a new `vultr` platform
 * systemd: activate relevant services on Vultr
