### PR TITLE
Update to Rust 2021; bump MSRV to 1.56.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   # Minimum supported Rust version (MSRV)
-  ACTIONS_MSRV_TOOLCHAIN: 1.49.0
+  ACTIONS_MSRV_TOOLCHAIN: 1.56.0
   # Pinned toolchain for linting
   ACTIONS_LINTS_TOOLCHAIN: 1.59.0
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ env:
   # Minimum supported Rust version (MSRV)
   ACTIONS_MSRV_TOOLCHAIN: 1.49.0
   # Pinned toolchain for linting
-  ACTIONS_LINTS_TOOLCHAIN: 1.57.0
+  ACTIONS_LINTS_TOOLCHAIN: 1.59.0
 
 jobs:
   tests-stable:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,8 +10,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  # Minimum supported Rust version (MSRV)
-  ACTIONS_MSRV_TOOLCHAIN: 1.56.0
   # Pinned toolchain for linting
   ACTIONS_LINTS_TOOLCHAIN: 1.59.0
 
@@ -52,10 +50,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Detect crate MSRV
+        run: |
+          msrv=$(cargo metadata --format-version 1 --no-deps | \
+              jq -r '.packages | .[].rust_version')
+          echo "Crate MSRV: $msrv"
+          echo "MSRV=$msrv" >> $GITHUB_ENV
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env['ACTIONS_MSRV_TOOLCHAIN']  }}
+          toolchain: ${{ env.MSRV }}
           default: true
       - name: cargo build (release)
         run: cargo build --release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "afterburn"
 repository = "https://github.com/coreos/afterburn"
 license = "Apache-2.0"
 edition = "2021"
+rust-version = "1.56.0"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore"]
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "afterburn"
 repository = "https://github.com/coreos/afterburn"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore"]
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -46,7 +46,6 @@ use nix::unistd;
 use openssh_keys::PublicKey;
 use slog_scope::warn;
 use std::collections::HashMap;
-use std::convert::TryInto;
 use std::fs::{self, File};
 use std::io::prelude::*;
 use std::path::Path;


### PR DESCRIPTION
RHEL 8.6 has a new-enough Rust to allow this. Dependencies are starting to require Rust 2021, and clap 3.0 needs Rust 1.54.0.