### PR TITLE
providers: move trait noops into MetadataProvider

### DIFF
--- a/src/providers/aliyun/mod.rs
+++ b/src/providers/aliyun/mod.rs
@@ -6,11 +6,10 @@
 #[cfg(test)]
 use mockito;
 use openssh_keys::PublicKey;
-use slog_scope::{error, warn};
+use slog_scope::error;
 use std::collections::{BTreeSet, HashMap};
 
 use crate::errors::*;
-use crate::network;
 use crate::providers::MetadataProvider;
 use crate::retry;
 
@@ -171,19 +170,5 @@ impl MetadataProvider for AliyunProvider {
         }
 
         Ok(out)
-    }
-
-    fn networks(&self) -> Result<Vec<network::Interface>> {
-        Ok(vec![])
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn boot_checkin(&self) -> Result<()> {
-        warn!("boot check-in requested, but not supported on this platform");
-        Ok(())
     }
 }

--- a/src/providers/aws/mod.rs
+++ b/src/providers/aws/mod.rs
@@ -25,7 +25,6 @@ use serde_derive::Deserialize;
 use slog_scope::warn;
 
 use crate::errors::*;
-use crate::network;
 use crate::providers::MetadataProvider;
 use crate::retry;
 
@@ -233,19 +232,5 @@ impl MetadataProvider for AwsProvider {
                 })
                 .collect::<Result<Vec<_>>>()
         })?
-    }
-
-    fn networks(&self) -> Result<Vec<network::Interface>> {
-        Ok(vec![])
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn boot_checkin(&self) -> Result<()> {
-        warn!("boot check-in requested, but not supported on this platform");
-        Ok(())
     }
 }

--- a/src/providers/azure/mod.rs
+++ b/src/providers/azure/mod.rs
@@ -28,7 +28,6 @@ use slog_scope::warn;
 
 use self::crypto::x509;
 use crate::errors::*;
-use crate::network;
 use crate::providers::MetadataProvider;
 use crate::retry;
 use nix::unistd::Uid;
@@ -425,15 +424,6 @@ impl MetadataProvider for Azure {
 
         let key = self.get_ssh_pubkey(certs_endpoint)?;
         Ok(vec![key])
-    }
-
-    fn networks(&self) -> Result<Vec<network::Interface>> {
-        Ok(vec![])
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
     }
 
     fn boot_checkin(&self) -> Result<()> {

--- a/src/providers/cloudstack/configdrive.rs
+++ b/src/providers/cloudstack/configdrive.rs
@@ -6,11 +6,10 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use openssh_keys::PublicKey;
-use slog_scope::{error, warn};
+use slog_scope::error;
 use tempfile::TempDir;
 
 use crate::errors::*;
-use crate::network;
 use crate::providers::MetadataProvider;
 
 const CONFIG_DRIVE_LABEL_1: &str = "config-2";
@@ -124,26 +123,8 @@ impl MetadataProvider for ConfigDrive {
         Ok(out)
     }
 
-    fn hostname(&self) -> Result<Option<String>> {
-        Ok(None)
-    }
-
     fn ssh_keys(&self) -> Result<Vec<PublicKey>> {
         self.fetch_publickeys()
-    }
-
-    fn networks(&self) -> Result<Vec<network::Interface>> {
-        Ok(vec![])
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn boot_checkin(&self) -> Result<()> {
-        warn!("boot check-in requested, but not supported on this platform");
-        Ok(())
     }
 }
 

--- a/src/providers/cloudstack/network.rs
+++ b/src/providers/cloudstack/network.rs
@@ -4,10 +4,8 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 
 use openssh_keys::PublicKey;
-use slog_scope::warn;
 
 use crate::errors::*;
-use crate::network;
 use crate::providers::MetadataProvider;
 use crate::retry;
 use crate::util;
@@ -93,19 +91,5 @@ impl MetadataProvider for CloudstackNetwork {
         } else {
             Ok(vec![])
         }
-    }
-
-    fn networks(&self) -> Result<Vec<network::Interface>> {
-        Ok(vec![])
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn boot_checkin(&self) -> Result<()> {
-        warn!("boot check-in requested, but not supported on this platform");
-        Ok(())
     }
 }

--- a/src/providers/digitalocean/mod.rs
+++ b/src/providers/digitalocean/mod.rs
@@ -22,7 +22,6 @@ use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 use openssh_keys::PublicKey;
 use pnet_base::MacAddr;
 use serde_derive::Deserialize;
-use slog_scope::warn;
 
 use crate::errors::*;
 use crate::network;
