### PR TITLE
Update metadata for OpenSSL `parse2()` migration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ mailparse = ">= 0.13, < 0.15"
 maplit = "1.0"
 nix = ">= 0.19, < 0.27"
 openssh-keys = ">= 0.5, < 0.7"
-openssl = "0.10"
+openssl = "0.10.46"
 pnet_base = ">= 0.26, < 0.34"
 pnet_datalink = ">= 0.26, < 0.34"
 reqwest = { version = ">= 0.10, < 0.12", features = [ "blocking" ] }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,7 @@ Major changes:
 
 Minor changes:
 
+- Fix SSH key fetching on Azure with `openssl` crate ≥ 0.10.46
 
 Packaging changes:
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -16,6 +16,7 @@ Packaging changes:
 
 - Require `clap` ≥ 4
 - Require `mockito` ≥ 1
+- Require `openssl` ≥ 0.10.46
 
 
 ## Afterburn 5.4.1 (2023-02-06)


### PR DESCRIPTION
On versions of the `openssl` crate new enough to have `parse2()`, the legacy `parse()` function is a wrapper that panics when parsing the Azure SSH key certificate:

    thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', [...]/openssl-0.10.52/src/pkcs12.rs:42:31

We've switched to `parse2()` in the current codebase, but older versions built with newer `openssl` will fail.  Note the fix.

Also update the minimum version of `openssl` to one that has `parse2()`.

See https://github.com/coreos/fedora-coreos-tracker/issues/1492.