### PR TITLE
Proxmoxve: Support static network configuration from cloud-init

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,6 +8,8 @@ nav_order: 8
 
 Major changes:
 
+- ProxmoxVE: Add support for static IP configuration from cloud-init
+
 Minor changes:
 
 - ProxmoxVE: Fixed instance boot without config drive
@@ -160,8 +162,8 @@ Changes:
 - providers/gcp: access GCP metadata service by IP address
 - providers/packet: access metadata service over HTTPS
 - cli: don't report an error when --help or --version is specified
-- cli: correctly print version when --version specified 
-- providers: Add PowerVS 
+- cli: correctly print version when --version specified
+- providers: Add PowerVS
 - workflows: bump toolchains; restrict repository access
 
 
@@ -173,7 +175,7 @@ Changes:
 - cargo: update all dependencies
 - *: remove cl-legacy feature
 - ibmcloud: don't ignore I/O error when parsing metadata
-- providers: fix clippy::unnecessary_wraps lint on 1.50 
+- providers: fix clippy::unnecessary_wraps lint on 1.50
 - workflows: update pinned lint toolchain to 1.50.0
 - *: switch from `error-chain` to `anyhow`
 - cli: stop wrapping command-line parse errors
@@ -266,7 +268,7 @@ Changes:
 
 - sshkeys: send structured info to journald
 - ci: test a secondary arch on Travis
-- ci: rust version from 1.39.0 to 1.40.0 
+- ci: rust version from 1.39.0 to 1.40.0
 - makefile: tweak install step
 - providers: add vmware
 - util/cmdline: add helpers for detecting network kargs
@@ -278,7 +280,7 @@ Changes:
 
 Changes:
 
-- cargo: relax dependencies micro versions 
+- cargo: relax dependencies micro versions
 - cargo: switch from deprecated tempdir crate to tempfile
 - providers: add exoscale
 - providers: add ibmcloud-classic as a separate platform
@@ -361,7 +363,7 @@ Changes:
 
 Changes:
 
-- providers/azure: fetch hostname from metadata 
+- providers/azure: fetch hostname from metadata
 - add checkin service files for Azure and Packet
 - metadata: accept "ec2" provider name only in legacy mode
 - bump minimum toolchain to 1.31
@@ -384,7 +386,7 @@ Bugfixes:
 
 - providers/gce: fix panic fetching metadata
 
-Misc: 
+Misc:
 - providers/gce: add basic hostname mock-test
 - rustfmt whole project
 
@@ -491,4 +493,4 @@ and behavior for all providers should be identical to the previous golang
 version.  If it's not, please file a bug in our bug tracker,
 https://github.com/coreos/bugs (or submit a pr!).
 
-Additionally, `coreos-metadata` now supports ssh keys for azure. 
+Additionally, `coreos-metadata` now supports ssh keys for azure.

--- a/src/initrd/mod.rs
+++ b/src/initrd/mod.rs
@@ -4,6 +4,7 @@
 //! services are configured, so it may not be able to use all usual metadata
 //! fetcher.
 
+use crate::providers::proxmoxve::ProxmoxVEConfigDrive;
 use crate::providers::vmware::VmwareProvider;
 use crate::providers::MetadataProvider;
 use anyhow::{Context, Result};
@@ -17,6 +18,7 @@ static KARGS_PATH: &str = "/etc/cmdline.d/50-afterburn-network-kargs.conf";
 pub(crate) fn fetch_network_kargs(provider: &str) -> Result<Option<String>> {
     match provider {
         "vmware" => VmwareProvider::try_new()?.rd_network_kargs(),
+        "proxmoxve" => ProxmoxVEConfigDrive::try_new()?.rd_network_kargs(),
         _ => Ok(None),
     }
 }

