### PR TITLE
Release 4.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "afterburn"
-version = "4.5.1-alpha.0"
+version = "4.5.1"
 dependencies = [
  "base64 0.12.3",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "afterburn"
-version = "4.5.1"
+version = "4.5.2-alpha.0"
 dependencies = [
  "base64 0.12.3",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml"]
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.5.1-alpha.0"
+version = "4.5.1"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml"]
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.5.1"
+version = "4.5.2-alpha.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Changes:
 * ibmcloud: add support for SSH keys
 * providers: move trait noops into MetadataProvider
 * systemd: add afterburn-sshkeys.target
 * ci: bump linting toolchain on Travis