### PR TITLE
cargo: enable debuginfo in the release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ path = "src/main.rs"
 
 [profile.release]
 lto = true
+# We assume we're being delivered via e.g. RPM which supports split debuginfo
+debug = true
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
This is needed to address the rpm build failure: https://kojipkgs.fedoraproject.org//work/tasks/6814/76186814/build.log