--- a/src/providers/proxmoxve/cloudconfig.rs
+++ b/src/providers/proxmoxve/cloudconfig.rs
@@ -34,18 +34,8 @@ pub struct ProxmoxVECloudMetaData {
 #[derive(Debug, Deserialize)]
 pub struct ProxmoxVECloudUserData {
     pub hostname: String,
-    pub manage_etc_hosts: bool,
-    pub fqdn: String,
-    pub chpasswd: ProxmoxVECloudChpasswdConfig,
-    pub users: Vec<String>,
-    pub package_upgrade: bool,
     #[serde(default)]
     pub ssh_authorized_keys: Vec<String>,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct ProxmoxVECloudChpasswdConfig {
-    pub expire: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -53,7 +43,6 @@ pub struct ProxmoxVECloudVendorData {}
 
 #[derive(Debug, Deserialize)]
 pub struct ProxmoxVECloudNetworkConfig {
-    pub version: u32,
     pub config: Vec<ProxmoxVECloudNetworkConfigEntry>,
 }
 
@@ -65,8 +54,6 @@ pub struct ProxmoxVECloudNetworkConfigEntry {
     pub mac_address: Option<String>,
     #[serde(default)]
     pub address: Vec<String>,
-    #[serde(default)]
-    pub search: Vec<String>,
     #[serde(default)]
     pub subnets: Vec<ProxmoxVECloudNetworkConfigSubnet>,
 }

--- a/src/providers/proxmoxve/cloudconfig.rs
+++ b/src/providers/proxmoxve/cloudconfig.rs
@@ -70,11 +70,13 @@ pub struct ProxmoxVECloudNetworkConfigSubnet {
 impl ProxmoxVECloudConfig {
     pub fn try_new(path: &Path) -> Result<Self> {
         let mut user_data = None;
-        let raw_user_data = std::fs::read_to_string(path.join("user-data"))?;
+        let raw_user_data = std::fs::read_to_string(path.join("user-data"))
+            .context("failed to read user-data file")?;
 
         if let Some(first_line) = raw_user_data.split('\n').next() {
             if first_line.starts_with("#cloud-config") {
-                user_data = serde_yaml::from_str(&raw_user_data)?;
+                user_data = serde_yaml::from_str(&raw_user_data)
+                    .context("failed to parse user-data as YAML")?;
             }
         }
 
@@ -86,9 +88,19 @@ impl ProxmoxVECloudConfig {
 
         Ok(Self {
             user_data,
-            meta_data: serde_yaml::from_reader(File::open(path.join("meta-data"))?)?,
-            vendor_data: serde_yaml::from_reader(File::open(path.join("vendor-data"))?)?,
-            network_config: serde_yaml::from_reader(File::open(path.join("network-config"))?)?,
+            meta_data: serde_yaml::from_reader(
+                File::open(path.join("meta-data")).context("failed to open meta-data file")?,
+            )
+            .context("failed to parse meta-data as YAML")?,
+            vendor_data: serde_yaml::from_reader(
+                File::open(path.join("vendor-data")).context("failed to open vendor-data file")?,
+            )
+            .context("failed to parse vendor-data as YAML")?,
+            network_config: serde_yaml::from_reader(
+                File::open(path.join("network-config"))
+                    .context("failed to open network-config file")?,
+            )
+            .context("failed to parse network-config as YAML")?,
         })
     }
 }

--- a/src/providers/proxmoxve/mod.rs
+++ b/src/providers/proxmoxve/mod.rs
@@ -29,8 +29,9 @@ mod tests;
 pub fn try_config_drive_else_leave() -> Result<Box<dyn providers::MetadataProvider>> {
     match ProxmoxVEConfigDrive::try_new() {
         Ok(config_drive) => Ok(Box::new(config_drive)),
-        Err(_) => {
-            warn!("failed to locate config-drive - aborting ProxmoxVE provider");
+        Err(e) => {
+            warn!("failed to locate config-drive: {}", e);
+            warn!("aborting ProxmoxVE provider");
             Ok(Box::new(NoopProvider::try_new()?))
         }
     }

--- a/tests/fixtures/proxmoxve/static-no-gateway/meta-data
+++ b/tests/fixtures/proxmoxve/static-no-gateway/meta-data
@@ -1,0 +1,1 @@
+instance-id: 15a9919cb91024fbd1d70fa07f0efa749cbba03b

--- a/tests/fixtures/proxmoxve/static-no-gateway/network-config
+++ b/tests/fixtures/proxmoxve/static-no-gateway/network-config
@@ -1,0 +1,13 @@
+version: 1
+config:
+  - type: physical
+    name: eth0
+    mac_address: "01:23:45:67:89:00"
+    subnets:
+      - type: static
+        address: "192.168.1.1"
+        netmask: "255.255.255.0"
+  - type: nameserver
+    address:
+      - "1.1.1.1"
+      - "8.8.8.8"

--- a/tests/fixtures/proxmoxve/static-no-gateway/user-data
+++ b/tests/fixtures/proxmoxve/static-no-gateway/user-data
@@ -1,0 +1,13 @@
+#cloud-config
+hostname: dummy
+manage_etc_hosts: true
+fqdn: dummy.local.com
+user: dummy-user
+password: $5$6LDowW6p$.RyFu8lVH7Cw3AB.pPS/K2lmB8IczVs99A7gbcUCLV2
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDd1hElre4j44sbmULXyO5j6dRnkRFCMjEGtRSy2SuvFD8WyB5uectcEMvz7ORhQIVbPlz94wFjpSX5wl/gmSKL/7GOyerJo0Y2cvyjJJahuDn+JnIL0tT0HS1pJ5iJqQpxXeOAzMK5Heum+uGw9BzbiUHnRzjJr8Ltx4CAGMfubevD4SX32Q8BTQiaU4ZnGtdHo16pWwRsq1f6/UtL4gDCni9vm8QmmGDRloi/pBn1csjKw+volFyu/kSEmGLWow6NuT6TrhGAbMKas5HfYq0Mn3LGPZL7XjqJQ6CO0TzkG/BNplZT2tiwHtsvXsbePTp4ZUi4dkCMz2xR4eikaI1V dummy@dummy.local
+chpasswd:
+  expire: False
+users:
+  - default
+package_upgrade: true


### PR DESCRIPTION
This PR adds in support for static network configuration from cloud-init data along with tests. It follows the same methods of configuring the network in the [initramfs](https://coreos.github.io/afterburn/usage/initrd-network-cmdline/#initrd-first-boot-network-arguments) via `afterburn-network-kargs.service`. Instead of reading from injected kargs for the network config like the VMware provider, we read mount the cidata disk and read the values out of the network-config file. 