### PR TITLE
*: bump MSRV to 1.58.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,8 @@ name = "afterburn"
 repository = "https://github.com/coreos/afterburn"
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.56.0"
+# when updating this, also update README.md and docs/index.md
+rust-version = "1.58.0"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore"]
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Afterburn
 
 [![crates.io](https://img.shields.io/crates/v/afterburn.svg)](https://crates.io/crates/afterburn)
-![minimum rust 1.46](https://img.shields.io/badge/rust-1.46%2B-orange.svg)
+![minimum rust 1.58](https://img.shields.io/badge/rust-1.58%2B-orange.svg)
 
 Afterburn is a one-shot agent for cloud-like platforms which interacts with provider-specific metadata endpoints.
 It is typically used in conjunction with [Ignition](https://github.com/coreos/ignition).

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ nav_order: 1
 # Afterburn
 
 [![crates.io](https://img.shields.io/crates/v/afterburn.svg)](https://crates.io/crates/afterburn)
-![minimum rust 1.46](https://img.shields.io/badge/rust-1.46%2B-orange.svg)
+![minimum rust 1.58](https://img.shields.io/badge/rust-1.58%2B-orange.svg)
 
 Afterburn is a one-shot agent for cloud-like platforms which interacts with provider-specific metadata endpoints.
 It is typically used in conjunction with [Ignition](https://github.com/coreos/ignition).

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -17,6 +17,7 @@ Minor changes:
 Packaging changes:
 
 - Remove static libraries from vendor archive
+- Require Rust ≥ 1.58.0
 
 
 ## Afterburn 5.3.0 (2022-04-29)


### PR DESCRIPTION
This is in RHEL 8.6 at least.

While we're here, add a comment in `Cargo.toml` to remember to update
the other places where we mention the MSRV which seem like they were
missed last bump.