### PR TITLE
openstack: Document the two platforms

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -45,11 +45,15 @@ The following platforms are supported, with a different set of features availabl
   - Attributes
   - SSH Keys
 * openstack
-  - Attributes
-  - SSH Keys
+  * Metadata source: config-drive if present, otherwise metadata service
+  * Features:
+      - Attributes
+      - SSH Keys
 * openstack-metadata
-  - Attributes
-  - SSH Keys
+  * Metadata source: metadata service
+  * Features:
+      - Attributes
+      - SSH Keys
 * packet
   - Attributes
   - First-boot check-in


### PR DESCRIPTION
As detailed in https://github.com/coreos/afterburn/pull/462, Afterburn has two separate OpenStack endpoints, each with a different metadata gathering policy. This patch adds the relevant information to the docs.