### PR TITLE
Explicitly log the hostname we write

### DIFF
--- a/src/providers/microsoft/azure/mod.rs
+++ b/src/providers/microsoft/azure/mod.rs
@@ -172,7 +172,7 @@ impl Azure {
         // try to fetch from dhcp, else use fallback; this is similar to what WALinuxAgent does
         Azure::get_fabric_address_from_dhcp().unwrap_or_else(|e| {
             warn!("Failed to get fabric address from DHCP: {}", e);
-            slog_scope::info!("Using fallback address");
+            slog_scope::info!("using fallback address");
             IpAddr::from(FALLBACK_WIRESERVER_ADDR)
         })
     }

--- a/src/providers/microsoft/azurestack/mod.rs
+++ b/src/providers/microsoft/azurestack/mod.rs
@@ -187,7 +187,7 @@ impl AzureStack {
         // try to fetch from dhcp, else use fallback; this is similar to what WALinuxAgent does
         AzureStack::get_fabric_address_from_dhcp().unwrap_or_else(|e| {
             warn!("Failed to get fabric address from DHCP: {}", e);
-            slog_scope::info!("Using fallback address");
+            slog_scope::info!("using fallback address");
             IpAddr::from(FALLBACK_WIRESERVER_ADDR)
         })
     }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -219,7 +219,7 @@ pub trait MetadataProvider {
                     hostname, hostname_file
                 )
             })?;
-            slog_scope::info!("Wrote hostname {} to {}", hostname, hostname_file_path);
+            slog_scope::info!("wrote hostname {} to {}", hostname, hostname_file_path);
         }
         Ok(())
     }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -211,18 +211,17 @@ pub trait MetadataProvider {
     }
 
     fn write_hostname(&self, hostname_file_path: String) -> Result<()> {
-        match self.hostname()? {
-            Some(ref hostname) => {
-                let mut hostname_file = create_file(&hostname_file_path)?;
-                writeln!(&mut hostname_file, "{}", hostname).with_context(|| {
-                    format!(
-                        "failed to write hostname {:?} to file {:?}",
-                        hostname, hostname_file
-                    )
-                })
-            }
-            None => Ok(()),
+        if let Some(hostname) = self.hostname()? {
+            let mut hostname_file = create_file(&hostname_file_path)?;
+            writeln!(&mut hostname_file, "{}", hostname).with_context(|| {
+                format!(
+                    "failed to write hostname {:?} to file {:?}",
+                    hostname, hostname_file
+                )
+            })?;
+            slog_scope::info!("Wrote hostname {} to {}", hostname, hostname_file_path);
         }
+        Ok(())
     }
 
     fn write_network_units(&self, network_units_dir: String) -> Result<()> {


### PR DESCRIPTION
This would have greatly helped debugging https://bugzilla.redhat.com/show_bug.cgi?id=2008521#c40
because it was not immediately obvious from the logs that
afterburn is just writing a full, untruncated hostname to `/sysroot/etc/hostname`.

We see in the logs that the service started/stopped successfully,
but in this case it happens that systemd truncates it, which obscured
the value.