### PR TITLE
cargo: add configuration for cargo-vendor-filterer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,15 @@ publish = false
 pre-release-commit-message = "cargo: Afterburn release {{version}}"
 tag-message = "Afterburn v{{version}}"
 
+# See https://github.com/coreos/cargo-vendor-filterer
+[package.metadata.vendor-filter]
+# cargo-vendor-filterer supports wildcards but requires some degree of LLVM
+# support for every matching platform, which isn't necessarily available
+# out of the box.  Use this as a stand-in.  Note that architecture-specific
+# crate dependencies (apart from wasm32) are uncommon in the ecosystem.
+platforms = ["x86_64-unknown-linux-gnu"]
+all-features = true
+
 [[bin]]
 name = "afterburn"
 path = "src/main.rs"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,7 @@ Minor changes:
 
 Packaging changes:
 
+- Remove non-Linux dependencies from vendor tarball
 
 
 ## Afterburn 5.4.0 (2023-02-03)


### PR DESCRIPTION
See https://github.com/coreos/cargo-vendor-filterer.

This project only targets Linux so we don't need any other platform dependencies.  Notably this obsoletes the manual step to strip all the static library files for the Windows crates.

```
$ find vendor-old -name '*.a' -delete
$ du -sh vendor-old vendor-new
155M	vendor-old
77M	vendor-new
```