### PR TITLE
providers/{gcp,packet}: don't trust DNS for metadata service

### DIFF
--- a/src/providers/gcp/mod.rs
+++ b/src/providers/gcp/mod.rs
@@ -54,10 +54,7 @@ impl GcpProvider {
 
     #[cfg(not(test))]
     fn endpoint_for(name: &str) -> String {
-        format!(
-            "http://metadata.google.internal/computeMetadata/v1/{}",
-            name
-        )
+        format!("http://169.254.169.254/computeMetadata/v1/{}", name)
     }
 
     fn fetch_all_ssh_keys(&self) -> Result<Vec<String>> {

--- a/src/providers/packet/mod.rs
+++ b/src/providers/packet/mod.rs
@@ -119,7 +119,7 @@ impl PacketProvider {
 
     #[cfg(not(test))]
     fn endpoint_for(name: &str) -> String {
-        let url = "http://metadata.packet.net";
+        let url = "https://metadata.packet.net";
         format!("{}/{}", url, name)
     }
 


### PR DESCRIPTION
There have been two hostname poisoning attacks against `metadata.google.internal`.  As a precaution, access it by IP address
instead, since the IP is documented anyway.

The Packet metadata service is also accessed by hostname, but we can use HTTPS.  Do so.

Addresses coreos/fedora-coreos-tracker#891.