### PR TITLE
dracut: run hostname service on aliyun

### DIFF
--- a/dracut/30afterburn/afterburn-hostname.service
+++ b/dracut/30afterburn/afterburn-hostname.service
@@ -3,6 +3,7 @@ Description=Afterburn Hostname
 # These platforms do not provide the hostname via DHCP
 # options, thus it needs to be fetched from the metadata
 # and statically applied on first-boot.
+ConditionKernelCommandLine=|ignition.platform.id=aliyun
 ConditionKernelCommandLine=|ignition.platform.id=azure
 ConditionKernelCommandLine=|ignition.platform.id=digitalocean
 ConditionKernelCommandLine=|ignition.platform.id=exoscale


### PR DESCRIPTION
Unfortunately, Aliyun does not offer the hostname via DHCP. The recommended way to set the hostname without cloud-init is by a custom shell script, see [Customize Linux images](https://www.alibabacloud.com/help/doc-detail/51138.htm?spm=a2c63.p38356.879954.11.15f81541TyNJQ9#concept-nt5-4km-xdb)

Fixes: #482 