### PR TITLE
providers: Use inline `format!` in a few places

### DIFF
--- a/src/providers/aliyun/mod.rs
+++ b/src/providers/aliyun/mod.rs
@@ -34,7 +34,7 @@ impl AliyunProvider {
     #[cfg(test)]
     fn endpoint_for(name: &str) -> String {
         let url = mockito::server_url();
-        format!("{}/{}", url, name)
+        format!("{url}/{name}")
     }
 
     #[cfg(not(test))]

--- a/src/providers/aws/mod.rs
+++ b/src/providers/aws/mod.rs
@@ -74,7 +74,7 @@ impl AwsProvider {
     #[cfg(test)]
     fn endpoint_for(key: &str, _use_latest: bool) -> String {
         let url = mockito::server_url();
-        format!("{}/{}", url, key)
+        format!("{url}/{key}")
     }
 
     #[cfg(not(test))]
@@ -83,9 +83,9 @@ impl AwsProvider {
         const URL: &str = "http://169.254.169.254/2021-01-03";
         const URL_LATEST: &str = "http://169.254.169.254/latest";
         if use_latest {
-            format!("{}/{}", URL_LATEST, key)
+            format!("{URL_LATEST}/{key}")
         } else {
-            format!("{}/{}", URL, key)
+            format!("{URL}/{key}")
         }
     }
 

--- a/src/providers/digitalocean/mod.rs
+++ b/src/providers/digitalocean/mod.rs
@@ -90,13 +90,13 @@ impl DigitalOceanProvider {
             for (i, a) in ifaces.iter().enumerate() {
                 if let Some(ref v4) = a.ipv4 {
                     attrs.push((
-                        format!("DIGITALOCEAN_IPV4_PUBLIC_{}", i),
+                        format!("DIGITALOCEAN_IPV4_PUBLIC_{i}"),
                         format!("{}", v4.ip_address),
                     ));
                 }
                 if let Some(ref v6) = a.ipv6 {
                     attrs.push((
-                        format!("DIGITALOCEAN_IPV6_PUBLIC_{}", i),
+                        format!("DIGITALOCEAN_IPV6_PUBLIC_{i}"),
                         format!("{}", v6.ip_address),
                     ));
                 }

--- a/src/providers/exoscale/mod.rs
+++ b/src/providers/exoscale/mod.rs
@@ -42,12 +42,12 @@ impl ExoscaleProvider {
     #[cfg(test)]
     fn endpoint_for(&self, key: &str) -> String {
         let url = mockito::server_url();
-        format!("{}/{}", url, key)
+        format!("{url}/{key}")
     }
 
     #[cfg(not(test))]
     fn endpoint_for(&self, key: &str) -> String {
-        format!("http://169.254.169.254/1.0/meta-data/{}", key)
+        format!("http://169.254.169.254/1.0/meta-data/{key}")
     }
 }
 

--- a/src/providers/gcp/mod.rs
+++ b/src/providers/gcp/mod.rs
@@ -49,12 +49,12 @@ impl GcpProvider {
     #[cfg(test)]
     fn endpoint_for(name: &str) -> String {
         let url = mockito::server_url();
-        format!("{}/{}", url, name)
+        format!("{url}/{name}")
     }
 
     #[cfg(not(test))]
     fn endpoint_for(name: &str) -> String {
-        format!("http://169.254.169.254/computeMetadata/v1/{}", name)
+        format!("http://169.254.169.254/computeMetadata/v1/{name}")
     }
 
     fn fetch_all_ssh_keys(&self) -> Result<Vec<String>> {

--- a/src/providers/packet/mod.rs
+++ b/src/providers/packet/mod.rs
@@ -119,13 +119,13 @@ impl PacketProvider {
     #[cfg(test)]
     fn endpoint_for(name: &str) -> String {
         let url = mockito::server_url();
-        format!("{}/{}", url, name)
+        format!("{url}/{name}")
     }
 
     #[cfg(not(test))]
     fn endpoint_for(name: &str) -> String {
         let url = "https://metadata.packet.net";
-        format!("{}/{}", url, name)
+        format!("{url}/{name}")
     }
 
     fn get_attrs(&self) -> Vec<(String, String)> {

--- a/src/providers/vultr/mod.rs
+++ b/src/providers/vultr/mod.rs
@@ -44,7 +44,7 @@ impl VultrProvider {
     #[cfg(test)]
     fn endpoint_for(name: &str) -> String {
         let url = mockito::server_url();
-        format!("{}/{}", url, name)
+        format!("{url}/{name}")
     }
 
     #[cfg(not(test))]


### PR DESCRIPTION
It reads more nicely.  No particular motivation, this is just
a drive-by random change.