### PR TITLE
build(deps): bump h2 from 0.3.23 to 0.3.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,9 +846,9 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "h2"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b553656127a00601c8ae5590fcfdc118e4083a7924b6cf4ffc1ea4b99dc429d7"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -956,7 +956,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.5",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",


### PR DESCRIPTION
It fixes a denial of service RUSTSEC-2024-0003, but that was not a problem for afterburn as it always already depends on the entity that is the only one that could deny here.