### PR TITLE
ci: skip broken kdump.crash kola test

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -10,5 +10,8 @@ buildPod {
 
 cosaPod {
     unstash name: 'build'
-    fcosBuild(overlays: ["install"])
+    fcosBuild(skipKola: true, overlays: ["install"])
+    // Skipping kdump.crash due to CI failure in afterburn repo
+    // https://github.com/coreos/fedora-coreos-tracker/issues/1075
+    fcosKola(extraArgs: "--denylist-test ext.config.kdump.crash")
 }


### PR DESCRIPTION
ext.config.kdump.crash was failing the upstream CI for afterburn and [coreos-installer](https://jenkins-coreos-ci.apps.ocp.ci.centos.org/job/github-ci/job/coreos/job/coreos-installer/job/PR-750/5/) repos so skipping them for these repositories.
Ref :https://github.com/coreos/fedora-coreos-config/pull/1420#issuecomment-1013289554