### PR TITLE
workflows/rust: update linting toolchain to latest stable

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ env:
   # Minimum supported Rust version (MSRV)
   ACTIONS_MSRV_TOOLCHAIN: 1.40.0
   # Pinned toolchain for linting
-  ACTIONS_LINTS_TOOLCHAIN: 1.46.0
+  ACTIONS_LINTS_TOOLCHAIN: 1.48.0
 
 jobs:
   tests-stable:

--- a/src/cli/exp.rs
+++ b/src/cli/exp.rs
@@ -48,7 +48,7 @@ impl CliRdNetworkKargs {
         let platform = super::parse_provider(matches)?;
         let default_kargs = matches
             .value_of("default-value")
-            .ok_or_else(|| "missing network kargs default value")?
+            .ok_or("missing network kargs default value")?
             .to_string();
 
         let cfg = Self {
@@ -66,9 +66,7 @@ impl CliRdNetworkKargs {
         };
 
         let provider_kargs = initrd::fetch_network_kargs(&self.platform)?;
-        let kargs = provider_kargs
-            .as_ref()
-            .unwrap_or_else(|| &self.default_kargs);
+        let kargs = provider_kargs.as_ref().unwrap_or(&self.default_kargs);
         initrd::write_network_kargs(kargs)
     }
 }

--- a/src/providers/azure/mod.rs
+++ b/src/providers/azure/mod.rs
@@ -215,7 +215,7 @@ impl Azure {
             )
             .send()
             .chain_err(|| "failed to get versions")?
-            .ok_or_else(|| "failed to get versions: not found")?;
+            .ok_or("failed to get versions: not found")?;
 
         if versions.supported.versions.iter().any(|v| v == version) {
             Ok(())
@@ -254,7 +254,7 @@ impl Azure {
             )
             .send()
             .chain_err(|| "failed to get certificates")?
-            .ok_or_else(|| "failed to get certificates: not found")?;
+            .ok_or("failed to get certificates: not found")?;
 
         // the cms decryption expects it to have MIME information on the top
         // since cms is really for email attachments....
@@ -313,7 +313,7 @@ impl Azure {
             .get(retry::Xml, endpoint.to_string())
             .send()
             .chain_err(|| "failed to get shared configuration")?
-            .ok_or_else(|| "failed to get shared configuration: not found")?;
+            .ok_or("failed to get shared configuration: not found")?;
 
         let mut attributes = Attributes::default();
 


### PR DESCRIPTION
This updates the linting toolchain to latest stable (1.48.0), fixing all new clippy warnings too.