### PR TITLE
Makefile: download `90-afterburn-authorized-keys-file.conf` for rpm building

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -7,6 +7,7 @@ srpm:
 	# similar to https://github.com/actions/checkout/issues/760, but for COPR
 	git config --global --add safe.directory '*'
 	curl -LOf https://src.fedoraproject.org/rpms/rust-afterburn/raw/rawhide/f/rust-afterburn.spec
+	curl -LOf https://src.fedoraproject.org/rpms/rust-afterburn/raw/rawhide/f/90-afterburn-authorized-keys-file.conf
 	version=$$(git describe --always --tags | sed -e 's,-,\.,g' -e 's,^v,,'); \
 	git archive --format=tar --prefix=afterburn-$$version/ HEAD | gzip > afterburn-$$version.crate; \
 	sed -ie "s,^Version:.*,Version: $$version," rust-afterburn.spec

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -10,6 +10,7 @@ packages:
     actions:
       post-upstream-clone:
         - wget https://src.fedoraproject.org/rpms/rust-afterburn/raw/rawhide/f/rust-afterburn.spec
+        - wget https://src.fedoraproject.org/rpms/rust-afterburn/raw/rawhide/f/90-afterburn-authorized-keys-file.conf
       changelog-entry:
         - bash -c 'echo "- New upstream release"'
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,7 @@ Major changes:
 Minor changes:
 
 - KubeVirt: Refactor for a more integrated testing, similar to ProxmoxVE
+- Makefile: download `90-afterburn-authorized-keys-file.conf` for rpm building
 
 Packaging changes:
 


### PR DESCRIPTION
Fix build error because of
https://src.fedoraproject.org/rpms/rust-afterburn/c/e61c6e5f776410ea72e8f731cec88567577f6bb8?branch=rawhide