### PR TITLE
docs: clarify afterburn.service enablement

### DIFF
--- a/docs/usage/attributes.md
+++ b/docs/usage/attributes.md
@@ -1,6 +1,11 @@
 # Metadata attributes
 
 Afterburn can consume cloud-specific metadata and serialize instance attributes into an environment file (e.g. `/run/metadata/afterburn`), which can then be consumed by systemd service units via `EnvironmentFile=`.
+
+Usually, OS vendors which ship Afterburn do not enable it by default. Therefore, any service
+which wants to make use of Afterburn metadata must explicitly pull it in using e.g.
+`Requires=afterburn.service` and `After=afterburn.service`.
+
 Cloud providers with supported metadata endpoints and their respective attributes are listed below.
 
 * aliyun

--- a/systemd/afterburn.service
+++ b/systemd/afterburn.service
@@ -2,6 +2,7 @@
 # needed by dependent services.
 [Unit]
 Description=Afterburn (Metadata)
+Documentation=https://github.com/coreos/afterburn
 
 [Service]
 Type=oneshot

--- a/systemd/afterburn.service
+++ b/systemd/afterburn.service
@@ -1,3 +1,5 @@
+# Note this unit is normally not enabled by default. It is instead pulled in as
+# needed by dependent services.
 [Unit]
 Description=Afterburn (Metadata)
 


### PR DESCRIPTION
This led to some confusion yesterday in
coreos/fedora-coreos-tracker#626.

We should also have FCOS-specific docs for this, but let's put something
here as well since that's the current recommended upstream stance.