### PR TITLE
Cargo.toml: bump MSRV to 1.84.1 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ repository = "https://github.com/coreos/afterburn"
 license = "Apache-2.0"
 edition = "2021"
 # when updating this, also update README.md and docs/index.md
-rust-version = "1.75.0"
+rust-version = "1.84.1"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore"]
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -18,6 +18,8 @@ Minor changes:
 
 Packaging changes:
 
+- Require Rust ≥ 1.84.1
+
 ## Afterburn 5.7.0
 
 Major changes:

--- a/src/providers/microsoft/azure/mod.rs
+++ b/src/providers/microsoft/azure/mod.rs
@@ -140,15 +140,13 @@ impl Azure {
         // Make sure WireServer API version is compatible with our logic.
         azure
             .is_fabric_compatible(MS_VERSION)
-            .map_err(|e| {
+            .inspect_err(|_e| {
                 let is_root = Uid::current().is_root();
                 if !is_root {
                     // Firewall rules may be blocking requests from non-root
                     // processes, see https://github.com/coreos/bugs/issues/2468.
                     warn!("unable to reach Azure endpoints, please check whether firewall rules are blocking access to them");
                 }
-
-                e
             })
             .context("failed version compatibility check")?;
 

--- a/src/providers/microsoft/azurestack/mod.rs
+++ b/src/providers/microsoft/azurestack/mod.rs
@@ -141,15 +141,13 @@ impl AzureStack {
         // Make sure WireServer API version is compatible with our logic.
         azure_stack
             .is_fabric_compatible(MS_VERSION)
-            .map_err(|e| {
+            .inspect_err(|_e| {
                 let is_root = Uid::current().is_root();
                 if !is_root {
                     // Firewall rules may be blocking requests from non-root
                     // processes, see https://github.com/coreos/bugs/issues/2468.
                     warn!("unable to reach AzureStack endpoints, please check whether firewall rules are blocking access to them");
                 }
-
-                e
             })
             .context("failed version compatibility check")?;
 


### PR DESCRIPTION
The Afterburn build is failing due to dependencies requiring MSRV 1.84.1. We need to update the MSRV to 1.84.1 to fix the build and ensure CI works for downstream repos.

See the build failure here:
https://github.com/coreos/afterburn/actions/runs/13607099114/job/38039854721?pr=1171

Related PR: 
- https://github.com/coreos/repo-templates/pull/289

Solves:  #1176