### PR TITLE
providers/ibmcloud: avoid error if an ssh key not found in metadata

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,7 @@ Minor changes:
 - Add `AWS_AVAILABILITY_ZONE_ID` attribute to AWS
 - Add release notes to documentation
 - Fix default dependency ordering on all `checkin` services
+- Fix failure setting SSH keys on IBM Cloud if none are provided
 
 Packaging changes:
 

--- a/src/providers/ibmcloud/mod.rs
+++ b/src/providers/ibmcloud/mod.rs
@@ -10,7 +10,7 @@
 //!
 //! nocloud: https://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use openssh_keys::PublicKey;
 use std::collections::HashMap;
 use std::fs::File;
@@ -150,7 +150,7 @@ impl IBMGen2Provider {
         }
         // Parse YAML to find SSH keys
         if cloud_config.is_empty() {
-            bail!("no cloud-config section found in vendor-data");
+            return Ok(Vec::new());
         }
         let deserialized_cloud_config: VendorDataCloudConfig = serde_yaml::from_str(&cloud_config)
             .context("failed to deserialize cloud-config content")?;


### PR DESCRIPTION
Fixes https://github.com/coreos/afterburn/issues/755
Ideally, users are not required to provide an SSH key via the cloud mechanism. So we can return an empty list and avoid throwing an error.