### PR TITLE
build(deps): bump hyper from 0.14.9 to 0.14.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,9 +558,9 @@ checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "hyper"
-version = "0.14.9"
+version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d6baa1b441335f3ce5098ac421fb6547c46dda735ca1bc6d0153c838f9dd83"
+checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
 dependencies = [
  "bytes",
  "futures-channel",


### PR DESCRIPTION
This fixes two security issues:
https://rustsec.org/advisories/RUSTSEC-2021-0078 AKA CVE-2021-32715
https://rustsec.org/advisories/RUSTSEC-2021-0079 AKA CVE-2021-32714