### PR TITLE
Release 5.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "afterburn"
-version = "5.1.0"
+version = "5.1.1-alpha.0"
 dependencies = [
  "anyhow",
  "base64 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "afterburn"
-version = "5.0.1-alpha.0"
+version = "5.1.0"
 dependencies = [
  "anyhow",
  "base64 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore"]
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "5.1.0"
+version = "5.1.1-alpha.0"
 
 [package.metadata.release]
 sign-commit = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore"]
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
-version = "5.0.1-alpha.0"
+version = "5.1.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Changes:
- docs: fix "Edit this page on GitHub" links
- *: rename master branch to main
- *: fix clippy warnings
- lockfile: general refresh, update all openssl crates
- providers/gcp: access GCP metadata service by IP address
- providers/packet: access metadata service over HTTPS
- cli: don't report an error when --help or --version is specified
- cli: correctly print version when --version specified 
- providers: Add PowerVS 
- workflows: bump toolchains; restrict repository access