### PR TITLE
Release 4.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "afterburn"
-version = "4.5.2-alpha.0"
+version = "4.5.2"
 dependencies = [
  "base64 0.13.0",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "afterburn"
-version = "4.5.2"
+version = "4.5.3-alpha.0"
 dependencies = [
  "base64 0.13.0",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml"]
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.5.2"
+version = "4.5.3-alpha.0"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore", "/.travis.yml"]
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.5.2-alpha.0"
+version = "4.5.2"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Changes:

- docs: clarify afterburn.service enablement
- docs: Add GitHub Pages support
- sshkeys: activate service on OpenStack
- providers/vmware: allow avoiding iopl permission errors
- cargo: remove carets from semver requirements 
