### PR TITLE
providers/vmware: add missing public functions for non-amd64

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,7 @@ Major changes:
 
 Minor changes:
 
+- providers/vmware: add missing public functions for non-amd64
 
 Packaging changes:
 

--- a/src/providers/vmware/unsupported.rs
+++ b/src/providers/vmware/unsupported.rs
@@ -7,4 +7,8 @@ impl VmwareProvider {
     pub fn try_new() -> Result<Self> {
         bail!("unsupported architecture");
     }
+
+    pub fn parse_netplan_config(&self) -> Result<Option<String>> {
+        bail!("unsupported architecture");
+    }
 }


### PR DESCRIPTION
In v5.5.0, `VmwareProvider` must have a corresponding empty function `parse_netplan_config()` in unsupported part as well, just like the amd64 part.

Otherwise build would fail when cross-building afterburn for arm64.

```
error[E0599]: no method named `parse_netplan_config` found for reference
`&VmwareProvider` in the current scope
  --> src/providers/vmware/mod.rs:37:14
   |
37 |         self.parse_netplan_config()
   |              ^^^^^^^^^^^^^^^^^^^^ method not found in
`&VmwareProvider`
```

See also https://github.com/coreos/afterburn/pull/888, https://github.com/flatcar/scripts/pull/1467.