### PR TITLE
ci: mark git checkout as safe

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -24,6 +24,9 @@ jobs:
         # fetch tags for versioning
         with:
           fetch-depth: 0
+      # https://github.com/actions/checkout/issues/760
+      - name: Mark git checkout as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Build RPMs
         run: |
           mkdir rpms


### PR DESCRIPTION
Recent git became more strict wrt git repos in parent dirs owned by
other users. This broke us likely due to the container workdir being a
volume mount. We need to explicitly mark the repo as safe.

Interestingly, the checkout action also does this but only temporarily
for itself.

For more information, see:
https://github.com/actions/checkout/issues/760