### PR TITLE
sshkeys: activate service on OpenStack

### DIFF
--- a/systemd/afterburn-sshkeys@.service.in
+++ b/systemd/afterburn-sshkeys@.service.in
@@ -11,9 +11,10 @@ ConditionKernelCommandLine=|ignition.platform.id=azure
 ConditionKernelCommandLine=|ignition.platform.id=digitalocean
 ConditionKernelCommandLine=|ignition.platform.id=exoscale
 ConditionKernelCommandLine=|ignition.platform.id=gcp
+ConditionKernelCommandLine=|ignition.platform.id=ibmcloud
+ConditionKernelCommandLine=|ignition.platform.id=openstack
 ConditionKernelCommandLine=|ignition.platform.id=packet
 ConditionKernelCommandLine=|ignition.platform.id=vultr
-ConditionKernelCommandLine=|ignition.platform.id=ibmcloud
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This adds triggering condition to SSH-keys service units on OpenStack.