### PR TITLE
providers/aws: expose instance availability-zone-id as AWS_AVAILABILITY_ZONE_ID

### DIFF
--- a/src/providers/aws/mock_tests.rs
+++ b/src/providers/aws/mock_tests.rs
@@ -48,6 +48,7 @@ fn aws_get_maps() -> (
     let ipv4_public = "test-ipv4-public";
     let ipv6 = "test-ipv6";
     let availability_zone = "test-availability-zone";
+    let availability_zone_id = "test-availability-zone-id";
     let hostname = "test-hostname";
     let public_hostname = "test-public-hostname";
     let instance_id_doc = r#"{"region": "test-region"}"#;
@@ -61,6 +62,7 @@ fn aws_get_maps() -> (
             "/meta-data/public-ipv4" => ipv4_public,
             "/meta-data/ipv6" => ipv6,
             "/meta-data/placement/availability-zone" => availability_zone,
+            "/meta-data/placement/availability-zone-id" => availability_zone_id,
             "/meta-data/hostname" => hostname,
             "/meta-data/public-hostname" => public_hostname,
             "/dynamic/instance-identity/document" => instance_id_doc,
@@ -72,6 +74,7 @@ fn aws_get_maps() -> (
             "AWS_IPV4_PUBLIC".to_string() => ipv4_public.to_string(),
             "AWS_IPV6".to_string() => ipv6.to_string(),
             "AWS_AVAILABILITY_ZONE".to_string() => availability_zone.to_string(),
+            "AWS_AVAILABILITY_ZONE_ID".to_string() => availability_zone_id.to_string(),
             "AWS_HOSTNAME".to_string() => hostname.to_string(),
             "AWS_PUBLIC_HOSTNAME".to_string() => public_hostname.to_string(),
             "AWS_REGION".to_string() => region.to_string(),

--- a/src/providers/aws/mod.rs
+++ b/src/providers/aws/mod.rs
@@ -169,6 +169,11 @@ impl MetadataProvider for AwsProvider {
             "AWS_AVAILABILITY_ZONE",
             "meta-data/placement/availability-zone",
         )?;
+        add_value(
+            &mut out,
+            "AWS_AVAILABILITY_ZONE_ID",
+            "meta-data/placement/availability-zone-id",
+        )?;
         add_value(&mut out, "AWS_HOSTNAME", "meta-data/hostname")?;
         add_value(&mut out, "AWS_PUBLIC_HOSTNAME", "meta-data/public-hostname")?;
 


### PR DESCRIPTION
ec2 instance metadata exposes the physical id for availability zone. Physical zone ids are useful
because they are same across AWS accounts and helpful when trying to decide if instances are actually
in the same zone when reconciling that between instances in different accounts.

See doc:
> https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-categories.html

```
placement/availability-zone-id	The static Availability Zone ID in which the instance is launched. The Availability Zone ID is consistent across accounts. However, it might be different from the Availability Zone, which can vary by account.	2020-08-24
```

This is available in api versions starting 2020-08-24, and afterbun already uses 2021-01-03 [1].

[1]: https://github.com/coreos/afterburn/blob/640ce9790c4f2d56aa75d1e3ad63f8011bec4255/src/providers/aws/mod.rs#L83