### PR TITLE
build(deps): allow building with libsystemd 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,14 +978,14 @@ dependencies = [
 
 [[package]]
 name = "libsystemd"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b9597a67aa1c81a6624603e6bd0bcefb9e0f94c9c54970ec53771082104b4e"
+checksum = "c592dc396b464005f78a5853555b9f240bc5378bf5221acc4e129910b2678869"
 dependencies = [
  "hmac",
  "libc",
  "log",
- "nix 0.26.3",
+ "nix 0.27.1",
  "nom",
  "once_cell",
  "serde",
@@ -1064,6 +1064,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,7 +1141,7 @@ dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.7.1",
 ]
 
 [[package]]
@@ -1144,6 +1153,7 @@ dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
  "libc",
+ "memoffset 0.9.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ cfg-if = "1.0"
 clap = { version = "4", "default_features" = false, "features" = ["std", "cargo", "derive", "error-context", "help", "suggestions", "usage", "wrap_help"] }
 ipnetwork = ">= 0.17, < 0.21"
 libflate = "1.3"
-libsystemd = ">= 0.2.1, < 0.7.0"
+libsystemd = ">= 0.2.1, < 0.8.0"
 mailparse = ">= 0.13, < 0.15"
 maplit = "1.0"
 nix = { version = ">= 0.19, < 0.28", "default_features" = false, "features" = [ "mount", "user"] }


### PR DESCRIPTION
This allows building afterburn with the latest version of the libsystemd crate, v0.7.0. Bumping from v0.6.0 to v0.7.0 does not appear to require any code changes.

Not sure why dependabot didn't pick up this one, it made PRs for all previous versions.
