### PR TITLE
systemd/firstboot-checkin: order before first-boot-complete.target

### DIFF
--- a/systemd/afterburn-firstboot-checkin.service
+++ b/systemd/afterburn-firstboot-checkin.service
@@ -2,6 +2,14 @@
 Description=Afterburn (Firstboot Check In)
 ConditionKernelCommandLine=|ignition.platform.id=packet
 ConditionFirstBoot=yes
+# All services which use ConditionFirstBoot=yes should use
+# Before=first-boot-complete.target, which is a target that
+# was introduced in https://github.com/systemd/systemd/issues/4511
+# and hasn't propagated everywhere yet. Once the target propagates
+# everywhere, we can drop the systemd-machine-id-commit.service
+# from the Before= line.
+Before=first-boot-complete.target systemd-machine-id-commit.service
+Wants=first-boot-complete.target
 After=network.target
 After=boot-complete.target
 


### PR DESCRIPTION
Otherwise, it's possible we'll never run if the system is rebooted after
`systemd-machine-id-commit.service` but before this unit.

This will be recommended by systemd starting from:
https://github.com/systemd/systemd/pull/16939