@@ -292,15 +291,5 @@ impl MetadataProvider for DigitalOceanProvider {
 
     fn networks(&self) -> Result<Vec<network::Interface>> {
         self.parse_network()
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn boot_checkin(&self) -> Result<()> {
-        warn!("boot check-in requested, but not supported on this platform");
-        Ok(())
     }
 }

--- a/src/providers/exoscale/mod.rs
+++ b/src/providers/exoscale/mod.rs
@@ -19,10 +19,8 @@
 use std::collections::HashMap;
 
 use openssh_keys::PublicKey;
-use slog_scope::warn;
 
 use crate::errors::*;
-use crate::network;
 use crate::providers::MetadataProvider;
 use crate::retry;
 
@@ -105,19 +103,5 @@ impl MetadataProvider for ExoscaleProvider {
         Ok(keys
             .map(|s| PublicKey::read_keys(s.as_bytes()))
             .unwrap_or_else(|| Ok(vec![]))?)
-    }
-
-    fn networks(&self) -> Result<Vec<network::Interface>> {
-        Ok(vec![])
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn boot_checkin(&self) -> Result<()> {
-        warn!("boot check-in requested, but not supported on this platform");
-        Ok(())
     }
 }

--- a/src/providers/gcp/mod.rs
+++ b/src/providers/gcp/mod.rs
@@ -18,11 +18,9 @@
 use mockito;
 use openssh_keys::PublicKey;
 use reqwest::header::{HeaderName, HeaderValue};
-use slog_scope::warn;
 use std::collections::HashMap;
 
 use crate::errors::*;
-use crate::network;
 use crate::providers::MetadataProvider;
 use crate::retry;
 
@@ -188,19 +186,5 @@ impl MetadataProvider for GcpProvider {
         }
 
         Ok(out)
-    }
-
-    fn networks(&self) -> Result<Vec<network::Interface>> {
-        Ok(vec![])
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn boot_checkin(&self) -> Result<()> {
-        warn!("boot check-in requested, but not supported on this platform");
-        Ok(())
     }
 }

--- a/src/providers/ibmcloud/mod.rs
+++ b/src/providers/ibmcloud/mod.rs
@@ -15,12 +15,9 @@ use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 
-use openssh_keys::PublicKey;
-use slog_scope::warn;
 use tempfile::TempDir;
 
 use crate::errors::*;
-use crate::network;
 use crate::providers::MetadataProvider;
 
 const CONFIG_DRIVE_LABEL: &str = "cidata";
