### PR TITLE
Fix Azure SharedConfig xml parsing in Attribute retrieval

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -12,6 +12,7 @@ Major changes:
 
 Minor changes:
 - Azure: fetch SSH keys from IMDS instead of deprecated certificates endpoint.
+- Azure: fix parsing of SharedConfig XML document with current serde-xml-rs
 
 Packaging changes:
 

--- a/src/providers/microsoft/azure/mod.rs
+++ b/src/providers/microsoft/azure/mod.rs
@@ -212,15 +212,6 @@ impl Azure {
         "http://169.254.169.254".into()
     }
 
-    #[cfg(test)]
-    fn get_attributes(&self) -> Result<Attributes> {
-        Ok(Attributes {
-            virtual_ipv4: Some(Azure::get_fabric_address()),
-            dynamic_ipv4: Some(Azure::get_fabric_address()),
-        })
-    }
-
-    #[cfg(not(test))]
     fn get_attributes(&self) -> Result<Attributes> {
         use std::net::SocketAddr;
 

--- a/src/providers/microsoft/goalstate.rs
+++ b/src/providers/microsoft/goalstate.rs
@@ -94,7 +94,7 @@ pub(crate) struct SharedConfig {
 #[derive(Debug, Deserialize, Clone)]
 #[allow(dead_code)]
 pub(crate) struct Incarnation {
-    #[serde(rename = "@instance")]
+    #[serde(rename = "@instance", alias = "instance")]
     pub instance: String,
 }
 
@@ -108,9 +108,9 @@ pub(crate) struct Instances {
 #[derive(Debug, Deserialize, Clone)]
 #[allow(dead_code)]
 pub(crate) struct Instance {
-    #[serde(rename = "@id")]
+    #[serde(rename = "@id", alias = "id")]
     pub id: String,
-    #[serde(rename = "@address")]
+    #[serde(rename = "@address", alias = "address")]
     pub address: String,
     #[serde(rename = "InputEndpoints")]
     pub input_endpoints: InputEndpoints,

--- a/src/providers/microsoft/goalstate.rs
+++ b/src/providers/microsoft/goalstate.rs
@@ -94,6 +94,7 @@ pub(crate) struct SharedConfig {
 #[derive(Debug, Deserialize, Clone)]
 #[allow(dead_code)]
 pub(crate) struct Incarnation {
+    #[serde(rename = "@instance")]
     pub instance: String,
 }
 
@@ -107,7 +108,9 @@ pub(crate) struct Instances {
 #[derive(Debug, Deserialize, Clone)]
 #[allow(dead_code)]
 pub(crate) struct Instance {
+    #[serde(rename = "@id")]
     pub id: String,
+    #[serde(rename = "@address")]
     pub address: String,
     #[serde(rename = "InputEndpoints")]
     pub input_endpoints: InputEndpoints,


### PR DESCRIPTION
serde-xml-rs 0.8.0 stopped parsing XML attributes into fields, unless the name starts with '@', so afterburn now panics on Azure.
Add a mock/test that exercises that part of the parser and fix the bug by renaming the 3 fields that seem to be affected by this.

See #1231