### PR TITLE
providers/hetzner: fix duplicate attribute prefix

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,6 +10,8 @@ Major changes:
 
 Minor changes:
 
+- Hetzner: fix duplicate attribute prefix
+
 Packaging changes:
 
 

--- a/src/providers/hetzner/mock_tests.rs
+++ b/src/providers/hetzner/mock_tests.rs
@@ -35,11 +35,11 @@ vendor_data: "blah blah blah""#
     );
 
     let expected = maplit::hashmap! {
-        "AFTERBURN_HETZNER_AVAILABILITY_ZONE".to_string() => availability_zone.to_string(),
-        "AFTERBURN_HETZNER_HOSTNAME".to_string() => hostname.to_string(),
-        "AFTERBURN_HETZNER_INSTANCE_ID".to_string() => instance_id.to_string(),
-        "AFTERBURN_HETZNER_PUBLIC_IPV4".to_string() => public_ipv4.to_string(),
-        "AFTERBURN_HETZNER_REGION".to_string() => region.to_string(),
+        "HETZNER_AVAILABILITY_ZONE".to_string() => availability_zone.to_string(),
+        "HETZNER_HOSTNAME".to_string() => hostname.to_string(),
+        "HETZNER_INSTANCE_ID".to_string() => instance_id.to_string(),
+        "HETZNER_PUBLIC_IPV4".to_string() => public_ipv4.to_string(),
+        "HETZNER_REGION".to_string() => region.to_string(),
     };
 
     // Fail on not found

--- a/src/providers/hetzner/mod.rs
+++ b/src/providers/hetzner/mod.rs
@@ -112,17 +112,17 @@ impl From<HetznerMetadata> for HashMap<String, String> {
 
         add_value(
             &mut out,
-            "AFTERBURN_HETZNER_AVAILABILITY_ZONE",
+            "HETZNER_AVAILABILITY_ZONE",
             meta.availability_zone,
         );
-        add_value(&mut out, "AFTERBURN_HETZNER_HOSTNAME", meta.hostname);
+        add_value(&mut out, "HETZNER_HOSTNAME", meta.hostname);
         add_value(
             &mut out,
-            "AFTERBURN_HETZNER_INSTANCE_ID",
+            "HETZNER_INSTANCE_ID",
             meta.instance_id.map(|i| i.to_string()),
         );
-        add_value(&mut out, "AFTERBURN_HETZNER_PUBLIC_IPV4", meta.public_ipv4);
-        add_value(&mut out, "AFTERBURN_HETZNER_REGION", meta.region);
+        add_value(&mut out, "HETZNER_PUBLIC_IPV4", meta.public_ipv4);
+        add_value(&mut out, "HETZNER_REGION", meta.region);
 
         out
     }


### PR DESCRIPTION
The attributes generated for the hetzner provider had a duplicate prefix:

    AFTERBURN_AFTERBURN_HETZNER_HOSTNAME=flatcar-test

Afterburn already adds the prefix itself in src/providers/mod.rs `MetadataProvider.write_attributes()`, so the additional prefix added in the hetzner provider was unnecessary.

This is a breaking change for the generated output, not sure how you want to handle this. I can also keep the previous output and just add the new correct output next to it.