### PR TITLE
Move away from deprecated `users` to `uzers`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ dependencies = [
  "slog-scope",
  "slog-term",
  "tempfile",
- "users",
+ "uzers",
  "vmw_backdoor",
  "zbus",
 ]
@@ -2066,22 +2066,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "users"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
-dependencies = [
- "libc",
- "log",
-]
-
-[[package]]
 name = "uuid"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "uzers"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d283dc7e8c901e79e32d077866eaf599156cbf427fffa8289aecc52c5c3f63"
+dependencies = [
+ "libc",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ slog-async = ">= 2.5, < 3"
 slog-scope = "4.3"
 slog-term = ">= 2.6, < 3"
 tempfile = ">= 3.2, < 4"
-users = "0.11"
+uzers = "0.11"
 vmw_backdoor = "0.2"
 zbus = ">= 2.3, < 4"
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -16,8 +16,9 @@ Minor changes:
 
 Packaging changes:
 
-Require Rust ≥ 1.71.0
-Specify features depended on from Nix
+- Require Rust ≥ 1.71.0
+- Specify features depended on from Nix
+- Replace deprecated dependency `users` by `uzers`
 
 
 ## Afterburn 5.4.3 (2023-06-05)

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -49,7 +49,7 @@ use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::prelude::*;
 use std::path::Path;
-use users::{self, User};
+use uzers::{self, User};
 
 /// Message ID markers for authorized-keys entries in journal.
 const AFTERBURN_SSH_AUTHORIZED_KEYS_ADDED_MESSAGEID: &str = "0f7d7a502f2d433caa1323440a6b4190";
@@ -90,10 +90,10 @@ fn write_ssh_key_journal_entry(log: logging::Priority, name: &str, path: &str, a
 
 fn write_ssh_keys(user: User, ssh_keys: Vec<PublicKey>) -> Result<()> {
     use std::io::ErrorKind::NotFound;
-    use users::os::unix::UserExt;
+    use uzers::os::unix::UserExt;
 
     // switch users
-    let _guard = users::switch::switch_user_group(user.uid(), user.primary_group_id())
+    let _guard = uzers::switch::switch_user_group(user.uid(), user.primary_group_id())
         .context("failed to switch user/group")?;
 
     // get paths
@@ -230,7 +230,7 @@ pub trait MetadataProvider {
 
     fn write_ssh_keys(&self, ssh_keys_user: String) -> Result<()> {
         let ssh_keys = self.ssh_keys()?;
-        let user = users::get_user_by_name(&ssh_keys_user)
+        let user = uzers::get_user_by_name(&ssh_keys_user)
             .ok_or_else(|| anyhow!("could not find user with username {:?}", ssh_keys_user))?;
 
         write_ssh_keys(user, ssh_keys)?;


### PR DESCRIPTION
It hasn't been updated in years. Move to the adopted crate `uzers`.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2214213
Related: https://rustsec.org/advisories/RUSTSEC-2023-0040.html
Related: https://github.com/ogham/rust-users/issues/54
Closes: https://github.com/coreos/afterburn/issues/999