### PR TITLE
ci: migrate to new directory and method names

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -10,8 +10,8 @@ buildPod {
 
 cosaPod {
     unstash name: 'build'
-    fcosBuild(skipKola: true, overlays: ["install"])
+    cosaBuild(skipKola: true, overlays: ["install"])
     // Skipping kdump.crash due to CI failure in afterburn repo
     // https://github.com/coreos/fedora-coreos-tracker/issues/1075
-    fcosKola(extraArgs: "--denylist-test ext.config.kdump.crash")
+    kola(extraArgs: "--denylist-test ext.config.kdump.crash")
 }


### PR DESCRIPTION
The previous `fcos*` ones are deprecated.
See: https://github.com/coreos/coreos-ci-lib/pull/122