### PR TITLE
providers/azure: switch SSH key retrieval from certs endpoint to IMDS

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,7 @@ Major changes:
 - Add support for UpCloud
 
 Minor changes:
+- Azure: fetch SSH keys from IMDS instead of deprecated certificates endpoint.
 
 Packaging changes:
 


### PR DESCRIPTION
Azure no longer reliably provides SSH public keys in the goal-state certificates endpoints (`comp=certificates`) but Azure VM provisioning populates keys in the Instance Metadata Service (IMDS) under `compute/publicKeys`.

Update the Azure provider ssh key retrieval to remove the deprecated certificates flow. Instead, query the IMDS and parse the returned keyData entries into `PublicKey`s.

Fixes: https://github.com/coreos/afterburn/issues/1217