### PR TITLE
providers/*stack: allow 404 returns on *stack network provider

### DIFF
--- a/src/providers/cloudstack/mock_tests.rs
+++ b/src/providers/cloudstack/mock_tests.rs
@@ -1,0 +1,41 @@
+use crate::providers::cloudstack::network::CloudstackNetwork;
+use crate::providers::MetadataProvider;
+
+#[test]
+fn test_ssh_keys() {
+    let mut provider = CloudstackNetwork::try_new().unwrap();
+    provider.client = provider.client.max_retries(0);
+
+    let key1 = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCsXe6CfHl45kCIzMF92VhDf2NpBWUyS1+IiTtxm5a83mT9730Hb8xim7GYeJu47kiESw2DAN8vNJ/Irg0apZ217ah2rXXjPQuWYSXuEuap8yLBSjqw8exgqVj/kzW+YqmnHASxI13eoFDxTQQGzyqbqowvxu/5gQmDwBmNAa9bT809ziB/qmpS1mD6qyyFDpR23kUwu3TkgAbwMXBDoqK+pdwfaF9uo9XaLHNEH8lD5BZuG2BeDafm2o76DhNSo83MvcCPNXKLxu3BbX/FCMFO6O8RRqony4i91fEV1b8TbXrbJz1bwEYEnJRvmjnqI/389tQFeYvplXR2WdT9PCKyEAG+j8y6XgecIcdTqV/7gFfak1mp2S7mYHZDnXixsn3MjCP/cIxxJVDitKusnj1TdFqtSXl4tqGccbg/5Sqnt/EVSK4bGwwBxv/YmE0P9cbXLxuEVI0JYzgrQvC8TtUgd8kUu2jqi1/Yj9IWm3aFsl/hhh8YwYrv/gm8PV0TxkM= root@example1";
+    let key2 = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDj6FBVgkTt7/DB93VVLk6304Nx7WUjLBJDSCh38zjCimHUpeo9uYDxflfu2N1CLtrSImIKBVP/JRy9g7K4zmRAH/wXw2UxYziX+hZoFIpbW3GmYQqhjx2lDvIRXJI7blhHhTUNWX5f10lFAYOLqA9J859AB1w7ND09+MS3jQgSazCx17h+QZ0qQ6kLSfnXw9PMUOE1Xba9hD1nYj14ryTVj9jrFPMFuUfXdb/G9lsDJ+cGvdE2/RMuPfDmEdo04zvZ5fQJJKvS7OyAuYev4Y+JC8MhEr756ITDZ17yq4BEMo/8rNPxZ5Von/8xnvry+8/2C3ep9rZyHtCwpRb6WT6TndV2ddXKhEIneyd1XiOcWPJguHj5vSoMN3mo8k2PvznGauvxBstvpjUSFLQu869/ZQwyMnbQi3wnkJk5CpLXePXn1J9njocJjt8+SKGijmmIAsmYosx8gmmu3H1mvq9Wi0qqWDITMm+J24AZBEPBhwVrjhLZb5MKxylF6JFJJBs= root@example2";
+
+    let _m = mockito::mock("GET", "/latest/meta-data/public-keys")
+        .with_status(200)
+        .with_body(format!("{}\n{}", key1, key2))
+        .create();
+
+    let keys = provider.ssh_keys().unwrap();
+    assert_eq!(keys.len(), 2);
+    assert_eq!(keys[0].options, None);
+    assert_eq!(keys[0].comment, Some("root@example1".to_string()));
+
+    assert_eq!(keys[1].options, None);
+    assert_eq!(keys[1].comment, Some("root@example2".to_string()));
+
+    mockito::reset();
+    provider.ssh_keys().unwrap_err();
+}
+
+#[test]
+fn test_ssh_keys_404_ok() {
+    let mut provider = CloudstackNetwork::try_new().unwrap();
+    provider.client = provider.client.max_retries(0);
+
+    let _m = mockito::mock("GET", "/latest/meta-data/public-keys")
+        .with_status(404)
+        .create();
+    let v = provider.ssh_keys().unwrap();
+    assert_eq!(v.len(), 0);
+    mockito::reset();
+    provider.ssh_keys().unwrap_err();
+}

--- a/src/providers/cloudstack/mod.rs
+++ b/src/providers/cloudstack/mod.rs
@@ -1,4 +1,6 @@
 //! Metadata fetchers for the cloudstack provider
 
 pub mod configdrive;
+#[cfg(test)]
+mod mock_tests;
 pub mod network;

--- a/src/providers/cloudstack/network.rs
+++ b/src/providers/cloudstack/network.rs
@@ -21,7 +21,7 @@ pub struct CloudstackNetwork {
 impl CloudstackNetwork {
     pub fn try_new() -> Result<CloudstackNetwork> {
         let server_address = CloudstackNetwork::get_dhcp_server_address()?;
-        let client = retry::Client::try_new()?;
+        let client = retry::Client::try_new()?.return_on_404(true);
 
         Ok(CloudstackNetwork {
             server_address,

--- a/src/providers/cloudstack/network.rs
+++ b/src/providers/cloudstack/network.rs
@@ -14,31 +14,35 @@ const SERVER_ADDRESS: &str = "SERVER_ADDRESS";
 
 #[derive(Clone, Debug)]
 pub struct CloudstackNetwork {
-    server_address: IpAddr,
-    client: retry::Client,
+    server_base_url: String,
+    pub(crate) client: retry::Client,
 }
 
 impl CloudstackNetwork {
     pub fn try_new() -> Result<CloudstackNetwork> {
-        let server_address = CloudstackNetwork::get_dhcp_server_address()?;
+        let server_base_url = CloudstackNetwork::get_server_base_url_from_dhcp()?;
         let client = retry::Client::try_new()?.return_on_404(true);
 
         Ok(CloudstackNetwork {
-            server_address,
+            server_base_url,
             client,
         })
     }
 
     fn endpoint_for(&self, key: &str) -> String {
-        format!("http://{}/latest/meta-data/{}", self.server_address, key)
+        format!("{}/latest/meta-data/{}", self.server_base_url, key)
     }
 
-    fn get_dhcp_server_address() -> Result<IpAddr> {
+    fn get_server_base_url_from_dhcp() -> Result<String> {
+        if cfg!(test) {
+            #[cfg(test)]
+            return Ok(mockito::server_url());
+        }
         let server = util::dns_lease_key_lookup(SERVER_ADDRESS)?;
         let ip = server
-            .parse()
+            .parse::<IpAddr>()
             .chain_err(|| format!("failed to parse server ip address: {}", server))?;
-        Ok(IpAddr::V4(ip))
+        Ok(format!("http://{}", ip))
     }
 }
 

--- a/src/providers/openstack/mock_tests.rs
+++ b/src/providers/openstack/mock_tests.rs
@@ -1,0 +1,51 @@
+use crate::providers::openstack::OpenstackProviderNetwork;
+use crate::providers::MetadataProvider;
+use mockito;
+
+#[test]
+fn test_ssh_keys() {
+    let mut provider = OpenstackProviderNetwork::try_new().unwrap();
+    provider.client = provider.client.max_retries(0);
+
+    let key1 = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCsXe6CfHl45kCIzMF92VhDf2NpBWUyS1+IiTtxm5a83mT9730Hb8xim7GYeJu47kiESw2DAN8vNJ/Irg0apZ217ah2rXXjPQuWYSXuEuap8yLBSjqw8exgqVj/kzW+YqmnHASxI13eoFDxTQQGzyqbqowvxu/5gQmDwBmNAa9bT809ziB/qmpS1mD6qyyFDpR23kUwu3TkgAbwMXBDoqK+pdwfaF9uo9XaLHNEH8lD5BZuG2BeDafm2o76DhNSo83MvcCPNXKLxu3BbX/FCMFO6O8RRqony4i91fEV1b8TbXrbJz1bwEYEnJRvmjnqI/389tQFeYvplXR2WdT9PCKyEAG+j8y6XgecIcdTqV/7gFfak1mp2S7mYHZDnXixsn3MjCP/cIxxJVDitKusnj1TdFqtSXl4tqGccbg/5Sqnt/EVSK4bGwwBxv/YmE0P9cbXLxuEVI0JYzgrQvC8TtUgd8kUu2jqi1/Yj9IWm3aFsl/hhh8YwYrv/gm8PV0TxkM= root@example1";
+    let key2 = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDj6FBVgkTt7/DB93VVLk6304Nx7WUjLBJDSCh38zjCimHUpeo9uYDxflfu2N1CLtrSImIKBVP/JRy9g7K4zmRAH/wXw2UxYziX+hZoFIpbW3GmYQqhjx2lDvIRXJI7blhHhTUNWX5f10lFAYOLqA9J859AB1w7ND09+MS3jQgSazCx17h+QZ0qQ6kLSfnXw9PMUOE1Xba9hD1nYj14ryTVj9jrFPMFuUfXdb/G9lsDJ+cGvdE2/RMuPfDmEdo04zvZ5fQJJKvS7OyAuYev4Y+JC8MhEr756ITDZ17yq4BEMo/8rNPxZ5Von/8xnvry+8/2C3ep9rZyHtCwpRb6WT6TndV2ddXKhEIneyd1XiOcWPJguHj5vSoMN3mo8k2PvznGauvxBstvpjUSFLQu869/ZQwyMnbQi3wnkJk5CpLXePXn1J9njocJjt8+SKGijmmIAsmYosx8gmmu3H1mvq9Wi0qqWDITMm+J24AZBEPBhwVrjhLZb5MKxylF6JFJJBs= root@example2";
+    let endpoints = maplit::btreemap! {
+        "/public-keys" => "0=test1\n1=test2",
+        "/public-keys/0/openssh-key" => key1,
+        "/public-keys/1/openssh-key" => key2,
+    };
+
+    let mut mocks = Vec::with_capacity(endpoints.len());
+    for (endpoint, body) in endpoints {
+        let m = mockito::mock("GET", endpoint)
+            .with_status(200)
+            .with_body(body)
+            .create();
+        mocks.push(m)
+    }
+
+    let keys = provider.ssh_keys().unwrap();
+    assert_eq!(keys.len(), 2);
+    assert_eq!(keys[0].options, None);
+    assert_eq!(keys[0].comment, Some("root@example1".to_string()));
+
+    assert_eq!(keys[1].options, None);
+    assert_eq!(keys[1].comment, Some("root@example2".to_string()));
+
+    mockito::reset();
+    provider.ssh_keys().unwrap_err();
+}
+
+#[test]
+fn test_ssh_keys_404_ok() {
+    let mut provider = OpenstackProviderNetwork::try_new().unwrap();
+    provider.client = provider.client.max_retries(0);
+
+    let _m = mockito::mock("GET", "/public-keys")
+        .with_status(404)
+        .create();
+    let v = provider.ssh_keys().unwrap();
+    assert_eq!(v.len(), 0);
+    mockito::reset();
+    provider.ssh_keys().unwrap_err();
+}

--- a/src/providers/openstack/mod.rs
+++ b/src/providers/openstack/mod.rs
@@ -23,6 +23,9 @@ use slog_scope::warn;
 pub mod configdrive;
 pub mod network;
 
+#[cfg(test)]
+mod mock_tests;
+
 /// Read metadata from the config-drive first then fallback to fetch from metadata server.
 ///
 /// Reference: https://github.com/coreos/fedora-coreos-tracker/issues/422

--- a/src/providers/openstack/network.rs
+++ b/src/providers/openstack/network.rs
@@ -17,7 +17,7 @@ pub struct OpenstackProviderNetwork {
 
 impl OpenstackProviderNetwork {
     pub fn try_new() -> Result<OpenstackProviderNetwork> {
-        let client = retry::Client::try_new()?;
+        let client = retry::Client::try_new()?.return_on_404(true);
         Ok(OpenstackProviderNetwork { client })
     }
 

--- a/src/providers/openstack/network.rs
+++ b/src/providers/openstack/network.rs
@@ -8,11 +8,12 @@ use crate::errors::*;
 use crate::providers::MetadataProvider;
 use crate::retry;
 
+#[cfg(not(test))]
 const URL: &str = "http://169.254.169.254/latest/meta-data";
 
 #[derive(Clone, Debug)]
 pub struct OpenstackProviderNetwork {
-    client: retry::Client,
+    pub(crate) client: retry::Client,
 }
 
 impl OpenstackProviderNetwork {
@@ -21,6 +22,12 @@ impl OpenstackProviderNetwork {
         Ok(OpenstackProviderNetwork { client })
     }
 
+    #[cfg(test)]
+    fn endpoint_for(key: &str) -> String {
+        format!("{}/{}", &mockito::server_url(), key)
+    }
+
+    #[cfg(not(test))]
     fn endpoint_for(key: &str) -> String {
         format!("{}/{}", URL, key)
     }


### PR DESCRIPTION
Set `return_on_404` to `true` for the *stack network providers to handle the
`public-keys` not existing if an SSH key is not provided.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/662