### PR TITLE
build(deps): bump regex from 1.5.4 to 1.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,9 +1053,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",


### PR DESCRIPTION
As this is only used via mockito, I assume that afterburn is not
vulnerable as it doesn't take a user supplied regex. This fixes a denial
of service security bug in the regex crate, just to be sure. The bug
made it possible for user supplied regexes to avoid mitigations which
are supposed to prevent the regex from taking a very long time to parse
with.

Fixes: https://rustsec.org/advisories/RUSTSEC-2022-0013
Fixes: CVE-2022-24713