### PR TITLE
cargo: remove carets from semver requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,42 +25,42 @@ path = "src/main.rs"
 lto = true
 
 [dependencies]
-base64 = "^0.12"
-byteorder = "^1.3"
-cfg-if = "^0.1"
-clap = "^2.33"
-error-chain = { version = "^0.12", default-features = false }
-hostname = "^0.3"
-ipnetwork = "^0.17"
-libsystemd = "^0.2.1"
-mailparse = "^0.13"
-maplit = "^1.0"
-mime = "^0.3"
-nix = "^0.18"
-openssh-keys = "^0.4"
-openssl = "^0.10"
-pnet_base = "^0.26"
-pnet_datalink = "^0.26"
-reqwest = { version = "^0.10", features = [ "blocking" ] }
-serde =  { version = "^1.0", features = [ "derive" ] }
-serde-xml-rs = "^0.4"
-serde_derive = "^1.0"
-serde_json = "^1.0"
-serde_yaml = "^0.8"
-slog-async = "^2.5"
-slog-scope = "^4.3"
-slog-term = "^2.6"
-tempfile = "^3.1"
-update-ssh-keys = { version = "^0.6", optional = true }
-users = "^0.10"
-vmw_backdoor = "^0.2"
+base64 = "0.12"
+byteorder = "1.3"
+cfg-if = "0.1"
+clap = "2.33"
+error-chain = { version = "0.12", default-features = false }
+hostname = "0.3"
+ipnetwork = "0.17"
+libsystemd = "0.2.1"
+mailparse = "0.13"
+maplit = "1.0"
+mime = "0.3"
+nix = "0.18"
+openssh-keys = "0.4"
+openssl = "0.10"
+pnet_base = "0.26"
+pnet_datalink = "0.26"
+reqwest = { version = "0.10", features = [ "blocking" ] }
+serde =  { version = "1.0", features = [ "derive" ] }
+serde-xml-rs = "0.4"
+serde_derive = "1.0"
+serde_json = "1.0"
+serde_yaml = "0.8"
+slog-async = "2.5"
+slog-scope = "4.3"
+slog-term = "2.6"
+tempfile = "3.1"
+update-ssh-keys = { version = "0.6", optional = true }
+users = "0.10"
+vmw_backdoor = "0.2"
 
 [dependencies.slog]
-version = "^2.5"
+version = "2.5"
 features = ["max_level_trace", "release_max_level_info"]
 
 [features]
 cl-legacy = ["update-ssh-keys"]
 
 [dev-dependencies]
-mockito = "^0.27"
+mockito = "0.27"


### PR DESCRIPTION
This removes all carets (`^`) from dependencies, resulting in
semver entries which are semantically equivalent from cargo
point of view.
This repository is starting to accumulate stale dependencies, as
dependabot is having troubles when trying to update them. I think
I'm seeing a pattern where the `^` may be the one thing confusing
the bot, and the changes in here try to verify such theory.

Ref: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-cratesio
Ref: https://github.com/dependabot/dependabot-core/issues/2532