### PR TITLE
dracut/hostname: run service on ibmcloud

### DIFF
--- a/dracut/30afterburn/afterburn-hostname.service
+++ b/dracut/30afterburn/afterburn-hostname.service
@@ -7,6 +7,7 @@ ConditionKernelCommandLine=|ignition.platform.id=aliyun
 ConditionKernelCommandLine=|ignition.platform.id=azure
 ConditionKernelCommandLine=|ignition.platform.id=digitalocean
 ConditionKernelCommandLine=|ignition.platform.id=exoscale
+ConditionKernelCommandLine=|ignition.platform.id=ibmcloud
 ConditionKernelCommandLine=|ignition.platform.id=vultr
 
 # We order this service after sysroot has been mounted


### PR DESCRIPTION
This tweaks the `afterburn-hostname` service unit in order to run
it on `ibmcloud` nodes too.

Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/668