### PR TITLE
cli: switch to clap derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,10 +282,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
 dependencies = [
  "bitflags",
+ "clap_derive",
  "clap_lex",
  "once_cell",
  "strsim",
  "terminal_size",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -704,6 +718,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -1289,6 +1309,30 @@ checksum = "66618389e4ec1c7afe67d51a9bf34ff9236480f8d51e7489b7d5ab0303c13f34"
 dependencies = [
  "once_cell",
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ debug = true
 [dependencies]
 anyhow = "1.0"
 cfg-if = "1.0"
-clap = { version = "4", "default_features" = false, "features" = ["std", "cargo", "error-context", "help", "suggestions", "usage", "wrap_help"] }
+clap = { version = "4", "default_features" = false, "features" = ["std", "cargo", "derive", "error-context", "help", "suggestions", "usage", "wrap_help"] }
 ipnetwork = ">= 0.17, < 0.21"
 libsystemd = ">= 0.2.1, < 0.7.0"
 mailparse = ">= 0.13, < 0.15"

--- a/src/cli/exp.rs
+++ b/src/cli/exp.rs
@@ -2,25 +2,15 @@
 
 use crate::{initrd, util};
 use anyhow::Result;
-use clap::ArgMatches;
+use clap::{ArgGroup, Parser};
 
-/// Experimental subcommands.
-#[derive(Debug)]
+/// Experimental subcommands
+#[derive(Debug, Parser)]
 pub enum CliExp {
     RdNetworkKargs(CliRdNetworkKargs),
 }
 
 impl CliExp {
-    /// Parse sub-command into configuration.
-    pub(crate) fn parse(app_matches: &ArgMatches) -> Result<super::CliConfig> {
-        let cfg = match app_matches.subcommand().expect("no subcommand") {
-            ("rd-network-kargs", matches) => CliRdNetworkKargs::parse(matches)?,
-            (x, _) => unreachable!("unrecognized subcommand for 'exp': '{}'", x),
-        };
-
-        Ok(super::CliConfig::Exp(cfg))
-    }
-
     // Run sub-command.
     pub(crate) fn run(&self) -> Result<()> {
         match self {
@@ -30,37 +20,32 @@ impl CliExp {
     }
 }
 
-/// Sub-command for network kernel arguments.
-#[derive(Debug)]
+/// Supplement initrd with network configuration kargs
+#[derive(Debug, Parser)]
+#[command(group(ArgGroup::new("provider-group").args(["cmdline", "provider"]).required(true)))]
 pub struct CliRdNetworkKargs {
-    platform: String,
+    /// Read the cloud provider from the kernel cmdline
+    #[arg(long)]
+    cmdline: bool,
+    /// The name of the cloud provider
+    #[arg(long, value_name = "name")]
+    provider: Option<String>,
+    /// Default value for network kargs fallback
+    #[arg(long = "default-value", value_name = "args")]
     default_kargs: String,
 }
 
 impl CliRdNetworkKargs {
-    /// Parse sub-command into configuration.
-    pub(crate) fn parse(matches: &ArgMatches) -> Result<CliExp> {
-        let platform = super::parse_provider(matches)?;
-        let default_kargs = matches
-            .get_one::<String>("default-value")
-            .expect("missing network kargs default value")
-            .clone();
-
-        let cfg = Self {
-            platform,
-            default_kargs,
-        };
-        Ok(CliExp::RdNetworkKargs(cfg))
-    }
-
     /// Run the sub-command.
     pub(crate) fn run(&self) -> Result<()> {
+        let provider = super::get_provider(self.provider.as_deref())?;
+
         if util::has_network_kargs(super::CMDLINE_PATH)? {
             slog_scope::warn!("kernel cmdline already specifies network arguments, skipping");
             return Ok(());
         };
 
-        let provider_kargs = initrd::fetch_network_kargs(&self.platform)?;
+        let provider_kargs = initrd::fetch_network_kargs(&provider)?;
         let kargs = provider_kargs.as_ref().unwrap_or(&self.default_kargs);
         initrd::write_network_kargs(kargs)
     }

--- a/src/cli/exp.rs
+++ b/src/cli/exp.rs
@@ -1,7 +1,7 @@
 //! `exp` CLI sub-command.
 
 use crate::{initrd, util};
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use clap::ArgMatches;
 
 /// Experimental subcommands.
@@ -43,7 +43,7 @@ impl CliRdNetworkKargs {
         let platform = super::parse_provider(matches)?;
         let default_kargs = matches
             .get_one::<String>("default-value")
-            .ok_or_else(|| anyhow!("missing network kargs default value"))?
+            .expect("missing network kargs default value")
             .clone();
 
         let cfg = Self {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -81,6 +81,7 @@ fn cli_setup() -> Command {
                 .arg(
                     Arg::new("provider")
                         .long("provider")
+                        .value_name("name")
                         .help("The name of the cloud provider")
                         .global(true),
                 )
@@ -94,6 +95,7 @@ fn cli_setup() -> Command {
                 .arg(
                     Arg::new("attributes")
                         .long("attributes")
+                        .value_name("path")
                         .help("The file into which the metadata attributes are written"),
                 )
                 .arg(
@@ -105,16 +107,19 @@ fn cli_setup() -> Command {
                 .arg(
                     Arg::new("hostname")
                         .long("hostname")
+                        .value_name("path")
                         .help("The file into which the hostname should be written"),
                 )
                 .arg(
                     Arg::new("network-units")
                         .long("network-units")
+                        .value_name("path")
                         .help("The directory into which network units are written"),
                 )
                 .arg(
                     Arg::new("ssh-keys")
                         .long("ssh-keys")
+                        .value_name("username")
                         .help("Update SSH keys for the given user"),
                 )
                 .group(
@@ -140,12 +145,14 @@ fn cli_setup() -> Command {
                         .arg(
                             Arg::new("provider")
                                 .long("provider")
+                                .value_name("name")
                                 .help("The name of the cloud provider")
                                 .global(true),
                         )
                         .arg(
                             Arg::new("default-value")
                                 .long("default-value")
+                                .value_name("args")
                                 .help("Default value for network kargs fallback")
                                 .required(true),
                         )


### PR DESCRIPTION
Switch from clap builder to clap derive, dropping a bunch of custom parsing code.

Fixes https://github.com/coreos/afterburn/issues/816.