### PR TITLE
dependabot: automatically add `dependency` and `skip-notes` labels to PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,6 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+  labels:
+  - dependency
+  - skip-notes


### PR DESCRIPTION
Dependabot was defaulting to a `dependencies` label, which doesn't match our other repos.  Rename it.