### PR TITLE
Update mockito to 1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,25 +378,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
-name = "deadpool"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
-dependencies = [
- "async-trait",
- "deadpool-runtime",
- "num_cpus",
- "retain_mut",
- "tokio",
-]
-
-[[package]]
-name = "deadpool-runtime"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa37046cc0f6c3cc6090fbdbf73ef0b8ef4cfcc37f6befc0020f63e8cf121e1"
-
-[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,14 +981,12 @@ dependencies = [
 
 [[package]]
 name = "mockito"
-version = "0.32.4"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fa08cccbc31b07113e4322d79df4464e0ed888032fc67ec56136325cd3afecf"
+checksum = "a383b2462062a0ef6f378d44b8057ef2bdcb94429b8e30bd4078842cd38ee453"
 dependencies = [
  "assert-json-diff",
- "async-trait",
  "colored",
- "deadpool",
  "futures",
  "hyper",
  "lazy_static",
@@ -1418,12 +1397,6 @@ dependencies = [
  "web-sys",
  "winreg",
 ]
-
-[[package]]
-name = "retain_mut"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,4 +64,4 @@ vmw_backdoor = "0.2"
 zbus = ">= 2.3, < 4"
 
 [dev-dependencies]
-mockito = ">= 0.29, < 0.33"
+mockito = "1"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,7 +14,8 @@ Minor changes:
 
 Packaging changes:
 
-- Require clap ≥ 4
+- Require `clap` ≥ 4
+- Require `mockito` ≥ 1
 
 
 ## Afterburn 5.4.1 (2023-02-06)

--- a/src/providers/aliyun/mod.rs
+++ b/src/providers/aliyun/mod.rs
@@ -4,8 +4,6 @@
 //! The metadata endpoint is documented at https://www.alibabacloud.com/help/doc-detail/49122.htm.
 
 use anyhow::{anyhow, Result};
-#[cfg(test)]
-use mockito;
 use openssh_keys::PublicKey;
 use slog_scope::error;
 use std::collections::{BTreeSet, HashMap};
@@ -31,13 +29,6 @@ impl AliyunProvider {
         Ok(AliyunProvider { client })
     }
 
-    #[cfg(test)]
-    fn endpoint_for(name: &str) -> String {
-        let url = mockito::server_url();
-        format!("{url}/{name}")
-    }
-
-    #[cfg(not(test))]
     fn endpoint_for(name: &str) -> String {
         format!("http://100.100.100.200/latest/meta-data/{name}")
     }

--- a/src/providers/aws/mock_tests.rs
+++ b/src/providers/aws/mock_tests.rs
@@ -7,12 +7,13 @@ use mockito;
 
 #[test]
 fn test_aws_basic() {
-    let ep = "/meta-data/public-keys";
+    let ep = "/2021-01-03/meta-data/public-keys";
     let client = crate::retry::Client::try_new()
         .context("failed to create http client")
         .unwrap()
         .max_retries(0)
-        .return_on_404(true);
+        .return_on_404(true)
+        .mock_base_url(mockito::server_url());
     let provider = aws::AwsProvider { client };
 
     provider.fetch_ssh_keys().unwrap_err();
@@ -56,16 +57,16 @@ fn aws_get_maps() -> (
 
     (
         maplit::btreemap! {
-            "/meta-data/instance-id" => instance_id,
-            "/meta-data/instance-type" => instance_type,
-            "/meta-data/local-ipv4" => ipv4_local,
-            "/meta-data/public-ipv4" => ipv4_public,
-            "/meta-data/ipv6" => ipv6,
-            "/meta-data/placement/availability-zone" => availability_zone,
-            "/meta-data/placement/availability-zone-id" => availability_zone_id,
-            "/meta-data/hostname" => hostname,
-            "/meta-data/public-hostname" => public_hostname,
-            "/dynamic/instance-identity/document" => instance_id_doc,
+            "/2021-01-03/meta-data/instance-id" => instance_id,
+            "/2021-01-03/meta-data/instance-type" => instance_type,
+            "/2021-01-03/meta-data/local-ipv4" => ipv4_local,
+            "/2021-01-03/meta-data/public-ipv4" => ipv4_public,
+            "/2021-01-03/meta-data/ipv6" => ipv6,
+            "/2021-01-03/meta-data/placement/availability-zone" => availability_zone,
+            "/2021-01-03/meta-data/placement/availability-zone-id" => availability_zone_id,
+            "/2021-01-03/meta-data/hostname" => hostname,
+            "/2021-01-03/meta-data/public-hostname" => public_hostname,
+            "/2021-01-03/dynamic/instance-identity/document" => instance_id_doc,
         },
         maplit::hashmap! {
             "AWS_INSTANCE_ID".to_string() => instance_id.to_string(),
@@ -99,7 +100,8 @@ fn test_aws_attributes() {
         .context("failed to create http client")
         .unwrap()
         .max_retries(0)
-        .return_on_404(true);
+        .return_on_404(true)
+        .mock_base_url(mockito::server_url());
     let provider = aws::AwsProvider { client };
 
     let v = provider.attributes().unwrap();
@@ -117,7 +119,8 @@ fn test_aws_imds_version1() {
         .context("failed to create http client")
         .unwrap()
         .max_retries(0)
-        .return_on_404(true);
+        .return_on_404(true)
+        .mock_base_url(mockito::server_url());
 
     let mut mocks = Vec::with_capacity(endpoints.len());
     for (endpoint, body) in endpoints.clone() {
@@ -128,7 +131,7 @@ fn test_aws_imds_version1() {
         mocks.push(m);
     }
 
-    let _m = mockito::mock("PUT", "/api/token")
+    let _m = mockito::mock("PUT", "/latest/api/token")
         .match_header("X-aws-ec2-metadata-token-ttl-seconds", "21600")
         .with_status(403)
         .with_body("Forbidden")
@@ -152,7 +155,8 @@ fn test_aws_imds_version2() {
         .context("failed to create http client")
         .unwrap()
         .max_retries(0)
-        .return_on_404(true);
+        .return_on_404(true)
+        .mock_base_url(mockito::server_url());
 
     let token = "test-api-token";
     let mut mocks = Vec::with_capacity(endpoints.len());
@@ -165,7 +169,7 @@ fn test_aws_imds_version2() {
         mocks.push(m);
     }
 
-    let _m = mockito::mock("PUT", "/api/token")
+    let _m = mockito::mock("PUT", "/latest/api/token")
         .match_header("X-aws-ec2-metadata-token-ttl-seconds", "21600")
         .with_status(200)
         .with_body(token)

--- a/src/providers/aws/mod.rs
+++ b/src/providers/aws/mod.rs
@@ -18,8 +18,6 @@
 use std::collections::HashMap;
 
 use anyhow::{anyhow, bail, Context, Result};
-#[cfg(test)]
-use mockito;
 use openssh_keys::PublicKey;
 use reqwest::header;
 use serde::Deserialize;
@@ -71,13 +69,6 @@ impl AwsProvider {
         Ok(AwsProvider { client })
     }
 
-    #[cfg(test)]
-    fn endpoint_for(key: &str, _use_latest: bool) -> String {
-        let url = mockito::server_url();
-        format!("{url}/{key}")
-    }
-
-    #[cfg(not(test))]
     fn endpoint_for(key: &str, use_latest: bool) -> String {
         // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-categories.html
         const URL: &str = "http://169.254.169.254/2021-01-03";

--- a/src/providers/cloudstack/mock_tests.rs
+++ b/src/providers/cloudstack/mock_tests.rs
@@ -4,7 +4,10 @@ use crate::providers::MetadataProvider;
 #[test]
 fn test_ssh_keys() {
     let mut provider = CloudstackNetwork::try_new().unwrap();
-    provider.client = provider.client.max_retries(0);
+    provider.client = provider
+        .client
+        .max_retries(0)
+        .mock_base_url(mockito::server_url());
 
     let key1 = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCsXe6CfHl45kCIzMF92VhDf2NpBWUyS1+IiTtxm5a83mT9730Hb8xim7GYeJu47kiESw2DAN8vNJ/Irg0apZ217ah2rXXjPQuWYSXuEuap8yLBSjqw8exgqVj/kzW+YqmnHASxI13eoFDxTQQGzyqbqowvxu/5gQmDwBmNAa9bT809ziB/qmpS1mD6qyyFDpR23kUwu3TkgAbwMXBDoqK+pdwfaF9uo9XaLHNEH8lD5BZuG2BeDafm2o76DhNSo83MvcCPNXKLxu3BbX/FCMFO6O8RRqony4i91fEV1b8TbXrbJz1bwEYEnJRvmjnqI/389tQFeYvplXR2WdT9PCKyEAG+j8y6XgecIcdTqV/7gFfak1mp2S7mYHZDnXixsn3MjCP/cIxxJVDitKusnj1TdFqtSXl4tqGccbg/5Sqnt/EVSK4bGwwBxv/YmE0P9cbXLxuEVI0JYzgrQvC8TtUgd8kUu2jqi1/Yj9IWm3aFsl/hhh8YwYrv/gm8PV0TxkM= root@example1";
     let key2 = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDj6FBVgkTt7/DB93VVLk6304Nx7WUjLBJDSCh38zjCimHUpeo9uYDxflfu2N1CLtrSImIKBVP/JRy9g7K4zmRAH/wXw2UxYziX+hZoFIpbW3GmYQqhjx2lDvIRXJI7blhHhTUNWX5f10lFAYOLqA9J859AB1w7ND09+MS3jQgSazCx17h+QZ0qQ6kLSfnXw9PMUOE1Xba9hD1nYj14ryTVj9jrFPMFuUfXdb/G9lsDJ+cGvdE2/RMuPfDmEdo04zvZ5fQJJKvS7OyAuYev4Y+JC8MhEr756ITDZ17yq4BEMo/8rNPxZ5Von/8xnvry+8/2C3ep9rZyHtCwpRb6WT6TndV2ddXKhEIneyd1XiOcWPJguHj5vSoMN3mo8k2PvznGauvxBstvpjUSFLQu869/ZQwyMnbQi3wnkJk5CpLXePXn1J9njocJjt8+SKGijmmIAsmYosx8gmmu3H1mvq9Wi0qqWDITMm+J24AZBEPBhwVrjhLZb5MKxylF6JFJJBs= root@example2";
@@ -29,7 +32,10 @@ fn test_ssh_keys() {
 #[test]
 fn test_ssh_keys_404_ok() {
     let mut provider = CloudstackNetwork::try_new().unwrap();
-    provider.client = provider.client.max_retries(0);
+    provider.client = provider
+        .client
+        .max_retries(0)
+        .mock_base_url(mockito::server_url());
 
     let _m = mockito::mock("GET", "/latest/meta-data/public-keys")
         .with_status(404)

--- a/src/providers/cloudstack/mock_tests.rs
+++ b/src/providers/cloudstack/mock_tests.rs
@@ -3,16 +3,15 @@ use crate::providers::MetadataProvider;
 
 #[test]
 fn test_ssh_keys() {
+    let mut server = mockito::Server::new();
     let mut provider = CloudstackNetwork::try_new().unwrap();
-    provider.client = provider
-        .client
-        .max_retries(0)
-        .mock_base_url(mockito::server_url());
+    provider.client = provider.client.max_retries(0).mock_base_url(server.url());
 
     let key1 = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCsXe6CfHl45kCIzMF92VhDf2NpBWUyS1+IiTtxm5a83mT9730Hb8xim7GYeJu47kiESw2DAN8vNJ/Irg0apZ217ah2rXXjPQuWYSXuEuap8yLBSjqw8exgqVj/kzW+YqmnHASxI13eoFDxTQQGzyqbqowvxu/5gQmDwBmNAa9bT809ziB/qmpS1mD6qyyFDpR23kUwu3TkgAbwMXBDoqK+pdwfaF9uo9XaLHNEH8lD5BZuG2BeDafm2o76DhNSo83MvcCPNXKLxu3BbX/FCMFO6O8RRqony4i91fEV1b8TbXrbJz1bwEYEnJRvmjnqI/389tQFeYvplXR2WdT9PCKyEAG+j8y6XgecIcdTqV/7gFfak1mp2S7mYHZDnXixsn3MjCP/cIxxJVDitKusnj1TdFqtSXl4tqGccbg/5Sqnt/EVSK4bGwwBxv/YmE0P9cbXLxuEVI0JYzgrQvC8TtUgd8kUu2jqi1/Yj9IWm3aFsl/hhh8YwYrv/gm8PV0TxkM= root@example1";
     let key2 = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDj6FBVgkTt7/DB93VVLk6304Nx7WUjLBJDSCh38zjCimHUpeo9uYDxflfu2N1CLtrSImIKBVP/JRy9g7K4zmRAH/wXw2UxYziX+hZoFIpbW3GmYQqhjx2lDvIRXJI7blhHhTUNWX5f10lFAYOLqA9J859AB1w7ND09+MS3jQgSazCx17h+QZ0qQ6kLSfnXw9PMUOE1Xba9hD1nYj14ryTVj9jrFPMFuUfXdb/G9lsDJ+cGvdE2/RMuPfDmEdo04zvZ5fQJJKvS7OyAuYev4Y+JC8MhEr756ITDZ17yq4BEMo/8rNPxZ5Von/8xnvry+8/2C3ep9rZyHtCwpRb6WT6TndV2ddXKhEIneyd1XiOcWPJguHj5vSoMN3mo8k2PvznGauvxBstvpjUSFLQu869/ZQwyMnbQi3wnkJk5CpLXePXn1J9njocJjt8+SKGijmmIAsmYosx8gmmu3H1mvq9Wi0qqWDITMm+J24AZBEPBhwVrjhLZb5MKxylF6JFJJBs= root@example2";
 
-    let _m = mockito::mock("GET", "/latest/meta-data/public-keys")
+    server
+        .mock("GET", "/latest/meta-data/public-keys")
         .with_status(200)
         .with_body(format!("{key1}\n{key2}"))
         .create();
@@ -25,23 +24,22 @@ fn test_ssh_keys() {
     assert_eq!(keys[1].options, None);
     assert_eq!(keys[1].comment, Some("root@example2".to_string()));
 
-    mockito::reset();
+    server.reset();
     provider.ssh_keys().unwrap_err();
 }
 
 #[test]
 fn test_ssh_keys_404_ok() {
+    let mut server = mockito::Server::new();
     let mut provider = CloudstackNetwork::try_new().unwrap();
-    provider.client = provider
-        .client
-        .max_retries(0)
-        .mock_base_url(mockito::server_url());
+    provider.client = provider.client.max_retries(0).mock_base_url(server.url());
 
-    let _m = mockito::mock("GET", "/latest/meta-data/public-keys")
+    server
+        .mock("GET", "/latest/meta-data/public-keys")
         .with_status(404)
         .create();
     let v = provider.ssh_keys().unwrap();
     assert_eq!(v.len(), 0);
-    mockito::reset();
+    server.reset();
     provider.ssh_keys().unwrap_err();
 }

--- a/src/providers/cloudstack/network.rs
+++ b/src/providers/cloudstack/network.rs
@@ -33,8 +33,8 @@ impl CloudstackNetwork {
 
     fn get_server_base_url_from_dhcp() -> Result<String> {
         if cfg!(test) {
-            #[cfg(test)]
-            return Ok(mockito::server_url());
+            // will be ignored by retry.Client
+            return Ok("http://localhost".into());
         }
         let server = DhcpOption::DhcpServerId.get_value()?;
         let ip = server

--- a/src/providers/exoscale/mock_tests.rs
+++ b/src/providers/exoscale/mock_tests.rs
@@ -4,11 +4,14 @@ use mockito;
 
 #[test]
 fn basic_hostname() {
-    let ep = "/local-hostname";
+    let ep = "/1.0/meta-data/local-hostname";
     let hostname = "test-hostname";
 
     let mut provider = exoscale::ExoscaleProvider::try_new().unwrap();
-    provider.client = provider.client.max_retries(0);
+    provider.client = provider
+        .client
+        .max_retries(0)
+        .mock_base_url(mockito::server_url());
 
     {
         let _m503 = mockito::mock("GET", ep).with_status(503).create();
@@ -40,9 +43,12 @@ fn basic_hostname() {
 #[test]
 fn basic_pubkeys() {
     let mut provider = exoscale::ExoscaleProvider::try_new().unwrap();
-    provider.client = provider.client.max_retries(0);
+    provider.client = provider
+        .client
+        .max_retries(0)
+        .mock_base_url(mockito::server_url());
 
-    let _m_keys = mockito::mock("GET", "/public-keys")
+    let _m_keys = mockito::mock("GET", "/1.0/meta-data/public-keys")
         .with_status(200)
         .with_body("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+bqdi18/+JfjrqmOEtVKyCU0bsIc6tBqqU7p9mesJkALocLddDU6d97w2zwERhzaqReDyg4msvQQohgtncb4afKKWQjCCCWlcwtP0nAeg9GFtUfmLeYcP2KAjxblabncluuAnvMHyBixKAjr5eWD4B1HjOmpMRmycwmy85QhGTYhF+AkiHGCPPUDrVy2cIvrPSDXEEa7bz5aQUime0Eold56n3O7E5BJuAozf+oeiWCERRRt9ATlLkMvwVItzBHN25YoMOd0KfgYMtBVAw86TErYFx4Tu98blYNUQTthf9VxcU8xy0rFacXmuS7LHbp+CKDY0X5dNHuhqz0wFto4J test-comment")
         .create();
@@ -71,15 +77,15 @@ fn basic_attributes() {
     let vm_id = "test-vm-id";
 
     let endpoints = maplit::btreemap! {
-        "/local-hostname" => local_hostname,
-        "/public-hostname" => public_hostname,
-        "/instance-id" => instance_id,
-        "/service-offering" => service_offering,
-        "/local-ipv4" => local_ipv4,
-        "/public-ipv4" => public_ipv4,
-        "/availability-zone" => availability_zone,
-        "/cloud-identifier" => cloud_identifier,
-        "/vm-id" => vm_id,
+        "/1.0/meta-data/local-hostname" => local_hostname,
+        "/1.0/meta-data/public-hostname" => public_hostname,
+        "/1.0/meta-data/instance-id" => instance_id,
+        "/1.0/meta-data/service-offering" => service_offering,
+        "/1.0/meta-data/local-ipv4" => local_ipv4,
+        "/1.0/meta-data/public-ipv4" => public_ipv4,
+        "/1.0/meta-data/availability-zone" => availability_zone,
+        "/1.0/meta-data/cloud-identifier" => cloud_identifier,
+        "/1.0/meta-data/vm-id" => vm_id,
     };
     let mut mocks = Vec::with_capacity(endpoints.len());
     for (endpoint, body) in endpoints {
@@ -105,7 +111,8 @@ fn basic_attributes() {
     let client = crate::retry::Client::try_new()
         .unwrap()
         .max_retries(0)
-        .return_on_404(true);
+        .return_on_404(true)
+        .mock_base_url(mockito::server_url());
     let provider = exoscale::ExoscaleProvider { client };
 
     let v = provider.attributes().unwrap();

--- a/src/providers/exoscale/mock_tests.rs
+++ b/src/providers/exoscale/mock_tests.rs
@@ -7,48 +7,40 @@ fn basic_hostname() {
     let ep = "/1.0/meta-data/local-hostname";
     let hostname = "test-hostname";
 
+    let mut server = mockito::Server::new();
     let mut provider = exoscale::ExoscaleProvider::try_new().unwrap();
-    provider.client = provider
-        .client
-        .max_retries(0)
-        .mock_base_url(mockito::server_url());
+    provider.client = provider.client.max_retries(0).mock_base_url(server.url());
 
-    {
-        let _m503 = mockito::mock("GET", ep).with_status(503).create();
-        provider.hostname().unwrap_err();
-    }
+    server.mock("GET", ep).with_status(503).create();
+    provider.hostname().unwrap_err();
 
-    {
-        let _m200 = mockito::mock("GET", ep)
-            .with_status(200)
-            .with_body(hostname)
-            .create();
-        let v = provider.hostname().unwrap();
-        assert_eq!(v, Some(hostname.to_string()));
-    }
+    server
+        .mock("GET", ep)
+        .with_status(200)
+        .with_body(hostname)
+        .create();
+    let v = provider.hostname().unwrap();
+    assert_eq!(v, Some(hostname.to_string()));
 
-    {
-        let _m200_empty = mockito::mock("GET", ep)
-            .with_status(200)
-            .with_body("")
-            .create();
-        let v = provider.hostname().unwrap();
-        assert_eq!(v, None);
-    }
+    server
+        .mock("GET", ep)
+        .with_status(200)
+        .with_body("")
+        .create();
+    let v = provider.hostname().unwrap();
+    assert_eq!(v, None);
 
-    mockito::reset();
+    server.reset();
     provider.hostname().unwrap_err();
 }
 
 #[test]
 fn basic_pubkeys() {
+    let mut server = mockito::Server::new();
     let mut provider = exoscale::ExoscaleProvider::try_new().unwrap();
-    provider.client = provider
-        .client
-        .max_retries(0)
-        .mock_base_url(mockito::server_url());
+    provider.client = provider.client.max_retries(0).mock_base_url(server.url());
 
-    let _m_keys = mockito::mock("GET", "/1.0/meta-data/public-keys")
+    server.mock("GET", "/1.0/meta-data/public-keys")
         .with_status(200)
         .with_body("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+bqdi18/+JfjrqmOEtVKyCU0bsIc6tBqqU7p9mesJkALocLddDU6d97w2zwERhzaqReDyg4msvQQohgtncb4afKKWQjCCCWlcwtP0nAeg9GFtUfmLeYcP2KAjxblabncluuAnvMHyBixKAjr5eWD4B1HjOmpMRmycwmy85QhGTYhF+AkiHGCPPUDrVy2cIvrPSDXEEa7bz5aQUime0Eold56n3O7E5BJuAozf+oeiWCERRRt9ATlLkMvwVItzBHN25YoMOd0KfgYMtBVAw86TErYFx4Tu98blYNUQTthf9VxcU8xy0rFacXmuS7LHbp+CKDY0X5dNHuhqz0wFto4J test-comment")
         .create();
@@ -60,7 +52,7 @@ fn basic_pubkeys() {
     assert_eq!(keys[0].options, None);
     assert_eq!(keys[0].comment, Some("test-comment".to_string()));
 
-    mockito::reset();
+    server.reset();
     provider.ssh_keys().unwrap_err();
 }
 
@@ -87,13 +79,13 @@ fn basic_attributes() {
         "/1.0/meta-data/cloud-identifier" => cloud_identifier,
         "/1.0/meta-data/vm-id" => vm_id,
     };
-    let mut mocks = Vec::with_capacity(endpoints.len());
+    let mut server = mockito::Server::new();
     for (endpoint, body) in endpoints {
-        let m = mockito::mock("GET", endpoint)
+        server
+            .mock("GET", endpoint)
             .with_status(200)
             .with_body(body)
             .create();
-        mocks.push(m);
     }
 
     let attributes = maplit::hashmap! {
@@ -112,12 +104,12 @@ fn basic_attributes() {
         .unwrap()
         .max_retries(0)
         .return_on_404(true)
-        .mock_base_url(mockito::server_url());
+        .mock_base_url(server.url());
     let provider = exoscale::ExoscaleProvider { client };
 
     let v = provider.attributes().unwrap();
     assert_eq!(v, attributes);
 
-    mockito::reset();
+    server.reset();
     provider.attributes().unwrap_err();
 }

--- a/src/providers/exoscale/mod.rs
+++ b/src/providers/exoscale/mod.rs
@@ -39,13 +39,6 @@ impl ExoscaleProvider {
         Ok(ExoscaleProvider { client })
     }
 
-    #[cfg(test)]
-    fn endpoint_for(&self, key: &str) -> String {
-        let url = mockito::server_url();
-        format!("{url}/{key}")
-    }
-
-    #[cfg(not(test))]
     fn endpoint_for(&self, key: &str) -> String {
         format!("http://169.254.169.254/1.0/meta-data/{key}")
     }

--- a/src/providers/gcp/mock_tests.rs
+++ b/src/providers/gcp/mock_tests.rs
@@ -4,11 +4,14 @@ use mockito;
 
 #[test]
 fn basic_hostname() {
-    let ep = "/instance/hostname";
+    let ep = "/computeMetadata/v1/instance/hostname";
     let hostname = "test-hostname";
 
     let mut provider = gcp::GcpProvider::try_new().unwrap();
-    provider.client = provider.client.max_retries(0);
+    provider.client = provider
+        .client
+        .max_retries(0)
+        .mock_base_url(mockito::server_url());
 
     {
         let _m503 = mockito::mock("GET", ep).with_status(503).create();
@@ -42,10 +45,10 @@ fn basic_attributes() {
     let machine_type = "test-machine-type";
 
     let endpoints = maplit::btreemap! {
-        "/instance/hostname" => hostname,
-        "/instance/network-interfaces/0/access-configs/0/external-ip" => ip_external,
-        "/instance/network-interfaces/0/ip" => ip_local,
-        "/instance/machine-type" => machine_type,
+        "/computeMetadata/v1/instance/hostname" => hostname,
+        "/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip" => ip_external,
+        "/computeMetadata/v1/instance/network-interfaces/0/ip" => ip_local,
+        "/computeMetadata/v1/instance/machine-type" => machine_type,
     };
     let mut mocks = Vec::with_capacity(endpoints.len());
     for (endpoint, body) in endpoints {
@@ -66,7 +69,8 @@ fn basic_attributes() {
     let client = crate::retry::Client::try_new()
         .unwrap()
         .max_retries(0)
-        .return_on_404(true);
+        .return_on_404(true)
+        .mock_base_url(mockito::server_url());
     let provider = gcp::GcpProvider { client };
 
     let v = provider.attributes().unwrap();

--- a/src/providers/gcp/mod.rs
+++ b/src/providers/gcp/mod.rs
@@ -15,8 +15,6 @@
 //! google compute engine metadata fetcher
 
 use anyhow::{anyhow, Result};
-#[cfg(test)]
-use mockito;
 use openssh_keys::PublicKey;
 use reqwest::header::{HeaderName, HeaderValue};
 use std::collections::HashMap;
@@ -46,13 +44,6 @@ impl GcpProvider {
         Ok(GcpProvider { client })
     }
 
-    #[cfg(test)]
-    fn endpoint_for(name: &str) -> String {
-        let url = mockito::server_url();
-        format!("{url}/{name}")
-    }
-
-    #[cfg(not(test))]
     fn endpoint_for(name: &str) -> String {
         format!("http://169.254.169.254/computeMetadata/v1/{name}")
     }

--- a/src/providers/microsoft/azure/mock_tests.rs
+++ b/src/providers/microsoft/azure/mock_tests.rs
@@ -125,8 +125,11 @@ fn test_boot_checkin() {
         .with_status(200)
         .create();
 
-    let provider = azure::Azure::try_new();
-    let r = provider.unwrap().boot_checkin();
+    let client = retry::Client::try_new()
+        .unwrap()
+        .mock_base_url(mockito::server_url());
+    let provider = azure::Azure::with_client(Some(client)).unwrap();
+    let r = provider.boot_checkin();
 
     m_version.assert();
     m_goalstate.assert();
@@ -136,7 +139,10 @@ fn test_boot_checkin() {
     mockito::reset();
 
     // Check error logic, but fail fast without re-trying.
-    let client = retry::Client::try_new().unwrap().max_retries(0);
+    let client = retry::Client::try_new()
+        .unwrap()
+        .max_retries(0)
+        .mock_base_url(mockito::server_url());
     azure::Azure::with_client(Some(client)).unwrap_err();
 }
 
@@ -152,8 +158,11 @@ fn test_hostname() {
         .with_status(200)
         .create();
 
-    let provider = azure::Azure::try_new();
-    let r = provider.unwrap().hostname().unwrap();
+    let client = retry::Client::try_new()
+        .unwrap()
+        .mock_base_url(mockito::server_url());
+    let provider = azure::Azure::with_client(Some(client)).unwrap();
+    let r = provider.hostname().unwrap();
 
     m_version.assert();
 
@@ -164,7 +173,10 @@ fn test_hostname() {
     mockito::reset();
 
     // Check error logic, but fail fast without re-trying.
-    let client = retry::Client::try_new().unwrap().max_retries(0);
+    let client = retry::Client::try_new()
+        .unwrap()
+        .max_retries(0)
+        .mock_base_url(mockito::server_url());
     azure::Azure::with_client(Some(client)).unwrap_err();
 }
 
@@ -180,8 +192,11 @@ fn test_vmsize() {
         .with_status(200)
         .create();
 
-    let provider = azure::Azure::try_new();
-    let attributes = provider.unwrap().attributes().unwrap();
+    let client = retry::Client::try_new()
+        .unwrap()
+        .mock_base_url(mockito::server_url());
+    let provider = azure::Azure::with_client(Some(client)).unwrap();
+    let attributes = provider.attributes().unwrap();
     let r = attributes.get("AZURE_VMSIZE");
 
     m_version.assert();
@@ -193,7 +208,10 @@ fn test_vmsize() {
     mockito::reset();
 
     // Check error logic, but fail fast without re-trying.
-    let client = retry::Client::try_new().unwrap().max_retries(0);
+    let client = retry::Client::try_new()
+        .unwrap()
+        .max_retries(0)
+        .mock_base_url(mockito::server_url());
     azure::Azure::with_client(Some(client)).unwrap_err();
 }
 
@@ -202,7 +220,10 @@ fn test_goalstate_certs() {
     let m_version = mock_fab_version();
     let m_goalstate = mock_goalstate(true);
 
-    let provider = azure::Azure::try_new().unwrap();
+    let client = retry::Client::try_new()
+        .unwrap()
+        .mock_base_url(mockito::server_url());
+    let provider = azure::Azure::with_client(Some(client)).unwrap();
     let goalstate = provider.fetch_goalstate().unwrap();
 
     m_version.assert();
@@ -220,7 +241,10 @@ fn test_goalstate_no_certs() {
     let m_version = mock_fab_version();
     let m_goalstate = mock_goalstate(false);
 
-    let provider = azure::Azure::try_new().unwrap();
+    let client = retry::Client::try_new()
+        .unwrap()
+        .mock_base_url(mockito::server_url());
+    let provider = azure::Azure::with_client(Some(client)).unwrap();
     let goalstate = provider.fetch_goalstate().unwrap();
 
     m_version.assert();

--- a/src/providers/microsoft/azure/mock_tests.rs
+++ b/src/providers/microsoft/azure/mock_tests.rs
@@ -67,7 +67,7 @@ static GOALSTATE_BODY_NO_CERTS: &str = r#"<?xml version="1.0" encoding="utf-8"?>
 </GoalState>
 "#;
 
-fn mock_fab_version() -> mockito::Mock {
+fn mock_fab_version(server: &mut mockito::Server) -> mockito::Mock {
     let fab_version = "/?comp=versions";
     let ver_body = r#"<?xml version="1.0" encoding="utf-8"?>
 <Versions>
@@ -88,13 +88,14 @@ fn mock_fab_version() -> mockito::Mock {
   </Supported>
 </Versions>"#;
 
-    mockito::mock("GET", fab_version)
+    server
+        .mock("GET", fab_version)
         .with_body(ver_body)
         .with_status(200)
         .create()
 }
 
-fn mock_goalstate(with_certificates: bool) -> mockito::Mock {
+fn mock_goalstate(server: &mut mockito::Server, with_certificates: bool) -> mockito::Mock {
     let fab_goalstate = "/machine/?comp=goalstate";
 
     let gs_body = if with_certificates {
@@ -103,7 +104,8 @@ fn mock_goalstate(with_certificates: bool) -> mockito::Mock {
         GOALSTATE_BODY_NO_CERTS
     };
 
-    mockito::mock("GET", fab_goalstate)
+    server
+        .mock("GET", fab_goalstate)
         .with_body(gs_body)
         .with_status(200)
         .create()
@@ -111,11 +113,13 @@ fn mock_goalstate(with_certificates: bool) -> mockito::Mock {
 
 #[test]
 fn test_boot_checkin() {
-    let m_version = mock_fab_version();
-    let m_goalstate = mock_goalstate(true);
+    let mut server = mockito::Server::new();
+    let m_version = mock_fab_version(&mut server);
+    let m_goalstate = mock_goalstate(&mut server, true);
 
     let fab_health = "/machine/?comp=health";
-    let m_health = mockito::mock("POST", fab_health)
+    let m_health = server
+        .mock("POST", fab_health)
         .match_header("content-type", Matcher::Regex("text/xml".to_string()))
         .match_header("x-ms-version", Matcher::Regex("2012-11-30".to_string()))
         .match_body(Matcher::Regex("<State>Ready</State>".to_string()))
@@ -127,7 +131,7 @@ fn test_boot_checkin() {
 
     let client = retry::Client::try_new()
         .unwrap()
-        .mock_base_url(mockito::server_url());
+        .mock_base_url(server.url());
     let provider = azure::Azure::with_client(Some(client)).unwrap();
     let r = provider.boot_checkin();
 
@@ -136,23 +140,25 @@ fn test_boot_checkin() {
     m_health.assert();
     r.unwrap();
 
-    mockito::reset();
+    server.reset();
 
     // Check error logic, but fail fast without re-trying.
     let client = retry::Client::try_new()
         .unwrap()
         .max_retries(0)
-        .mock_base_url(mockito::server_url());
+        .mock_base_url(server.url());
     azure::Azure::with_client(Some(client)).unwrap_err();
 }
 
 #[test]
 fn test_hostname() {
-    let m_version = mock_fab_version();
+    let mut server = mockito::Server::new();
+    let m_version = mock_fab_version(&mut server);
 
     let testname = "testname";
     let endpoint = "/metadata/instance/compute/name?api-version=2017-08-01&format=text";
-    let m_hostname = mockito::mock("GET", endpoint)
+    let m_hostname = server
+        .mock("GET", endpoint)
         .match_header("Metadata", "true")
         .with_body(testname)
         .with_status(200)
@@ -160,7 +166,7 @@ fn test_hostname() {
 
     let client = retry::Client::try_new()
         .unwrap()
-        .mock_base_url(mockito::server_url());
+        .mock_base_url(server.url());
     let provider = azure::Azure::with_client(Some(client)).unwrap();
     let r = provider.hostname().unwrap();
 
@@ -170,23 +176,25 @@ fn test_hostname() {
     let hostname = r.unwrap();
     assert_eq!(hostname, testname);
 
-    mockito::reset();
+    server.reset();
 
     // Check error logic, but fail fast without re-trying.
     let client = retry::Client::try_new()
         .unwrap()
         .max_retries(0)
-        .mock_base_url(mockito::server_url());
+        .mock_base_url(server.url());
     azure::Azure::with_client(Some(client)).unwrap_err();
 }
 
 #[test]
 fn test_vmsize() {
-    let m_version = mock_fab_version();
+    let mut server = mockito::Server::new();
+    let m_version = mock_fab_version(&mut server);
 
     let testvmsize = "testvmsize";
     let endpoint = "/metadata/instance/compute/vmSize?api-version=2017-08-01&format=text";
-    let m_vmsize = mockito::mock("GET", endpoint)
+    let m_vmsize = server
+        .mock("GET", endpoint)
         .match_header("Metadata", "true")
         .with_body(testvmsize)
         .with_status(200)
@@ -194,7 +202,7 @@ fn test_vmsize() {
 
     let client = retry::Client::try_new()
         .unwrap()
-        .mock_base_url(mockito::server_url());
+        .mock_base_url(server.url());
     let provider = azure::Azure::with_client(Some(client)).unwrap();
     let attributes = provider.attributes().unwrap();
     let r = attributes.get("AZURE_VMSIZE");
@@ -205,24 +213,25 @@ fn test_vmsize() {
     let vmsize = r.unwrap();
     assert_eq!(vmsize, testvmsize);
 
-    mockito::reset();
+    server.reset();
 
     // Check error logic, but fail fast without re-trying.
     let client = retry::Client::try_new()
         .unwrap()
         .max_retries(0)
-        .mock_base_url(mockito::server_url());
+        .mock_base_url(server.url());
     azure::Azure::with_client(Some(client)).unwrap_err();
 }
 
 #[test]
 fn test_goalstate_certs() {
-    let m_version = mock_fab_version();
-    let m_goalstate = mock_goalstate(true);
+    let mut server = mockito::Server::new();
+    let m_version = mock_fab_version(&mut server);
+    let m_goalstate = mock_goalstate(&mut server, true);
 
     let client = retry::Client::try_new()
         .unwrap()
-        .mock_base_url(mockito::server_url());
+        .mock_base_url(server.url());
     let provider = azure::Azure::with_client(Some(client)).unwrap();
     let goalstate = provider.fetch_goalstate().unwrap();
 
@@ -233,17 +242,18 @@ fn test_goalstate_certs() {
     let certs_url = reqwest::Url::parse(&ep).unwrap();
     assert_eq!(certs_url.scheme(), "http");
 
-    mockito::reset();
+    server.reset();
 }
 
 #[test]
 fn test_goalstate_no_certs() {
-    let m_version = mock_fab_version();
-    let m_goalstate = mock_goalstate(false);
+    let mut server = mockito::Server::new();
+    let m_version = mock_fab_version(&mut server);
+    let m_goalstate = mock_goalstate(&mut server, false);
 
     let client = retry::Client::try_new()
         .unwrap()
-        .mock_base_url(mockito::server_url());
+        .mock_base_url(server.url());
     let provider = azure::Azure::with_client(Some(client)).unwrap();
     let goalstate = provider.fetch_goalstate().unwrap();
 
@@ -252,5 +262,5 @@ fn test_goalstate_no_certs() {
 
     assert_eq!(goalstate.certs_endpoint(), None);
 
-    mockito::reset();
+    server.reset();
 }

--- a/src/providers/microsoft/azure/mock_tests.rs
+++ b/src/providers/microsoft/azure/mock_tests.rs
@@ -1,4 +1,5 @@
 use crate::providers::{microsoft::azure, MetadataProvider};
+use crate::retry;
 use mockito::{self, Matcher};
 
 /// Response body for goalstate (with certificates endpoint).
@@ -135,7 +136,7 @@ fn test_boot_checkin() {
     mockito::reset();
 
     // Check error logic, but fail fast without re-trying.
-    let client = crate::retry::Client::try_new().unwrap().max_retries(0);
+    let client = retry::Client::try_new().unwrap().max_retries(0);
     azure::Azure::with_client(Some(client)).unwrap_err();
 }
 
@@ -163,7 +164,7 @@ fn test_hostname() {
     mockito::reset();
 
     // Check error logic, but fail fast without re-trying.
-    let client = crate::retry::Client::try_new().unwrap().max_retries(0);
+    let client = retry::Client::try_new().unwrap().max_retries(0);
     azure::Azure::with_client(Some(client)).unwrap_err();
 }
 
@@ -192,7 +193,7 @@ fn test_vmsize() {
     mockito::reset();
 
     // Check error logic, but fail fast without re-trying.
-    let client = crate::retry::Client::try_new().unwrap().max_retries(0);
+    let client = retry::Client::try_new().unwrap().max_retries(0);
     azure::Azure::with_client(Some(client)).unwrap_err();
 }
 

--- a/src/providers/microsoft/azure/mod.rs
+++ b/src/providers/microsoft/azure/mod.rs
@@ -338,7 +338,9 @@ impl Azure {
         const NAME_URL: &str = "metadata/instance/compute/name?api-version=2017-08-01&format=text";
         let url = format!("{}/{}", Self::metadata_endpoint(), NAME_URL);
 
-        let name = retry::Client::try_new()?
+        let name = self
+            .client
+            .clone()
             .header(
                 HeaderName::from_static("metadata"),
                 HeaderValue::from_static("true"),
@@ -354,7 +356,9 @@ impl Azure {
             "metadata/instance/compute/vmSize?api-version=2017-08-01&format=text";
         let url = format!("{}/{}", Self::metadata_endpoint(), VMSIZE_URL);
 
-        let vmsize = retry::Client::try_new()?
+        let vmsize = self
+            .client
+            .clone()
             .header(
                 HeaderName::from_static("metadata"),
                 HeaderValue::from_static("true"),

--- a/src/providers/microsoft/azure/mod.rs
+++ b/src/providers/microsoft/azure/mod.rs
@@ -189,7 +189,6 @@ impl Azure {
         Ok(IpAddr::V4(dec.into()))
     }
 
-    #[cfg(not(test))]
     fn fabric_base_url(&self) -> String {
         format!("http://{}", self.endpoint)
     }
@@ -198,11 +197,6 @@ impl Azure {
     fn get_fabric_address() -> IpAddr {
         use std::net::Ipv4Addr;
         IpAddr::from(Ipv4Addr::new(127, 0, 0, 1))
-    }
-
-    #[cfg(test)]
-    fn fabric_base_url(&self) -> String {
-        mockito::server_url()
     }
 
     fn is_fabric_compatible(&self, version: &str) -> Result<()> {
@@ -227,15 +221,8 @@ impl Azure {
         }
     }
 
-    #[cfg(test)]
     fn metadata_endpoint() -> String {
-        mockito::server_url()
-    }
-
-    #[cfg(not(test))]
-    fn metadata_endpoint() -> String {
-        const URL: &str = "http://169.254.169.254";
-        URL.to_string()
+        "http://169.254.169.254".into()
     }
 
     // Fetch the certificate.

--- a/src/providers/microsoft/azurestack/mock_tests.rs
+++ b/src/providers/microsoft/azurestack/mock_tests.rs
@@ -125,8 +125,11 @@ fn test_boot_checkin() {
         .with_status(200)
         .create();
 
-    let provider = azurestack::AzureStack::try_new();
-    let r = provider.unwrap().boot_checkin();
+    let client = retry::Client::try_new()
+        .unwrap()
+        .mock_base_url(mockito::server_url());
+    let provider = azurestack::AzureStack::with_client(Some(client)).unwrap();
+    let r = provider.boot_checkin();
 
     m_version.assert();
     m_goalstate.assert();
@@ -153,8 +156,11 @@ fn test_identity() {
         .with_status(200)
         .create();
 
-    let provider = azurestack::AzureStack::try_new();
-    let r = provider.unwrap().hostname().unwrap();
+    let client = retry::Client::try_new()
+        .unwrap()
+        .mock_base_url(mockito::server_url());
+    let provider = azurestack::AzureStack::with_client(Some(client)).unwrap();
+    let r = provider.hostname().unwrap();
 
     m_version.assert();
 
@@ -182,8 +188,11 @@ fn test_hostname() {
         .with_status(200)
         .create();
 
-    let provider = azurestack::AzureStack::try_new();
-    let r = provider.unwrap().hostname().unwrap();
+    let client = retry::Client::try_new()
+        .unwrap()
+        .mock_base_url(mockito::server_url());
+    let provider = azurestack::AzureStack::with_client(Some(client)).unwrap();
+    let r = provider.hostname().unwrap();
 
     m_version.assert();
 
@@ -203,7 +212,10 @@ fn test_goalstate_certs() {
     let m_version = mock_fab_version();
     let m_goalstate = mock_goalstate(true);
 
-    let provider = azurestack::AzureStack::try_new().unwrap();
+    let client = retry::Client::try_new()
+        .unwrap()
+        .mock_base_url(mockito::server_url());
+    let provider = azurestack::AzureStack::with_client(Some(client)).unwrap();
     let goalstate = provider.fetch_goalstate().unwrap();
 
     m_version.assert();
@@ -221,7 +233,10 @@ fn test_goalstate_no_certs() {
     let m_version = mock_fab_version();
     let m_goalstate = mock_goalstate(false);
 
-    let provider = azurestack::AzureStack::try_new().unwrap();
+    let client = retry::Client::try_new()
+        .unwrap()
+        .mock_base_url(mockito::server_url());
+    let provider = azurestack::AzureStack::with_client(Some(client)).unwrap();
     let goalstate = provider.fetch_goalstate().unwrap();
 
     m_version.assert();

--- a/src/providers/microsoft/azurestack/mock_tests.rs
+++ b/src/providers/microsoft/azurestack/mock_tests.rs
@@ -1,4 +1,5 @@
 use crate::providers::{microsoft::azurestack, MetadataProvider};
+use crate::retry;
 use mockito::{self, Matcher};
 
 /// Response body for goalstate (with certificates endpoint).
@@ -135,7 +136,7 @@ fn test_boot_checkin() {
     mockito::reset();
 
     // Check error logic, but fail fast without re-trying.
-    let client = crate::retry::Client::try_new().unwrap().max_retries(0);
+    let client = retry::Client::try_new().unwrap().max_retries(0);
     azurestack::AzureStack::with_client(Some(client)).unwrap_err();
 }
 
@@ -164,7 +165,7 @@ fn test_identity() {
     mockito::reset();
 
     // Check error logic, but fail fast without re-trying.
-    let client = crate::retry::Client::try_new().unwrap().max_retries(0);
+    let client = retry::Client::try_new().unwrap().max_retries(0);
     azurestack::AzureStack::with_client(Some(client)).unwrap_err();
 }
 
@@ -193,7 +194,7 @@ fn test_hostname() {
     mockito::reset();
 
     // Check error logic, but fail fast without re-trying.
-    let client = crate::retry::Client::try_new().unwrap().max_retries(0);
+    let client = retry::Client::try_new().unwrap().max_retries(0);
     azurestack::AzureStack::with_client(Some(client)).unwrap_err();
 }
 

--- a/src/providers/microsoft/azurestack/mod.rs
+++ b/src/providers/microsoft/azurestack/mod.rs
@@ -168,10 +168,11 @@ impl AzureStack {
             .ok_or_else(|| anyhow!("failed to get goal state: not found response"))
     }
 
-    fn fetch_identity() -> Result<InstanceMetadata> {
+    fn fetch_identity(&self) -> Result<InstanceMetadata> {
         const NAME_URL: &str = "Microsoft.Compute/identity?api-version=2019-03-11";
         let url = format!("{}/{}", Self::metadata_endpoint(), NAME_URL);
-        retry::Client::try_new()?
+        self.client
+            .clone()
             .header(
                 HeaderName::from_static("metadata"),
                 HeaderValue::from_static("true"),
@@ -306,7 +307,7 @@ impl AzureStack {
     }
 
     fn fetch_hostname(&self) -> Result<Option<String>> {
-        let instance_metadata = AzureStack::fetch_identity()?;
+        let instance_metadata = self.fetch_identity()?;
         Ok(Some(instance_metadata.vm_name))
     }
 

--- a/src/providers/microsoft/azurestack/mod.rs
+++ b/src/providers/microsoft/azurestack/mod.rs
@@ -205,7 +205,6 @@ impl AzureStack {
         Ok(IpAddr::V4(dec.into()))
     }
 
-    #[cfg(not(test))]
     fn fabric_base_url(&self) -> String {
         format!("http://{}", self.endpoint)
     }
@@ -214,11 +213,6 @@ impl AzureStack {
     fn get_fabric_address() -> IpAddr {
         use std::net::Ipv4Addr;
         IpAddr::from(Ipv4Addr::new(127, 0, 0, 1))
-    }
-
-    #[cfg(test)]
-    fn fabric_base_url(&self) -> String {
-        mockito::server_url()
     }
 
     fn is_fabric_compatible(&self, version: &str) -> Result<()> {
@@ -243,15 +237,8 @@ impl AzureStack {
         }
     }
 
-    #[cfg(test)]
     fn metadata_endpoint() -> String {
-        mockito::server_url()
-    }
-
-    #[cfg(not(test))]
-    fn metadata_endpoint() -> String {
-        const URL: &str = "http://169.254.169.254";
-        URL.to_string()
+        "http://169.254.169.254".into()
     }
 
     // Fetch the certificate.

--- a/src/providers/openstack/mock_tests.rs
+++ b/src/providers/openstack/mock_tests.rs
@@ -5,14 +5,17 @@ use mockito;
 #[test]
 fn test_ssh_keys() {
     let mut provider = OpenstackProviderNetwork::try_new().unwrap();
-    provider.client = provider.client.max_retries(0);
+    provider.client = provider
+        .client
+        .max_retries(0)
+        .mock_base_url(mockito::server_url());
 
     let key1 = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCsXe6CfHl45kCIzMF92VhDf2NpBWUyS1+IiTtxm5a83mT9730Hb8xim7GYeJu47kiESw2DAN8vNJ/Irg0apZ217ah2rXXjPQuWYSXuEuap8yLBSjqw8exgqVj/kzW+YqmnHASxI13eoFDxTQQGzyqbqowvxu/5gQmDwBmNAa9bT809ziB/qmpS1mD6qyyFDpR23kUwu3TkgAbwMXBDoqK+pdwfaF9uo9XaLHNEH8lD5BZuG2BeDafm2o76DhNSo83MvcCPNXKLxu3BbX/FCMFO6O8RRqony4i91fEV1b8TbXrbJz1bwEYEnJRvmjnqI/389tQFeYvplXR2WdT9PCKyEAG+j8y6XgecIcdTqV/7gFfak1mp2S7mYHZDnXixsn3MjCP/cIxxJVDitKusnj1TdFqtSXl4tqGccbg/5Sqnt/EVSK4bGwwBxv/YmE0P9cbXLxuEVI0JYzgrQvC8TtUgd8kUu2jqi1/Yj9IWm3aFsl/hhh8YwYrv/gm8PV0TxkM= root@example1";
     let key2 = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDj6FBVgkTt7/DB93VVLk6304Nx7WUjLBJDSCh38zjCimHUpeo9uYDxflfu2N1CLtrSImIKBVP/JRy9g7K4zmRAH/wXw2UxYziX+hZoFIpbW3GmYQqhjx2lDvIRXJI7blhHhTUNWX5f10lFAYOLqA9J859AB1w7ND09+MS3jQgSazCx17h+QZ0qQ6kLSfnXw9PMUOE1Xba9hD1nYj14ryTVj9jrFPMFuUfXdb/G9lsDJ+cGvdE2/RMuPfDmEdo04zvZ5fQJJKvS7OyAuYev4Y+JC8MhEr756ITDZ17yq4BEMo/8rNPxZ5Von/8xnvry+8/2C3ep9rZyHtCwpRb6WT6TndV2ddXKhEIneyd1XiOcWPJguHj5vSoMN3mo8k2PvznGauvxBstvpjUSFLQu869/ZQwyMnbQi3wnkJk5CpLXePXn1J9njocJjt8+SKGijmmIAsmYosx8gmmu3H1mvq9Wi0qqWDITMm+J24AZBEPBhwVrjhLZb5MKxylF6JFJJBs= root@example2";
     let endpoints = maplit::btreemap! {
-        "/public-keys" => "0=test1\n1=test2",
-        "/public-keys/0/openssh-key" => key1,
-        "/public-keys/1/openssh-key" => key2,
+        "/latest/meta-data/public-keys" => "0=test1\n1=test2",
+        "/latest/meta-data/public-keys/0/openssh-key" => key1,
+        "/latest/meta-data/public-keys/1/openssh-key" => key2,
     };
 
     let mut mocks = Vec::with_capacity(endpoints.len());
@@ -39,9 +42,12 @@ fn test_ssh_keys() {
 #[test]
 fn test_ssh_keys_404_ok() {
     let mut provider = OpenstackProviderNetwork::try_new().unwrap();
-    provider.client = provider.client.max_retries(0);
+    provider.client = provider
+        .client
+        .max_retries(0)
+        .mock_base_url(mockito::server_url());
 
-    let _m = mockito::mock("GET", "/public-keys")
+    let _m = mockito::mock("GET", "/latest/meta-data/public-keys")
         .with_status(404)
         .create();
     let v = provider.ssh_keys().unwrap();

--- a/src/providers/openstack/mock_tests.rs
+++ b/src/providers/openstack/mock_tests.rs
@@ -4,11 +4,9 @@ use mockito;
 
 #[test]
 fn test_ssh_keys() {
+    let mut server = mockito::Server::new();
     let mut provider = OpenstackProviderNetwork::try_new().unwrap();
-    provider.client = provider
-        .client
-        .max_retries(0)
-        .mock_base_url(mockito::server_url());
+    provider.client = provider.client.max_retries(0).mock_base_url(server.url());
 
     let key1 = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCsXe6CfHl45kCIzMF92VhDf2NpBWUyS1+IiTtxm5a83mT9730Hb8xim7GYeJu47kiESw2DAN8vNJ/Irg0apZ217ah2rXXjPQuWYSXuEuap8yLBSjqw8exgqVj/kzW+YqmnHASxI13eoFDxTQQGzyqbqowvxu/5gQmDwBmNAa9bT809ziB/qmpS1mD6qyyFDpR23kUwu3TkgAbwMXBDoqK+pdwfaF9uo9XaLHNEH8lD5BZuG2BeDafm2o76DhNSo83MvcCPNXKLxu3BbX/FCMFO6O8RRqony4i91fEV1b8TbXrbJz1bwEYEnJRvmjnqI/389tQFeYvplXR2WdT9PCKyEAG+j8y6XgecIcdTqV/7gFfak1mp2S7mYHZDnXixsn3MjCP/cIxxJVDitKusnj1TdFqtSXl4tqGccbg/5Sqnt/EVSK4bGwwBxv/YmE0P9cbXLxuEVI0JYzgrQvC8TtUgd8kUu2jqi1/Yj9IWm3aFsl/hhh8YwYrv/gm8PV0TxkM= root@example1";
     let key2 = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDj6FBVgkTt7/DB93VVLk6304Nx7WUjLBJDSCh38zjCimHUpeo9uYDxflfu2N1CLtrSImIKBVP/JRy9g7K4zmRAH/wXw2UxYziX+hZoFIpbW3GmYQqhjx2lDvIRXJI7blhHhTUNWX5f10lFAYOLqA9J859AB1w7ND09+MS3jQgSazCx17h+QZ0qQ6kLSfnXw9PMUOE1Xba9hD1nYj14ryTVj9jrFPMFuUfXdb/G9lsDJ+cGvdE2/RMuPfDmEdo04zvZ5fQJJKvS7OyAuYev4Y+JC8MhEr756ITDZ17yq4BEMo/8rNPxZ5Von/8xnvry+8/2C3ep9rZyHtCwpRb6WT6TndV2ddXKhEIneyd1XiOcWPJguHj5vSoMN3mo8k2PvznGauvxBstvpjUSFLQu869/ZQwyMnbQi3wnkJk5CpLXePXn1J9njocJjt8+SKGijmmIAsmYosx8gmmu3H1mvq9Wi0qqWDITMm+J24AZBEPBhwVrjhLZb5MKxylF6JFJJBs= root@example2";
@@ -18,13 +16,12 @@ fn test_ssh_keys() {
         "/latest/meta-data/public-keys/1/openssh-key" => key2,
     };
 
-    let mut mocks = Vec::with_capacity(endpoints.len());
     for (endpoint, body) in endpoints {
-        let m = mockito::mock("GET", endpoint)
+        server
+            .mock("GET", endpoint)
             .with_status(200)
             .with_body(body)
             .create();
-        mocks.push(m)
     }
 
     let keys = provider.ssh_keys().unwrap();
@@ -35,23 +32,22 @@ fn test_ssh_keys() {
     assert_eq!(keys[1].options, None);
     assert_eq!(keys[1].comment, Some("root@example2".to_string()));
 
-    mockito::reset();
+    server.reset();
     provider.ssh_keys().unwrap_err();
 }
 
 #[test]
 fn test_ssh_keys_404_ok() {
+    let mut server = mockito::Server::new();
     let mut provider = OpenstackProviderNetwork::try_new().unwrap();
-    provider.client = provider
-        .client
-        .max_retries(0)
-        .mock_base_url(mockito::server_url());
+    provider.client = provider.client.max_retries(0).mock_base_url(server.url());
 
-    let _m = mockito::mock("GET", "/latest/meta-data/public-keys")
+    server
+        .mock("GET", "/latest/meta-data/public-keys")
         .with_status(404)
         .create();
     let v = provider.ssh_keys().unwrap();
     assert_eq!(v.len(), 0);
-    mockito::reset();
+    server.reset();
     provider.ssh_keys().unwrap_err();
 }

--- a/src/providers/openstack/network.rs
+++ b/src/providers/openstack/network.rs
@@ -8,7 +8,6 @@ use openssh_keys::PublicKey;
 use crate::providers::MetadataProvider;
 use crate::retry;
 
-#[cfg(not(test))]
 const URL: &str = "http://169.254.169.254/latest/meta-data";
 
 #[derive(Clone, Debug)]
@@ -22,12 +21,6 @@ impl OpenstackProviderNetwork {
         Ok(OpenstackProviderNetwork { client })
     }
 
-    #[cfg(test)]
-    fn endpoint_for(key: &str) -> String {
-        format!("{}/{}", &mockito::server_url(), key)
-    }
-
-    #[cfg(not(test))]
     fn endpoint_for(key: &str) -> String {
         format!("{URL}/{key}")
     }

--- a/src/providers/packet/mock_tests.rs
+++ b/src/providers/packet/mock_tests.rs
@@ -3,7 +3,10 @@ use mockito::{self, Matcher};
 
 #[test]
 fn test_boot_checkin() {
-    let client = crate::retry::Client::try_new().unwrap().max_retries(0);
+    let client = crate::retry::Client::try_new()
+        .unwrap()
+        .max_retries(0)
+        .mock_base_url(mockito::server_url());
     let data = packet::PacketData {
         id: String::new(),
         hostname: String::new(),
@@ -118,7 +121,11 @@ fn test_packet_attributes() {
         .with_body(metadata)
         .create();
 
-    let provider = packet::PacketProvider::try_new().unwrap();
+    let client = crate::retry::Client::try_new()
+        .unwrap()
+        .max_retries(0)
+        .mock_base_url(mockito::server_url());
+    let provider = packet::PacketProvider::fetch_content(Some(client)).unwrap();
     let v = provider.attributes().unwrap();
 
     assert_eq!(v, attributes);
@@ -126,6 +133,9 @@ fn test_packet_attributes() {
     mockito::reset();
 
     // Check error logic, but fail fast without re-trying.
-    let client = crate::retry::Client::try_new().unwrap().max_retries(0);
+    let client = crate::retry::Client::try_new()
+        .unwrap()
+        .max_retries(0)
+        .mock_base_url(mockito::server_url());
     packet::PacketProvider::fetch_content(Some(client)).unwrap_err();
 }

--- a/src/providers/packet/mock_tests.rs
+++ b/src/providers/packet/mock_tests.rs
@@ -3,6 +3,7 @@ use mockito::{self, Matcher};
 
 #[test]
 fn test_boot_checkin() {
+    let client = crate::retry::Client::try_new().unwrap().max_retries(0);
     let data = packet::PacketData {
         id: String::new(),
         hostname: String::new(),
@@ -19,7 +20,10 @@ fn test_boot_checkin() {
         error: None,
         phone_home_url: mockito::server_url(),
     };
-    let provider = packet::PacketProvider { data };
+    let provider = packet::PacketProvider {
+        client: client.clone(),
+        data,
+    };
 
     let mock = mockito::mock("POST", "/")
         .match_header(
@@ -37,7 +41,6 @@ fn test_boot_checkin() {
     mockito::reset();
 
     // Check error logic, but fail fast without re-trying.
-    let client = crate::retry::Client::try_new().unwrap().max_retries(0);
     packet::PacketProvider::fetch_content(Some(client)).unwrap_err();
 }
 

--- a/src/providers/packet/mod.rs
+++ b/src/providers/packet/mod.rs
@@ -117,16 +117,8 @@ impl PacketProvider {
         Ok(Self { client, data })
     }
 
-    #[cfg(test)]
     fn endpoint_for(name: &str) -> String {
-        let url = mockito::server_url();
-        format!("{url}/{name}")
-    }
-
-    #[cfg(not(test))]
-    fn endpoint_for(name: &str) -> String {
-        let url = "https://metadata.packet.net";
-        format!("{url}/{name}")
+        format!("https://metadata.packet.net/{name}")
     }
 
     fn get_attrs(&self) -> Vec<(String, String)> {

--- a/src/providers/packet/mod.rs
+++ b/src/providers/packet/mod.rs
@@ -90,6 +90,7 @@ struct PacketAddressInfo {
 
 #[derive(Clone, Debug)]
 pub struct PacketProvider {
+    client: retry::Client,
     data: PacketData,
 }
 
@@ -113,7 +114,7 @@ impl PacketProvider {
             .send()?
             .ok_or_else(|| anyhow!("metadata endpoint unreachable"))?;
 
-        Ok(Self { data })
+        Ok(Self { client, data })
     }
 
     #[cfg(test)]
@@ -383,9 +384,8 @@ impl MetadataProvider for PacketProvider {
     }
 
     fn boot_checkin(&self) -> Result<()> {
-        let client = retry::Client::try_new()?;
         let url = self.data.phone_home_url.clone();
-        client.post(retry::Json, url, None).dispatch_post()?;
+        self.client.post(retry::Json, url, None).dispatch_post()?;
         Ok(())
     }
 }

--- a/src/providers/vultr/mock_tests.rs
+++ b/src/providers/vultr/mock_tests.rs
@@ -7,54 +7,44 @@ fn test_hostname() {
     let ep = "/v1/hostname";
     let hostname = "test-hostname";
 
+    let mut server = mockito::Server::new();
     let mut provider = vultr::VultrProvider::try_new().unwrap();
-    provider.client = provider
-        .client
-        .max_retries(0)
-        .mock_base_url(mockito::server_url());
+    provider.client = provider.client.max_retries(0).mock_base_url(server.url());
 
-    {
-        let _m503 = mockito::mock("GET", ep).with_status(503).create();
-        provider.hostname().unwrap_err();
-    }
+    server.mock("GET", ep).with_status(503).create();
+    provider.hostname().unwrap_err();
 
-    {
-        let _m200 = mockito::mock("GET", ep)
-            .with_status(200)
-            .with_body(hostname)
-            .create();
-        let v = provider.hostname().unwrap();
-        assert_eq!(v, Some(hostname.to_string()));
-    }
+    server
+        .mock("GET", ep)
+        .with_status(200)
+        .with_body(hostname)
+        .create();
+    let v = provider.hostname().unwrap();
+    assert_eq!(v, Some(hostname.to_string()));
 
-    {
-        let _m404 = mockito::mock("GET", ep).with_status(404).create();
-        let v = provider.hostname().unwrap();
-        assert_eq!(v, None);
-    }
+    server.mock("GET", ep).with_status(404).create();
+    let v = provider.hostname().unwrap();
+    assert_eq!(v, None);
 
-    {
-        let _m200_empty = mockito::mock("GET", ep)
-            .with_status(200)
-            .with_body("")
-            .create();
-        let v = provider.hostname().unwrap();
-        assert_eq!(v, None);
-    }
+    server
+        .mock("GET", ep)
+        .with_status(200)
+        .with_body("")
+        .create();
+    let v = provider.hostname().unwrap();
+    assert_eq!(v, None);
 
-    mockito::reset();
+    server.reset();
     provider.hostname().unwrap_err();
 }
 
 #[test]
 fn test_pubkeys() {
+    let mut server = mockito::Server::new();
     let mut provider = vultr::VultrProvider::try_new().unwrap();
-    provider.client = provider
-        .client
-        .max_retries(0)
-        .mock_base_url(mockito::server_url());
+    provider.client = provider.client.max_retries(0).mock_base_url(server.url());
 
-    let _m_keys = mockito::mock("GET", "/v1/public-keys")
+    server.mock("GET", "/v1/public-keys")
         .with_status(200)
         .with_body("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCsXe6CfHl45kCIzMF92VhDf2NpBWUyS1+IiTtxm5a83mT9730Hb8xim7GYeJu47kiESw2DAN8vNJ/Irg0apZ217ah2rXXjPQuWYSXuEuap8yLBSjqw8exgqVj/kzW+YqmnHASxI13eoFDxTQQGzyqbqowvxu/5gQmDwBmNAa9bT809ziB/qmpS1mD6qyyFDpR23kUwu3TkgAbwMXBDoqK+pdwfaF9uo9XaLHNEH8lD5BZuG2BeDafm2o76DhNSo83MvcCPNXKLxu3BbX/FCMFO6O8RRqony4i91fEV1b8TbXrbJz1bwEYEnJRvmjnqI/389tQFeYvplXR2WdT9PCKyEAG+j8y6XgecIcdTqV/7gFfak1mp2S7mYHZDnXixsn3MjCP/cIxxJVDitKusnj1TdFqtSXl4tqGccbg/5Sqnt/EVSK4bGwwBxv/YmE0P9cbXLxuEVI0JYzgrQvC8TtUgd8kUu2jqi1/Yj9IWm3aFsl/hhh8YwYrv/gm8PV0TxkM= root@example1\n
                    ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDj6FBVgkTt7/DB93VVLk6304Nx7WUjLBJDSCh38zjCimHUpeo9uYDxflfu2N1CLtrSImIKBVP/JRy9g7K4zmRAH/wXw2UxYziX+hZoFIpbW3GmYQqhjx2lDvIRXJI7blhHhTUNWX5f10lFAYOLqA9J859AB1w7ND09+MS3jQgSazCx17h+QZ0qQ6kLSfnXw9PMUOE1Xba9hD1nYj14ryTVj9jrFPMFuUfXdb/G9lsDJ+cGvdE2/RMuPfDmEdo04zvZ5fQJJKvS7OyAuYev4Y+JC8MhEr756ITDZ17yq4BEMo/8rNPxZ5Von/8xnvry+8/2C3ep9rZyHtCwpRb6WT6TndV2ddXKhEIneyd1XiOcWPJguHj5vSoMN3mo8k2PvznGauvxBstvpjUSFLQu869/ZQwyMnbQi3wnkJk5CpLXePXn1J9njocJjt8+SKGijmmIAsmYosx8gmmu3H1mvq9Wi0qqWDITMm+J24AZBEPBhwVrjhLZb5MKxylF6JFJJBs= root@example2")
@@ -70,7 +60,7 @@ fn test_pubkeys() {
     assert_eq!(keys[1].options, None);
     assert_eq!(keys[1].comment, Some("root@example2".to_string()));
 
-    mockito::reset();
+    server.reset();
     provider.ssh_keys().unwrap_err();
 }
 
@@ -86,13 +76,13 @@ fn test_attributes() {
         "/v1/region/regioncode" => regioncode,
     };
 
-    let mut mocks = Vec::with_capacity(endpoints.len());
+    let mut server = mockito::Server::new();
     for (endpoint, body) in endpoints {
-        let m = mockito::mock("GET", endpoint)
+        server
+            .mock("GET", endpoint)
             .with_status(200)
             .with_body(body)
             .create();
-        mocks.push(m)
     }
 
     let attributes = maplit::hashmap! {
@@ -105,12 +95,12 @@ fn test_attributes() {
         .unwrap()
         .max_retries(0)
         .return_on_404(true)
-        .mock_base_url(mockito::server_url());
+        .mock_base_url(server.url());
     let provider = vultr::VultrProvider { client };
 
     let v = provider.attributes().unwrap();
     assert_eq!(v, attributes);
 
-    mockito::reset();
+    server.reset();
     provider.attributes().unwrap_err();
 }

--- a/src/providers/vultr/mock_tests.rs
+++ b/src/providers/vultr/mock_tests.rs
@@ -4,11 +4,14 @@ use mockito;
 
 #[test]
 fn test_hostname() {
-    let ep = "/hostname";
+    let ep = "/v1/hostname";
     let hostname = "test-hostname";
 
     let mut provider = vultr::VultrProvider::try_new().unwrap();
-    provider.client = provider.client.max_retries(0);
+    provider.client = provider
+        .client
+        .max_retries(0)
+        .mock_base_url(mockito::server_url());
 
     {
         let _m503 = mockito::mock("GET", ep).with_status(503).create();
@@ -46,9 +49,12 @@ fn test_hostname() {
 #[test]
 fn test_pubkeys() {
     let mut provider = vultr::VultrProvider::try_new().unwrap();
-    provider.client = provider.client.max_retries(0);
+    provider.client = provider
+        .client
+        .max_retries(0)
+        .mock_base_url(mockito::server_url());
 
-    let _m_keys = mockito::mock("GET", "/public-keys")
+    let _m_keys = mockito::mock("GET", "/v1/public-keys")
         .with_status(200)
         .with_body("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCsXe6CfHl45kCIzMF92VhDf2NpBWUyS1+IiTtxm5a83mT9730Hb8xim7GYeJu47kiESw2DAN8vNJ/Irg0apZ217ah2rXXjPQuWYSXuEuap8yLBSjqw8exgqVj/kzW+YqmnHASxI13eoFDxTQQGzyqbqowvxu/5gQmDwBmNAa9bT809ziB/qmpS1mD6qyyFDpR23kUwu3TkgAbwMXBDoqK+pdwfaF9uo9XaLHNEH8lD5BZuG2BeDafm2o76DhNSo83MvcCPNXKLxu3BbX/FCMFO6O8RRqony4i91fEV1b8TbXrbJz1bwEYEnJRvmjnqI/389tQFeYvplXR2WdT9PCKyEAG+j8y6XgecIcdTqV/7gFfak1mp2S7mYHZDnXixsn3MjCP/cIxxJVDitKusnj1TdFqtSXl4tqGccbg/5Sqnt/EVSK4bGwwBxv/YmE0P9cbXLxuEVI0JYzgrQvC8TtUgd8kUu2jqi1/Yj9IWm3aFsl/hhh8YwYrv/gm8PV0TxkM= root@example1\n
                    ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDj6FBVgkTt7/DB93VVLk6304Nx7WUjLBJDSCh38zjCimHUpeo9uYDxflfu2N1CLtrSImIKBVP/JRy9g7K4zmRAH/wXw2UxYziX+hZoFIpbW3GmYQqhjx2lDvIRXJI7blhHhTUNWX5f10lFAYOLqA9J859AB1w7ND09+MS3jQgSazCx17h+QZ0qQ6kLSfnXw9PMUOE1Xba9hD1nYj14ryTVj9jrFPMFuUfXdb/G9lsDJ+cGvdE2/RMuPfDmEdo04zvZ5fQJJKvS7OyAuYev4Y+JC8MhEr756ITDZ17yq4BEMo/8rNPxZ5Von/8xnvry+8/2C3ep9rZyHtCwpRb6WT6TndV2ddXKhEIneyd1XiOcWPJguHj5vSoMN3mo8k2PvznGauvxBstvpjUSFLQu869/ZQwyMnbQi3wnkJk5CpLXePXn1J9njocJjt8+SKGijmmIAsmYosx8gmmu3H1mvq9Wi0qqWDITMm+J24AZBEPBhwVrjhLZb5MKxylF6JFJJBs= root@example2")
@@ -75,9 +81,9 @@ fn test_attributes() {
     let regioncode = "test-regioncode";
 
     let endpoints = maplit::btreemap! {
-        "/hostname" => hostname,
-        "/instanceid" => instance_id,
-        "/region/regioncode" => regioncode,
+        "/v1/hostname" => hostname,
+        "/v1/instanceid" => instance_id,
+        "/v1/region/regioncode" => regioncode,
     };
 
     let mut mocks = Vec::with_capacity(endpoints.len());
@@ -98,7 +104,8 @@ fn test_attributes() {
     let client = crate::retry::Client::try_new()
         .unwrap()
         .max_retries(0)
-        .return_on_404(true);
+        .return_on_404(true)
+        .mock_base_url(mockito::server_url());
     let provider = vultr::VultrProvider { client };
 
     let v = provider.attributes().unwrap();

--- a/src/providers/vultr/mod.rs
+++ b/src/providers/vultr/mod.rs
@@ -17,8 +17,6 @@
 //! The metadata endpoint is documented at https://www.vultr.com/metadata/.
 
 use anyhow::Result;
-#[cfg(test)]
-use mockito;
 use openssh_keys::PublicKey;
 use slog_scope::error;
 use std::collections::HashMap;
@@ -41,13 +39,6 @@ impl VultrProvider {
         Ok(VultrProvider { client })
     }
 
-    #[cfg(test)]
-    fn endpoint_for(name: &str) -> String {
-        let url = mockito::server_url();
-        format!("{url}/{name}")
-    }
-
-    #[cfg(not(test))]
     fn endpoint_for(name: &str) -> String {
         format!("http://169.254.169.254/v1/{name}")
     }

--- a/src/retry/client.rs
+++ b/src/retry/client.rs
@@ -213,7 +213,7 @@ where
     where
         T: for<'de> serde::Deserialize<'de>,
     {
-        let url = reqwest::Url::parse(self.url.as_str()).context("failed to parse uri")?;
+        let url = self.parse_url()?;
         let mut req = blocking::Request::new(Method::GET, url);
         req.headers_mut().extend(self.headers.clone().into_iter());
 
@@ -227,7 +227,7 @@ where
     where
         T: for<'de> serde::Deserialize<'de>,
     {
-        let url = reqwest::Url::parse(self.url.as_str()).context("failed to parse uri")?;
+        let url = self.parse_url()?;
 
         self.retry.clone().retry(|attempt| {
             let mut builder = blocking::Client::new()
@@ -254,7 +254,7 @@ where
     }
 
     pub fn dispatch_post(self) -> Result<reqwest::StatusCode> {
-        let url = reqwest::Url::parse(self.url.as_str()).context("failed to parse uri")?;
+        let url = self.parse_url()?;
 
         self.retry.clone().retry(|attempt| {
             let mut builder = blocking::Client::new()
@@ -307,6 +307,10 @@ where
                 Err(anyhow!(e).context("failed to fetch"))
             }
         }
+    }
+
+    fn parse_url(&self) -> Result<reqwest::Url> {
+        reqwest::Url::parse(self.url.as_str()).context("failed to parse uri")
     }
 }
 


### PR DESCRIPTION
The global server object has been removed, so we need to explicitly create servers and configure mocks on them.  Since individual providers can no longer query the global server object for the mock base URL to use, switch to having `retry::Client` rewrite URLs to use a scheme/host/port configured by an individual unit test.

In addition, individual mocks are no longer removed from servers when they go out of scope.  Stop artificially keeping mocks in scope.