### PR TITLE
systemd: add explicit ordering, after multi-user.target

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,7 @@ Minor changes:
 
 - Add `AWS_AVAILABILITY_ZONE_ID` attribute to AWS
 - Add release notes to documentation
+- Fix default dependency ordering on all `checkin` services
 
 Packaging changes:
 

--- a/systemd/afterburn-checkin.service
+++ b/systemd/afterburn-checkin.service
@@ -4,7 +4,7 @@ Documentation=https://coreos.github.io/afterburn/
 ConditionKernelCommandLine=|ignition.platform.id=azure
 ConditionKernelCommandLine=|ignition.platform.id=azurestack
 After=network.target
-After=boot-complete.target
+After=multi-user.target boot-complete.target
 
 [Service]
 Environment=AFTERBURN_OPT_PROVIDER=--cmdline

--- a/systemd/afterburn-firstboot-checkin.service
+++ b/systemd/afterburn-firstboot-checkin.service
@@ -4,7 +4,7 @@ Documentation=https://coreos.github.io/afterburn/
 ConditionKernelCommandLine=|ignition.platform.id=packet
 ConditionFirstBoot=yes
 After=network.target
-After=boot-complete.target
+After=multi-user.target boot-complete.target
 
 [Service]
 Environment=AFTERBURN_OPT_PROVIDER=--cmdline


### PR DESCRIPTION
This tweaks `checkin` service units ordering, adding explicit configuration for running after `multi-user.target`.
Those service units are currently pulled in by `multi-user.target`, which results in a implicit `Before` ordering being added by systemd. Unfortunately this may result in a dependency loop between `multi-user.target` and `boot-complete.target`, as the latter may need to start after the former.
Adding explicit `After=multi-user.target` statements here makes sure that both targets can be properly started in the relevant order, with Afterburn queuing after both of them.

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1298
Ref: https://lists.freedesktop.org/archives/systemd-devel/2022-September/048330.html