### PR TITLE
kubevirt: Run afterburn-hostname service

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -15,6 +15,7 @@ Minor changes:
 - openstack: Add `OPENSTACK_INSTANCE_UUID` attribute
 - openstack-metadata: Add `OPENSTACK_INSTANCE_UUID` attribute
 - providers: Add Hetzner Cloud
+- dracut: run hostname service on kubevirt
 
 Packaging changes:
 

--- a/dracut/30afterburn/afterburn-hostname.service
+++ b/dracut/30afterburn/afterburn-hostname.service
@@ -11,6 +11,7 @@ ConditionKernelCommandLine=|ignition.platform.id=digitalocean
 ConditionKernelCommandLine=|ignition.platform.id=exoscale
 ConditionKernelCommandLine=|ignition.platform.id=hetzner
 ConditionKernelCommandLine=|ignition.platform.id=ibmcloud
+ConditionKernelCommandLine=|ignition.platform.id=kubevirt
 ConditionKernelCommandLine=|ignition.platform.id=scaleway
 ConditionKernelCommandLine=|ignition.platform.id=vultr
 


### PR DESCRIPTION
The KubeVirt platform is already supported by afterburn to set the hostname, also there is an official fedora coreos container disk to run it. This change include it in the list of platforms allowed to run afterburn hostname feature at startup.

Close https://issues.redhat.com/browse/OCPBUGS-22259