### PR TITLE
ci: adapt to new buildroot image

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,7 +1,14 @@
 // Documentation: https://github.com/coreos/coreos-ci/blob/master/README-upstream-ci.md
 
-cosaPod(buildroot: true) {
+buildPod {
     checkout scm
+    stage("Build") {
+        shwrap("make && make install DESTDIR=install")
+        stash name: 'build', includes: 'install/**'
+    }
+}
 
-    fcosBuild(make: true)
+cosaPod {
+    unstash name: 'build'
+    fcosBuild(overlays: ["install"])
 }


### PR DESCRIPTION
Similar to https://github.com/coreos/ignition/pull/1182 as a result of
https://github.com/coreos/fedora-coreos-config/pull/740.