### PR TITLE
docs: Do not convert -- & --- to en/em-dash

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,6 +6,10 @@ url: "https://coreos.github.io"
 # url: "http://localhost:4000"
 permalink: /:title/
 markdown: kramdown
+kramdown:
+  typographic_symbols:
+    ndash: "--"
+    mdash: "---"
 
 remote_theme: coreos/just-the-docs
 plugins:


### PR DESCRIPTION
'--' is frequently used for command line options and was thus
incorrectly rendered as a special en-dash symbol.