### PR TITLE
systemd: enable sshkeys on Power VS platform

### DIFF
--- a/systemd/afterburn-sshkeys@.service.in
+++ b/systemd/afterburn-sshkeys@.service.in
@@ -15,6 +15,7 @@ ConditionKernelCommandLine=|ignition.platform.id=gcp
 ConditionKernelCommandLine=|ignition.platform.id=ibmcloud
 ConditionKernelCommandLine=|ignition.platform.id=openstack
 ConditionKernelCommandLine=|ignition.platform.id=packet
+ConditionKernelCommandLine=|ignition.platform.id=powervs
 ConditionKernelCommandLine=|ignition.platform.id=vultr
 
 [Service]


### PR DESCRIPTION
The metadata service exposes sshkeys, so use that to activate ssh-keys.