@@ -125,26 +122,6 @@ impl MetadataProvider for IBMGen2Provider {
         let metadata = self.read_metadata()?;
         let hostname = metadata.get("local-hostname").map(String::from);
         Ok(hostname)
-    }
-
-    fn ssh_keys(&self) -> Result<Vec<PublicKey>> {
-        warn!("cloud SSH keys requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn networks(&self) -> Result<Vec<network::Interface>> {
-        warn!("network metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn boot_checkin(&self) -> Result<()> {
-        warn!("boot check-in requested, but not supported on this platform");
-        Ok(())
     }
 }
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -195,11 +195,27 @@ fn write_ssh_keys(user: User, ssh_keys: Vec<PublicKey>) -> Result<()> {
 }
 
 pub trait MetadataProvider {
-    fn attributes(&self) -> Result<HashMap<String, String>>;
-    fn hostname(&self) -> Result<Option<String>>;
-    fn ssh_keys(&self) -> Result<Vec<PublicKey>>;
-    fn networks(&self) -> Result<Vec<network::Interface>>;
-    fn boot_checkin(&self) -> Result<()>;
+    fn attributes(&self) -> Result<HashMap<String, String>> {
+        Ok(HashMap::new())
+    }
+
+    fn hostname(&self) -> Result<Option<String>> {
+        Ok(None)
+    }
+
+    fn ssh_keys(&self) -> Result<Vec<PublicKey>> {
+        warn!("ssh-keys requested, but not supported on this platform");
+        Ok(vec![])
+    }
+
+    fn networks(&self) -> Result<Vec<network::Interface>> {
+        Ok(vec![])
+    }
+
+    fn boot_checkin(&self) -> Result<()> {
+        warn!("boot check-in requested, but not supported on this platform");
+        Ok(())
+    }
 
     /// Return a list of virtual network devices for this machine.
     ///
@@ -207,7 +223,9 @@ pub trait MetadataProvider {
     /// configuration fragments.
     ///
     /// netdev: https://www.freedesktop.org/software/systemd/man/systemd.netdev.html
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>>;
+    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
+        Ok(vec![])
+    }
 
     /// Return custom initrd network kernel arguments, if any.
     fn rd_network_kargs(&self) -> Result<Option<String>> {

--- a/src/providers/openstack/network.rs
+++ b/src/providers/openstack/network.rs
@@ -3,10 +3,8 @@
 use std::collections::HashMap;
 
 use openssh_keys::PublicKey;
-use slog_scope::warn;
 
 use crate::errors::*;
-use crate::network;
 use crate::providers::MetadataProvider;
 use crate::retry;
 
@@ -102,19 +100,5 @@ impl MetadataProvider for OpenstackProviderNetwork {
         }
 
         Ok(out)
-    }
-
-    fn networks(&self) -> Result<Vec<network::Interface>> {
-        Ok(vec![])
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn boot_checkin(&self) -> Result<()> {
-        warn!("boot check-in requested, but not supported on this platform");
-        Ok(())
     }
 }

--- a/src/providers/vagrant_virtualbox/mod.rs
+++ b/src/providers/vagrant_virtualbox/mod.rs
@@ -19,11 +19,9 @@ use std::net::IpAddr;
 use std::thread;
 use std::time::Duration;
 
-use openssh_keys::PublicKey;
-use slog_scope::{info, warn};
+use slog_scope::info;
 
 use crate::errors::*;
-use crate::network;
 use crate::providers::MetadataProvider;
 
 #[derive(Clone, Copy, Debug)]
@@ -77,27 +75,5 @@ impl MetadataProvider for VagrantVirtualboxProvider {
         };
 
         Ok(attributes)
-    }
-
-    fn hostname(&self) -> Result<Option<String>> {
-        Ok(None)
-    }
-
-    fn ssh_keys(&self) -> Result<Vec<PublicKey>> {
-        Ok(vec![])
-    }
-
-    fn networks(&self) -> Result<Vec<network::Interface>> {
-        Ok(vec![])
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn boot_checkin(&self) -> Result<()> {
-        warn!("boot check-in requested, but not supported on this platform");
-        Ok(())
     }
 }

--- a/src/providers/vmware/mod.rs
+++ b/src/providers/vmware/mod.rs
@@ -2,11 +2,7 @@
 
 use std::collections::HashMap;
 
-use openssh_keys::PublicKey;
-use slog_scope::warn;
-
 use crate::errors::*;
-use crate::network;
 use crate::providers::MetadataProvider;
 
 /// VMware provider.
@@ -30,29 +26,7 @@ impl MetadataProvider for VmwareProvider {
         Ok(HashMap::new())
     }
 
-    fn hostname(&self) -> Result<Option<String>> {
-        Ok(None)
-    }
-
-    fn ssh_keys(&self) -> Result<Vec<PublicKey>> {
-        Ok(vec![])
-    }
-
-    fn networks(&self) -> Result<Vec<network::Interface>> {
-        Ok(vec![])
-    }
-
     fn rd_network_kargs(&self) -> Result<Option<String>> {
         Ok(self.guestinfo_net_kargs.clone())
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn boot_checkin(&self) -> Result<()> {
-        warn!("boot check-in requested, but not supported on this platform");
-        Ok(())
     }
 }

--- a/src/providers/vultr/mod.rs
+++ b/src/providers/vultr/mod.rs
@@ -19,11 +19,10 @@
 #[cfg(test)]
 use mockito;
 use openssh_keys::PublicKey;
-use slog_scope::{error, warn};
+use slog_scope::error;
 use std::collections::HashMap;
 
 use crate::errors::*;
-use crate::network;
 use crate::providers::MetadataProvider;
 use crate::retry;
 
@@ -130,19 +129,5 @@ impl MetadataProvider for VultrProvider {
         }
 
         Ok(out)
-    }
-
-    fn networks(&self) -> Result<Vec<network::Interface>> {
-        Ok(vec![])
-    }
-
-    fn virtual_network_devices(&self) -> Result<Vec<network::VirtualNetDev>> {
-        warn!("virtual network devices metadata requested, but not supported on this platform");
-        Ok(vec![])
-    }
-
-    fn boot_checkin(&self) -> Result<()> {
-        warn!("boot check-in requested, but not supported on this platform");
-        Ok(())
     }
 }


### PR DESCRIPTION
Generally in all the providers there are trait(s) that are not
implemented or used by the provider; they all had various methods of
noop'ing. This change unifies the noop handling by implementing the
required fn in the trait definition itself.

Signed-off-by: Ben Howard <ben.howard@redhat.com>