### PR TITLE
*: use `RemainAfterExit` on all oneshot services

### DIFF
--- a/dracut/30afterburn/afterburn-hostname.service
+++ b/dracut/30afterburn/afterburn-hostname.service
@@ -30,3 +30,4 @@ ExecStart=/usr/bin/afterburn --cmdline --hostname=/sysroot/etc/hostname
 ExecStart=/bin/sh -c 'mkdir -p /run/tmpfiles.d'
 ExecStart=/bin/sh -c 'echo "z /etc/hostname - - -" > /run/tmpfiles.d/hostname-relabel.conf'
 Type=oneshot
+RemainAfterExit=yes

--- a/dracut/30afterburn/afterburn-network-kargs.service
+++ b/dracut/30afterburn/afterburn-network-kargs.service
@@ -18,3 +18,4 @@ Environment=AFTERBURN_OPT_PROVIDER=--cmdline
 # hard-failure, on purpose.
 ExecStart=/usr/bin/afterburn exp rd-network-kargs ${AFTERBURN_OPT_PROVIDER} --default-value $AFTERBURN_NETWORK_KARGS_DEFAULT
 Type=oneshot
+RemainAfterExit=yes

--- a/systemd/afterburn-sshkeys@.service.in
+++ b/systemd/afterburn-sshkeys@.service.in
@@ -21,6 +21,7 @@ ConditionKernelCommandLine=|ignition.platform.id=vultr
 Type=oneshot
 Environment=AFTERBURN_OPT_PROVIDER=--cmdline
 ExecStart=/usr/bin/afterburn ${AFTERBURN_OPT_PROVIDER} --ssh-keys=%i
+RemainAfterExit=yes
 
 [Install]
 DefaultInstance=@DEFAULT_INSTANCE@

--- a/systemd/afterburn.service
+++ b/systemd/afterburn.service
@@ -8,6 +8,7 @@ Documentation=https://github.com/coreos/afterburn
 Type=oneshot
 Environment=AFTERBURN_OPT_PROVIDER=--cmdline
 ExecStart=/usr/bin/afterburn ${AFTERBURN_OPT_PROVIDER} --attributes=/run/metadata/afterburn
+RemainAfterExit=yes
 
 [Install]
 RequiredBy=metadata.target


### PR DESCRIPTION
Services of type `Oneshot` should almost always use `RemainAfterExit`.
Otherwise, they go inactive and everytime they're pulled back into the
transaction by another requiring service, systemd will rerun them which
is not what we want.

Closes: #694