### PR TITLE
cargo: stop enabling LTO in release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ name = "afterburn"
 path = "src/main.rs"
 
 [profile.release]
-lto = true
 # We assume we're being delivered via e.g. RPM which supports split debuginfo
 debug = true
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -20,6 +20,7 @@ Packaging changes:
 
 - Remove static libraries from vendor archive
 - Require Rust ≥ 1.58.0
+- Disable LTO in release builds
 
 
 ## Afterburn 5.3.0 (2022-04-29)


### PR DESCRIPTION
It's not yet the upstream default, and it's caused miscompilations in the past on non-x86 builds.  We don't especially need the extra optimization, so let's be conservative and drop it.