### PR TITLE
Add COPR integration Makefile and add CI test for RPM building

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,11 @@
+.PHONY: srpm
+srpm:
+	dnf install -y git rust-packaging rpm-build rpmdevtools
+	curl -LO https://src.fedoraproject.org/rpms/rust-afterburn/raw/rawhide/f/rust-afterburn.spec
+	version=$$(git describe --always --tags | sed -e 's,-,\.,g' -e 's,^v,,'); \
+	git archive --format=tar --prefix=afterburn-$$version/ HEAD | gzip > afterburn-$$version.crate; \
+	sed -ie "s,^Version:.*,Version: $$version," rust-afterburn.spec
+	sed -ie 's/^Patch/# Patch/g' rust-afterburn.spec  # we don't want any downstream patches
+	sed -ie 's/^Source1/# Source1/g' rust-afterburn.spec  # we don't vendor
+	rpmbuild -bs --define "_sourcedir ${PWD}" --define "_specdir ${PWD}" --define "_builddir ${PWD}" --define "_srcrpmdir ${PWD}" --define "_rpmdir ${PWD}" --define "_buildrootdir ${PWD}/.build" rust-afterburn.spec
+	mv *.src.rpm $$outdir

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -1,0 +1,34 @@
+---
+name: RPM build
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+permissions:
+  contents: read
+
+jobs:
+  test-rpm-build:
+    name: "RPM build"
+    runs-on: ubuntu-latest
+    container:
+      image: registry.fedoraproject.org/fedora:latest
+      options: --privileged
+    steps:
+      # need to install git before checkout to get a git repo
+      - name: Install packages
+        run: dnf install -y git make mock
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Build RPM
+        run: |
+          mkdir rpms
+          make -f .copr/Makefile srpm outdir=rpms
+          mock --rebuild rpms/*.src.rpm
+          find /var/lib/mock -wholename '*/result/*.rpm' | xargs mv -t rpms
+      - name: Archive RPMs
+        uses: actions/upload-artifact@v2
+        with:
+          name: rpms
+          path: rpms/


### PR DESCRIPTION
```
commit 50831ebcaafb8162222f57b75411a1f92fd9a036
Date:   Tue Feb 15 13:41:55 2022 -0500

    Add COPR integration Makefile

    I'd like to enable auto-builds of this repo to
    https://copr.fedorainfracloud.org/coprs/g/CoreOS/continuous/ so it could
    eventually feed into
    https://github.com/coreos/fedora-coreos-tracker/issues/910.
```
```
commit 338c4db6bb80fd81a8e10e1b6ae39552f2d12c40
Date:   Tue Feb 15 13:45:30 2022 -0500

    workflows: add "RPM build" test

    Verify that we can build using purely Fedora packages. This will catch
    earlier any Rust packages we need to update or add in Fedora rather than
    find out at release time.

    It also ensures that the new continuous COPR builds will not break since
    we don't vendor there either.
```