### PR TITLE
cargo: update MSRV to 1.66

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   # Pinned toolchain for linting
-  ACTIONS_LINTS_TOOLCHAIN: 1.65.0
+  ACTIONS_LINTS_TOOLCHAIN: 1.66.0
 
 jobs:
   tests-stable:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ repository = "https://github.com/coreos/afterburn"
 license = "Apache-2.0"
 edition = "2021"
 # when updating this, also update README.md and docs/index.md
-rust-version = "1.58.0"
+rust-version = "1.66.0"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore"]
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Afterburn
 
 [![crates.io](https://img.shields.io/crates/v/afterburn.svg)](https://crates.io/crates/afterburn)
-![minimum rust 1.58](https://img.shields.io/badge/rust-1.58%2B-orange.svg)
+![minimum rust 1.66](https://img.shields.io/badge/rust-1.66%2B-orange.svg)
 
 Afterburn is a one-shot agent for cloud-like platforms which interacts with provider-specific metadata endpoints.
 It is typically used in conjunction with [Ignition](https://github.com/coreos/ignition).

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ nav_order: 1
 # Afterburn
 
 [![crates.io](https://img.shields.io/crates/v/afterburn.svg)](https://crates.io/crates/afterburn)
-![minimum rust 1.58](https://img.shields.io/badge/rust-1.58%2B-orange.svg)
+![minimum rust 1.66](https://img.shields.io/badge/rust-1.66%2B-orange.svg)
 
 Afterburn is a one-shot agent for cloud-like platforms which interacts with provider-specific metadata endpoints.
 It is typically used in conjunction with [Ignition](https://github.com/coreos/ignition).

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -19,7 +19,7 @@ Minor changes:
 Packaging changes:
 
 - Remove static libraries from vendor archive
-- Require Rust ≥ 1.58.0
+- Require Rust ≥ 1.66.0
 - Disable LTO in release builds
 - Drop `base64`, `byteorder`, `hostname`, `mime`, `serde_derive` dependencies
 


### PR DESCRIPTION
We're now targeting Fedora 37 and RHEL 9.2, both of which have 1.66.