### PR TITLE
systemd: add afterburn-sshkeys.target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ units = $(addprefix systemd/, \
 	afterburn-checkin.service \
 	afterburn-firstboot-checkin.service \
 	afterburn.service \
-	afterburn-sshkeys@.service)
+	afterburn-sshkeys@.service \
+	afterburn-sshkeys.target)
 
 .PHONY: all
 all: $(units)

--- a/systemd/afterburn-sshkeys.target
+++ b/systemd/afterburn-sshkeys.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=Synchronize afterburn-sshkeys@.service template instances
+
+[Install]
+RequiredBy=multi-user.target

--- a/systemd/afterburn-sshkeys@.service.in
+++ b/systemd/afterburn-sshkeys@.service.in
@@ -21,4 +21,4 @@ ExecStart=/usr/bin/afterburn ${AFTERBURN_OPT_PROVIDER} --ssh-keys=%i
 
 [Install]
 DefaultInstance=@DEFAULT_INSTANCE@
-RequiredBy=multi-user.target
+RequiredBy=afterburn-sshkeys.target


### PR DESCRIPTION
this adds `afterburn-sshkeys.target`, and has the `afterburn-sshkeys@.service`
template specify `RequiredBy=afterburn-sshkeys.target` in the [Install]
section.

Fixes https://github.com/coreos/afterburn/issues/417