### PR TITLE
microsoft/azure: allow empty certificate chain in PKCS12 file

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,7 @@ Major changes:
 Minor changes:
 
 - Hetzner: fix duplicate attribute prefix
+- Fix Azure SSH key fetching when no key provisioned
 
 Packaging changes:
 

--- a/src/providers/microsoft/azure/mod.rs
+++ b/src/providers/microsoft/azure/mod.rs
@@ -251,7 +251,7 @@ impl Azure {
     }
 
     // put it all together
-    fn get_ssh_pubkey(&self, certs_endpoint: String) -> Result<PublicKey> {
+    fn get_ssh_pubkey(&self, certs_endpoint: String) -> Result<Option<PublicKey>> {
         // we have to generate the rsa public/private keypair and the x509 cert
         // that we use to make the request. this is equivalent to
         // `openssl req -x509 -nodes -subj /CN=LinuxTransport -days 365 -newkey rsa:2048 -keyout private.pem -out cert.pem`
@@ -271,10 +271,7 @@ impl Azure {
             .context("failed to decrypt cms blob")?;
 
         // convert that to the OpenSSH public key format
-        let ssh_pubkey = crypto::p12_to_ssh_pubkey(&p12)
-            .context("failed to convert pkcs12 blob to ssh pubkey")?;
-
-        Ok(ssh_pubkey)
+        crypto::p12_to_ssh_pubkey(&p12).context("failed to convert pkcs12 blob to ssh pubkey")
     }
 
     #[cfg(test)]
@@ -402,18 +399,17 @@ impl MetadataProvider for Azure {
         let goalstate = self.fetch_goalstate()?;
         let certs_endpoint = match goalstate.certs_endpoint() {
             Some(ep) => ep,
-            None => {
-                warn!("SSH pubkeys requested, but not provisioned for this instance");
-                return Ok(vec![]);
-            }
+            None => return Ok(vec![]),
         };
 
         if certs_endpoint.is_empty() {
             bail!("unexpected empty certificates endpoint");
         }
 
-        let key = self.get_ssh_pubkey(certs_endpoint)?;
-        Ok(vec![key])
+        let maybe_key = self.get_ssh_pubkey(certs_endpoint)?;
+        let key: Vec<PublicKey> = maybe_key.into_iter().collect();
+
+        Ok(key)
     }
 
     fn boot_checkin(&self) -> Result<()> {


### PR DESCRIPTION
Azure is populating the certs endpoint even when an SSH key is not
provided. The certificate chain in the PKCS12 file is empty in this
case causing afterburn to fail with the current logic. Check if the
certificate chain is empty before retrieving the SSH public key
and handle this case as a valid option.

The more general `crypto/mod.rs` was updated here which also affected
the azurestack code. Update azurestack to accommodate the changes when
retrieving the SSH public key.

See: https://github.com/coreos/fedora-coreos-tracker/issues/1553