### PR TITLE
Release 5.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "afterburn"
-version = "4.6.1-alpha.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "base64 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "afterburn"
-version = "5.0.0"
+version = "5.0.1-alpha.0"
 dependencies = [
  "anyhow",
  "base64 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore"]
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "5.0.0"
+version = "5.0.1-alpha.0"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore"]
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "4.6.1-alpha.0"
+version = "5.0.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Changes:
- *: update minimum toolchain to 1.44
- cargo: update all dependencies
- *: remove cl-legacy feature
- ibmcloud: don't ignore I/O error when parsing metadata
- providers: fix clippy::unnecessary_wraps lint on 1.50 
- workflows: update pinned lint toolchain to 1.50.0
- *: switch from `error-chain` to `anyhow`
- cli: stop wrapping command-line parse errors
- github: release checklist cleanups
- ci: adapt to new buildroot image
- providers: add Azure Stack Hub