### PR TITLE
build(deps): bump thread_local from 1.1.3 to 1.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,9 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]


### PR DESCRIPTION
fixes https://rustsec.org/advisories/RUSTSEC-2022-0006