### PR TITLE
proxmoxve: do not fail if the config drive does not exist

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,6 +10,8 @@ Major changes:
 
 Minor changes:
 
+- ProxmoxVE: Fixed instance boot without config drive
+
 Packaging changes:
 
 ## Afterburn 5.7.0

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -33,7 +33,7 @@ use crate::providers::openstack;
 use crate::providers::openstack::network::OpenstackProviderNetwork;
 use crate::providers::packet::PacketProvider;
 use crate::providers::powervs::PowerVSProvider;
-use crate::providers::proxmoxve::ProxmoxVEConfigDrive;
+use crate::providers::proxmoxve;
 use crate::providers::scaleway::ScalewayProvider;
 use crate::providers::vmware::VmwareProvider;
 use crate::providers::vultr::VultrProvider;
@@ -71,7 +71,7 @@ pub fn fetch_metadata(provider: &str) -> Result<Box<dyn providers::MetadataProvi
         "openstack-metadata" => box_result!(OpenstackProviderNetwork::try_new()?),
         "packet" => box_result!(PacketProvider::try_new()?),
         "powervs" => box_result!(PowerVSProvider::try_new()?),
-        "proxmoxve" => box_result!(ProxmoxVEConfigDrive::try_new()?),
+        "proxmoxve" => proxmoxve::try_config_drive_else_leave(),
         "scaleway" => box_result!(ScalewayProvider::try_new()?),
         "vmware" => box_result!(VmwareProvider::try_new()?),
         "vultr" => box_result!(VultrProvider::try_new()?),

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -35,6 +35,7 @@ pub mod ibmcloud;
 pub mod ibmcloud_classic;
 pub mod kubevirt;
 pub mod microsoft;
+pub mod noop;
 pub mod openstack;
 pub mod packet;
 pub mod powervs;

--- a/src/providers/noop/mod.rs
+++ b/src/providers/noop/mod.rs
@@ -1,0 +1,28 @@
+// Copyright 2023 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::Result;
+
+use crate::providers::MetadataProvider;
+
+/// Noop provider
+pub struct NoopProvider {}
+
+impl NoopProvider {
+    pub fn try_new() -> Result<NoopProvider> {
+        Ok(Self { })
+    }
+}
+
+impl MetadataProvider for NoopProvider {}

--- a/src/providers/noop/mod.rs
+++ b/src/providers/noop/mod.rs
@@ -21,7 +21,7 @@ pub struct NoopProvider {}
 
 impl NoopProvider {
     pub fn try_new() -> Result<NoopProvider> {
-        Ok(Self { })
+        Ok(Self {})
     }
 }
 

--- a/src/providers/proxmoxve/mod.rs
+++ b/src/providers/proxmoxve/mod.rs
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::providers;
+use crate::providers::noop::NoopProvider;
+use anyhow::Result;
+use slog_scope::warn;
+
 mod configdrive;
 pub use configdrive::*;
 
@@ -20,3 +25,13 @@ pub use cloudconfig::*;
 
 #[cfg(test)]
 mod tests;
+
+pub fn try_config_drive_else_leave() -> Result<Box<dyn providers::MetadataProvider>> {
+    match ProxmoxVEConfigDrive::try_new() {
+        Ok(config_drive) => Ok(Box::new(config_drive)),
+        Err(_) => {
+            warn!("failed to locate config-drive - aborting ProxmoxVE provider");
+            Ok(Box::new(NoopProvider::try_new()?))
+        }
+    }
+}


### PR DESCRIPTION
ProxmoxVE provider will fail to be created if the config drive is not available. In this PR, we add a NoopProvider that is being used in such a case to avoid Afterburn to panic.

This has been tested on Flatcar (https://github.com/flatcar/Flatcar/discussions/1573#discussioncomment-11176313)

Closes: https://github.com/coreos/afterburn/issues/1126
