### PR TITLE
kubevirt: modprobe for virtio_blk; remove dracut preload

### DIFF
--- a/dracut/30afterburn/afterburn-network-kargs.service
+++ b/dracut/30afterburn/afterburn-network-kargs.service
@@ -14,8 +14,6 @@ OnFailureJobMode=isolate
 
 [Service]
 Environment=AFTERBURN_OPT_PROVIDER=--cmdline
-# To read config drive at kubevirt provider
-ExecStartPre=modprobe virtio_blk
 # AFTERBURN_NETWORK_KARGS_DEFAULT must be set externally by distributions.
 # If unset, variable expansion results in a missing argument and service
 # hard-failure, on purpose.

--- a/src/providers/kubevirt/provider.rs
+++ b/src/providers/kubevirt/provider.rs
@@ -57,6 +57,10 @@ impl KubeVirtProvider {
             .tempdir()
             .context("failed to create temporary directory")?;
 
+        // Best-effort: ensure virtio_blk is available so config devices are visible early
+        // Ignore errors; not all environments require or provide this module
+        let _ = Command::new("modprobe").arg("virtio_blk").status();
+
         let (device_path, format) = match Self::find_config_device() {
             Some(result) => result,
             None => return Ok(None),


### PR DESCRIPTION
As a followup to https://github.com/coreos/afterburn/pull/1238 Lets make sure we dont affect other platforms.