### PR TITLE
dracut: Ignore module when building kdump initrd

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,6 +9,7 @@ nav_order: 8
 Major changes:
 
 - Add support for Oracle Cloud Infrastructure
+- dracut: don't include module by default
 
 Minor changes:
 

--- a/dracut/30afterburn/module-setup.sh
+++ b/dracut/30afterburn/module-setup.sh
@@ -3,7 +3,11 @@
 # ex: ts=8 sw=4 sts=4 et filetype=sh
 
 check() {
-    return 0
+    # Return 255 so this module is only included if some other module depends on it
+    # See: https://github.com/coreos/fedora-coreos-tracker/issues/1832
+    #
+    # This module requires integration with the rest of the initramfs, so don't include it by default.
+    return 255
 }
 
 depends() {


### PR DESCRIPTION
Related to: coreos/fedora-coreos-tracker#1832