### PR TITLE
Turn on Afterburn hostname support for GCP

### DIFF
--- a/dracut/30afterburn/afterburn-hostname.service
+++ b/dracut/30afterburn/afterburn-hostname.service
@@ -7,6 +7,7 @@ ConditionKernelCommandLine=|ignition.platform.id=azure
 ConditionKernelCommandLine=|ignition.platform.id=digitalocean
 ConditionKernelCommandLine=|ignition.platform.id=exoscale
 ConditionKernelCommandLine=|ignition.platform.id=vultr
+ConditionKernelCommandLine=|ignition.platform.id=gcp
 
 # We order this service after sysroot has been mounted
 # but before ignition-files stage has run, so ignition can


### PR DESCRIPTION
On GCP the DHCP server send the FQDN as the shortname in DHCP.
So when the code that truncates the hostname in the kubelet runs,
NM gets ornery that it didn't change the hostname and flips it back to the long name

Signed-off-by: Nikita Dubrovskii <nikita@linux.ibm.com>