### PR TITLE
NetworkManager connection profile (keyfile) generation

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,6 +9,7 @@ nav_order: 8
 Major changes:
 
 - KubeVirt: Add support for static and dynamic IP configuration from cloud-init
+- Support the generation of NetworkManager connection profiles (keyfile format)
 
 Minor changes:
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,6 +10,7 @@ Major changes:
 
 - KubeVirt: Add support for static and dynamic IP configuration from cloud-init
 - Hetzner: Add support for network configuration
+- Support the generation of NetworkManager connection profiles (keyfile format)
 
 Minor changes:
 

--- a/src/cli/multi.rs
+++ b/src/cli/multi.rs
@@ -29,6 +29,9 @@ pub struct CliMulti {
     /// The directory into which a netplan config is written
     #[arg(long = "netplan-config", value_name = "path")]
     netplan_config_dir: Option<String>,
+    /// The directory into which NetworkManager connection profiles are written
+    #[arg(long = "networkmanager-profiles", value_name = "path")]
+    networkmanager_profiles_dir: Option<String>,
     /// Update SSH keys for the given user
     #[arg(long = "ssh-keys", value_name = "username")]
     ssh_keys_user: Option<String>,
@@ -45,6 +48,7 @@ impl CliMulti {
         if self.attributes_file.is_none()
             && self.network_units_dir.is_none()
             && self.netplan_config_dir.is_none()
+            && self.networkmanager_profiles_dir.is_none()
             && !self.check_in
             && self.ssh_keys_user.is_none()
             && self.hostname_file.is_none()
@@ -80,6 +84,11 @@ impl CliMulti {
         self.netplan_config_dir
             .map_or(Ok(()), |x| metadata.write_netplan_config(x))
             .context("writing netplan config")?;
+
+        // write NetworkManager profile if configured to do so
+        self.networkmanager_profiles_dir
+            .map_or(Ok(()), |x| metadata.write_nm_profiles(x))
+            .context("writing NetworkManager profile")?;
 
         // perform boot check-in.
         if self.check_in {

--- a/src/network.rs
+++ b/src/network.rs
@@ -19,6 +19,7 @@
 use anyhow::{anyhow, bail, Context, Result};
 use ipnetwork::IpNetwork;
 use pnet_base::MacAddr;
+use slog_scope::warn;
 use std::fmt::Write;
 use std::net::IpAddr;
 use std::string::String;
@@ -113,14 +114,52 @@ pub struct VirtualNetDev {
     pub kind: NetDevKind,
     pub mac_address: MacAddr,
     pub priority: Option<u32>,
-    pub sd_netdev_sections: Vec<SdSection>,
+    pub custom_sections: CustomNetworkSections,
 }
 
 /// A free-form `systemd.netdev` section.
+///
+/// Visit the [systemd documentation](docs) to learn more.
+///
+/// docs: https://www.freedesktop.org/software/systemd/man/latest/systemd.netdev.html
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SdSection {
     pub name: String,
     pub attributes: Vec<(String, String)>,
+}
+
+/// A free-form `NetworkManager` section.
+///
+/// Visit the [NetworkManager documentation](docs) to learn more.
+///
+/// docs: https://www.networkmanager.dev/docs/api/latest/ref-settings.html
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NmSection {
+    pub name: String,
+    pub attributes: Vec<(String, String)>,
+}
+
+/// Defines the free-form network sections used for defining custom attributes for
+/// `systemd.netdev` and `NetworkManager`.
+///
+/// See [`SdSection`] and [`NmSection`] for more information on each.
+//
+// NOTE: These are stored together in this struct to enforce setting
+// both at the same time. This should ensure any provider implementation
+// which uses custom attributes will at least consider both formats.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CustomNetworkSections {
+    sd_netdev_sections: Vec<SdSection>,
+    nm_sections: Vec<NmSection>,
+}
+
+impl CustomNetworkSections {
+    pub fn new(sd_netdev_sections: Vec<SdSection>, nm_sections: Vec<NmSection>) -> Self {
+        Self {
+            sd_netdev_sections,
+            nm_sections,
+        }
+    }
 }
 
 /// Supported virtual network device kinds.
@@ -174,19 +213,24 @@ impl DhcpSetting {
 }
 
 impl Interface {
-    /// Return a deterministic `systemd.network` unit name for this device.
-    pub fn sd_network_unit_name(&self) -> Result<String> {
-        let iface_name = match (&self.name, &self.mac_address, &self.path) {
-            (Some(ref name), _, _) => name.clone(),
+    /// Return a deterministic name for this device
+    pub fn name(&self) -> Result<String> {
+        Ok(match (&self.name, &self.mac_address, &self.path) {
+            (Some(ref name), _, _) => name.to_owned(),
             (None, Some(ref addr), _) => addr.to_string(),
-            (None, None, Some(ref path)) => path.to_string(),
+            (None, None, Some(ref path)) => path.to_owned(),
             (None, None, None) => bail!("network interface without name, MAC address, or path"),
-        };
-        let unit_name = format!("{:02}-{}.network", self.priority, iface_name);
-        Ok(unit_name)
+        })
     }
 
-    pub fn config(&self) -> String {
+    /// Return a deterministic `systemd.networkd` unit name for this device.
+    pub fn sd_unit_name(&self) -> Result<String> {
+        let iface_name = self.name()?;
+        Ok(format!("{:02}-{iface_name}.network", self.priority))
+    }
+
+    /// Return the `systemd.networkd` configuration for this device.
+    pub fn sd_config(&self) -> String {
         let mut config = String::new();
 
         // [Match] section
@@ -241,6 +285,148 @@ impl Interface {
 
         config
     }
+
+    /// Return the `NetworkManager` connection profile configuration for this device.
+    pub fn nm_config(&self) -> Result<String> {
+        let mut config = String::new();
+
+        // [connection] section
+        writeln!(config, "[connection]")?;
+        let iface_name = self.name()?;
+        writeln!(config, "id={}", iface_name)?;
+        writeln!(config, "type=ethernet")?;
+        // NOTE: Only write interface name if there is no mac address to match against.
+        // This is to avoid issues with modern systems which use predictable interface names.
+        // e.g. Hetzner's network-config names the primary interface eth0, but on FCOS the
+        // interface is instead given a predictable name (enp1s0) and hence won't be matched.
+        // See: https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames
+        if self.mac_address.is_none() {
+            if let Some(name) = &self.name {
+                writeln!(config, "interface-name={}", name)?;
+            }
+        }
+        writeln!(config, "autoconnect=true")?;
+        writeln!(
+            config,
+            "autoconnect-priority={}",
+            // Lower number means higher priority for systemd, but it's the opposite for NM
+            100 - (self.priority as u16)
+        )?;
+
+        if let Some(ref bond) = self.bond {
+            writeln!(config, "master={bond}")?;
+            writeln!(config, "slave-type=bond")?;
+        }
+
+        // [ethernet] section
+        if let Some(ref mac) = self.mac_address {
+            writeln!(config, "\n[ethernet]")?;
+            writeln!(config, "mac-address={}", mac)?;
+        }
+
+        // [ipv4] and [ipv6] sections
+        self.write_nm_config_common(&mut config)?;
+
+        Ok(config)
+    }
+
+    /// Write NetworkManager configuration that is common to bond masters and other devices to the
+    /// given string.
+    fn write_nm_config_common(&self, config: &mut String) -> Result<()> {
+        // [ipv4] section
+        writeln!(config, "\n[ipv4]")?;
+
+        let ipv4_addresses: Vec<_> = self.ip_addresses.iter().filter(|a| a.is_ipv4()).collect();
+        if matches!(self.dhcp, Some(DhcpSetting::V4 | DhcpSetting::Both)) {
+            writeln!(config, "method=auto")?;
+        } else if ipv4_addresses.is_empty() {
+            writeln!(config, "method=disabled")?;
+        } else {
+            writeln!(config, "method=manual")?;
+            for (i, addr) in ipv4_addresses.iter().enumerate() {
+                writeln!(config, "address{}={}", i + 1, addr)?;
+            }
+
+            // IPv4 gateway
+            let (default_route, ipv4_routes): (Vec<NetworkRoute>, Vec<NetworkRoute>) = self
+                .routes
+                .iter()
+                .filter(|r| r.destination.is_ipv4())
+                .partition(|r| r.destination.prefix() == 0);
+            if let Some(default_route) = default_route.first() {
+                writeln!(config, "gateway={}", default_route.gateway)?;
+            }
+
+            // IPv4 routes (non-default)
+            for (i, route) in ipv4_routes.iter().enumerate() {
+                writeln!(
+                    config,
+                    "route{}={},{},0",
+                    i + 1,
+                    route.destination,
+                    route.gateway
+                )?;
+            }
+        }
+
+        // IPv4 DNS servers
+        let ipv4_dns: Vec<_> = self.nameservers.iter().filter(|n| n.is_ipv4()).collect();
+        if !ipv4_dns.is_empty() {
+            let dns_list: Vec<_> = ipv4_dns
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect();
+            writeln!(config, "dns={};", dns_list.join(";"))?;
+        }
+
+        // [ipv6] section
+        writeln!(config, "\n[ipv6]")?;
+
+        let ipv6_addresses: Vec<_> = self.ip_addresses.iter().filter(|a| a.is_ipv6()).collect();
+        if matches!(self.dhcp, Some(DhcpSetting::V6 | DhcpSetting::Both)) {
+            writeln!(config, "method=auto")?;
+        } else if ipv6_addresses.is_empty() {
+            writeln!(config, "method=disabled")?;
+        } else {
+            writeln!(config, "method=manual")?;
+            for (i, addr) in ipv6_addresses.iter().enumerate() {
+                writeln!(config, "address{}={}", i + 1, addr)?;
+            }
+
+            // IPv6 gateway
+            let (default_route, ipv6_routes): (Vec<NetworkRoute>, Vec<NetworkRoute>) = self
+                .routes
+                .iter()
+                .filter(|r| r.destination.is_ipv6())
+                .partition(|r| r.destination.prefix() == 0);
+            if let Some(default_route) = default_route.first() {
+                writeln!(config, "gateway={}", default_route.gateway)?;
+            }
+
+            // IPv6 routes (non-default)
+            for (i, route) in ipv6_routes.iter().enumerate() {
+                writeln!(
+                    config,
+                    "route{}={},{},0",
+                    i + 1,
+                    route.destination,
+                    route.gateway
+                )?;
+            }
+        }
+
+        // IPv6 DNS servers
+        let ipv6_dns: Vec<_> = self.nameservers.iter().filter(|n| n.is_ipv6()).collect();
+        if !ipv6_dns.is_empty() {
+            let dns_list: Vec<_> = ipv6_dns
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect();
+            writeln!(config, "dns={};", dns_list.join(";"))?;
+        }
+
+        Ok(())
+    }
 }
 
 impl VirtualNetDev {
@@ -260,7 +446,7 @@ impl VirtualNetDev {
         writeln!(config, "MACAddress={}", self.mac_address).unwrap();
 
         // Custom sections.
-        for section in &self.sd_netdev_sections {
+        for section in &self.custom_sections.sd_netdev_sections {
             writeln!(config, "\n[{}]", section.name).unwrap();
             for attr in &section.attributes {
                 writeln!(config, "{}={}", attr.0, attr.1).unwrap();
@@ -268,6 +454,86 @@ impl VirtualNetDev {
         }
 
         config
+    }
+
+    /// Return the `NetworkManager` connection profile configuration for this virtual device.
+    /// Optionally takes a physical interface, which is used for bond network configuration.
+    pub fn nm_config(&self, physical_interface: Option<&Interface>) -> Result<String> {
+        let mut config = String::new();
+        if self.kind == NetDevKind::Bond && physical_interface.is_none() {
+            warn!("writing bond configuration without networking information",);
+        };
+
+        writeln!(config, "[connection]")?;
+        writeln!(config, "id={}", self.name)?;
+        writeln!(config, "type={}", self.kind.sd_netdev_kind())?;
+        // Unlike in the `Interface` implementation, we don't need to worry about
+        // predictable names, as these devices will be created by NetworkManager.
+        writeln!(config, "interface-name={}", self.name)?;
+        writeln!(config, "autoconnect=true")?;
+        if let Some(priority) = self.priority {
+            writeln!(
+                config,
+                "autoconnect-priority={}",
+                100i32.saturating_sub_unsigned(priority)
+            )?;
+        }
+
+        // Bond and VLAN specific configurations
+        // See:
+        // - https://www.networkmanager.dev/docs/api/latest/settings-vlan.html
+        // - https://www.networkmanager.dev/docs/api/latest/settings-bond.html
+        // - https://www.kernel.org/doc/html/v5.9/networking/bonding.html
+        match self.kind {
+            NetDevKind::Bond => {
+                writeln!(config, "\n[bond]")?;
+
+                if let Some(section) = self
+                    .custom_sections
+                    .nm_sections
+                    .iter()
+                    .find(|s| s.name == "bond")
+                {
+                    for (key, value) in &section.attributes {
+                        writeln!(config, "{}={}", key, value)?;
+                    }
+                };
+
+                // WARN: does not set mac address when creating the device, only when reloading the configuration
+                writeln!(config, "\n[ethernet]")?;
+                writeln!(config, "cloned-mac-address={}", self.mac_address)?;
+
+                if let Some(interface) = physical_interface {
+                    interface.write_nm_config_common(&mut config)?;
+                }
+            }
+            NetDevKind::Vlan => {
+                writeln!(config, "\n[vlan]")?;
+                let mut has_parent = false;
+
+                if let Some(section) = self
+                    .custom_sections
+                    .nm_sections
+                    .iter()
+                    .find(|s| s.name == "vlan")
+                {
+                    for (key, value) in &section.attributes {
+                        if key == "parent" {
+                            has_parent = true;
+                        }
+                        writeln!(config, "{}={}", key, value)?;
+                    }
+                };
+
+                // Match parent based on mac-address
+                if !has_parent {
+                    writeln!(config, "\n[ethernet]")?;
+                    writeln!(config, "mac-address={}", self.mac_address)?;
+                }
+            }
+        }
+
+        Ok(config)
     }
 }
 
@@ -369,7 +635,7 @@ mod tests {
         ];
 
         for (iface, expected) in cases {
-            let unit_name = iface.sd_network_unit_name().unwrap();
+            let unit_name = iface.sd_unit_name().unwrap();
             assert_eq!(unit_name, expected);
         }
     }
@@ -389,7 +655,7 @@ mod tests {
             unmanaged: false,
             required_for_online: None,
         };
-        i.sd_network_unit_name().unwrap_err();
+        i.sd_unit_name().unwrap_err();
     }
 
     #[test]
@@ -401,7 +667,7 @@ mod tests {
                     kind: NetDevKind::Vlan,
                     mac_address: MacAddr(0, 0, 0, 0, 0, 0),
                     priority: Some(20),
-                    sd_netdev_sections: vec![],
+                    custom_sections: CustomNetworkSections::default(),
                 },
                 "20-vlan0.netdev",
             ),
@@ -411,7 +677,7 @@ mod tests {
                     kind: NetDevKind::Vlan,
                     mac_address: MacAddr(0, 0, 0, 0, 0, 0),
                     priority: None,
-                    sd_netdev_sections: vec![],
+                    custom_sections: CustomNetworkSections::default(),
                 },
                 "10-vlan0.netdev",
             ),
@@ -423,7 +689,7 @@ mod tests {
     }
 
     #[test]
-    fn interface_config() {
+    fn interface_sd_config() {
         let is = vec![
             (
                 Interface {
@@ -473,7 +739,7 @@ Gateway=127.0.0.1
 ",
             ),
             // this isn't really a valid interface object, but it's testing
-            // the minimum possible configuration for all peices at the same
+            // the minimum possible configuration for all pieces at the same
             // time, so I'll allow it. (sdemos)
             (
                 Interface {
@@ -567,12 +833,12 @@ DHCP=ipv4
         ];
 
         for (i, s) in is {
-            assert_eq!(i.config(), s);
+            assert_eq!(i.sd_config(), s);
         }
     }
 
     #[test]
-    fn virtual_netdev_config() {
+    fn virtual_netdev_sd_config() {
         let ds = vec![
             (
                 VirtualNetDev {
@@ -580,19 +846,22 @@ DHCP=ipv4
                     kind: NetDevKind::Vlan,
                     mac_address: MacAddr(0, 0, 0, 0, 0, 0),
                     priority: Some(20),
-                    sd_netdev_sections: vec![
-                        SdSection {
-                            name: String::from("Test"),
-                            attributes: vec![
-                                (String::from("foo"), String::from("bar")),
-                                (String::from("oingo"), String::from("boingo")),
-                            ],
-                        },
-                        SdSection {
-                            name: String::from("Empty"),
-                            attributes: vec![],
-                        },
-                    ],
+                    custom_sections: CustomNetworkSections::new(
+                        vec![
+                            SdSection {
+                                name: String::from("Test"),
+                                attributes: vec![
+                                    (String::from("foo"), String::from("bar")),
+                                    (String::from("oingo"), String::from("boingo")),
+                                ],
+                            },
+                            SdSection {
+                                name: String::from("Empty"),
+                                attributes: vec![],
+                            },
+                        ],
+                        vec![],
+                    ),
                 },
                 "[NetDev]
 Name=vlan0
@@ -612,7 +881,7 @@ oingo=boingo
                     kind: NetDevKind::Vlan,
                     mac_address: MacAddr(0, 0, 0, 0, 0, 0),
                     priority: Some(20),
-                    sd_netdev_sections: vec![],
+                    custom_sections: CustomNetworkSections::default(),
                 },
                 "[NetDev]
 Name=vlan0
@@ -624,6 +893,169 @@ MACAddress=00:00:00:00:00:00
 
         for (d, s) in ds {
             assert_eq!(d.sd_netdev_config(), s);
+        }
+    }
+
+    #[test]
+    fn interface_nm_config() {
+        let ds = vec![(
+            Interface {
+                name: Some(String::from("eth0")),
+                mac_address: Some(MacAddr(0, 0, 0, 0, 0, 0)),
+                path: None,
+                priority: 0,
+                nameservers: vec![
+                    IpAddr::V6(Ipv6Addr::new(0x2a01, 0x4ff, 0xff00, 0, 0, 0, 0x0add, 2)),
+                    IpAddr::V6(Ipv6Addr::new(0x2a01, 0x4ff, 0xff00, 0, 0, 0, 0x0add, 1)),
+                ],
+                ip_addresses: vec![IpNetwork::V6(
+                    Ipv6Network::new(Ipv6Addr::new(0x2a01, 0x4f9, 0xc014, 0x6d3b, 0, 0, 0, 1), 64)
+                        .unwrap(),
+                )],
+                dhcp: Some(DhcpSetting::V4),
+                routes: vec![NetworkRoute {
+                    destination: IpNetwork::V6(
+                        Ipv6Network::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0), 0).unwrap(),
+                    ),
+                    gateway: IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1)),
+                }],
+                bond: None,
+                unmanaged: false,
+                required_for_online: None,
+            },
+            "[connection]
+id=eth0
+type=ethernet
+autoconnect=true
+autoconnect-priority=100
+
+[ethernet]
+mac-address=00:00:00:00:00:00
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=manual
+address1=2a01:4f9:c014:6d3b::1/64
+gateway=fe80::1
+dns=2a01:4ff:ff00::add:2;2a01:4ff:ff00::add:1;
+",
+        )];
+
+        for (d, s) in ds {
+            assert_eq!(d.nm_config().unwrap(), s);
+        }
+    }
+
+    #[test]
+    fn virtual_netdev_nm_config() {
+        let interface = Interface {
+            name: Some(String::from("bond0")),
+            mac_address: Some(MacAddr(0, 0, 0, 0, 0, 0)),
+            path: None,
+            priority: 0,
+            nameservers: vec![],
+            ip_addresses: vec![],
+            dhcp: Some(DhcpSetting::V4),
+            routes: vec![],
+            bond: None,
+            unmanaged: false,
+            required_for_online: None,
+        };
+
+        let dis = vec![
+            (
+                VirtualNetDev {
+                    name: String::from("bond0"),
+                    kind: NetDevKind::Bond,
+                    mac_address: MacAddr(0, 0, 0, 0, 0, 0),
+                    priority: Some(20),
+                    custom_sections: CustomNetworkSections::new(
+                        vec![],
+                        vec![NmSection {
+                            name: String::from("bond"),
+                            attributes: vec![
+                                (
+                                    String::from("mode"),
+                                    bonding_mode_to_string(BONDING_MODE_BALANCE_RR).unwrap(),
+                                ),
+                                (String::from("miimon"), String::from("100")),
+                                (String::from("lp_interval"), String::from("2")),
+                                (String::from("arp_validate"), String::from("backup")),
+                                (String::from("all_slaves_active"), String::from("1")),
+                                (String::from("xmit_hash_policy"), String::from("layer2")),
+                            ],
+                        }],
+                    ),
+                },
+                Some(&interface),
+                "[connection]
+id=bond0
+type=bond
+interface-name=bond0
+autoconnect=true
+autoconnect-priority=80
+
+[bond]
+mode=balance-rr
+miimon=100
+lp_interval=2
+arp_validate=backup
+all_slaves_active=1
+xmit_hash_policy=layer2
+
+[ethernet]
+cloned-mac-address=00:00:00:00:00:00
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=disabled
+",
+            ),
+            (
+                VirtualNetDev {
+                    name: String::from("vlan0"),
+                    kind: NetDevKind::Vlan,
+                    mac_address: MacAddr(0, 0, 0, 0, 0, 0),
+                    priority: Some(20),
+                    custom_sections: CustomNetworkSections::new(
+                        vec![],
+                        vec![NmSection {
+                            name: String::from("vlan"),
+                            attributes: vec![
+                                (String::from("id"), String::from("100")),
+                                (String::from("ingress-priority-map"), String::from("25:5")),
+                                (String::from("protocol"), String::from("802.1ad")),
+                                (String::from("flags"), String::from("6")),
+                            ],
+                        }],
+                    ),
+                },
+                None,
+                "[connection]
+id=vlan0
+type=vlan
+interface-name=vlan0
+autoconnect=true
+autoconnect-priority=80
+
+[vlan]
+id=100
+ingress-priority-map=25:5
+protocol=802.1ad
+flags=6
+
+[ethernet]
+mac-address=00:00:00:00:00:00
+",
+            ),
+        ];
+
+        for (d, i, s) in dis {
+            assert_eq!(d.nm_config(i).unwrap(), s);
         }
     }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -22,6 +22,7 @@ use pnet_base::MacAddr;
 use slog_scope::warn;
 use std::fmt::Write;
 use std::net::IpAddr;
+use std::ops::Deref;
 use std::string::String;
 use std::string::ToString;
 
@@ -82,6 +83,55 @@ pub struct NetworkRoute {
     pub gateway: IpAddr,
 }
 
+/// Represents a NetworkManager autoconnect-priority.
+///
+/// Range: -999 to 999
+/// Priority given to higher number, unlike the systemd priorities.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct NmAutoconnectPriority(i16);
+impl NmAutoconnectPriority {
+    const MIN: i16 = -999;
+    const MAX: i16 = 999;
+
+    fn new(priority: i16) -> Self {
+        debug_assert!(priority >= Self::MIN, "value less than the minimum");
+        debug_assert!(priority <= Self::MAX, "value greater than the maximum");
+
+        Self(priority)
+    }
+
+    /// Creates [`Self`] from a systemd.network priority.
+    ///
+    /// While the valid range is 0..4294967295, values above 999 will
+    /// be capped at the minimum NetworkManager priority (0).
+    fn from_systemd_network_priority(priority: u32) -> Self {
+        let priority: i16 = match priority {
+            0..999 => priority as i16,
+            _ => 999,
+        };
+        NmAutoconnectPriority::new(999 - priority)
+    }
+
+    /// Creates [`Self`] from a systemd.netdev priority.
+    ///
+    /// While the valid range is 0..65535, values above 999 will
+    /// be capped at the minimum NetworkManager priority (0).
+    fn from_systemd_netdev_priority(priority: u16) -> Self {
+        let priority: i16 = match priority {
+            0..999 => priority as i16,
+            _ => 999,
+        };
+        NmAutoconnectPriority::new(999 - priority)
+    }
+}
+
+impl Deref for NmAutoconnectPriority {
+    type Target = i16;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 /// A network interface/link.
 ///
 /// Depending on platforms, an interface may be identified by
@@ -95,7 +145,7 @@ pub struct Interface {
     /// Path as identifier
     pub path: Option<String>,
     /// Relative priority for interface configuration.
-    pub priority: u8,
+    pub priority: u32,
     pub nameservers: Vec<IpAddr>,
     pub ip_addresses: Vec<IpNetwork>,
     // Optionally enable DHCP
@@ -113,7 +163,7 @@ pub struct VirtualNetDev {
     pub name: String,
     pub kind: NetDevKind,
     pub mac_address: MacAddr,
-    pub priority: Option<u32>,
+    pub priority: Option<u16>,
     pub custom_sections: CustomNetworkSections,
 }
 
@@ -320,8 +370,7 @@ impl Interface {
         writeln!(
             config,
             "autoconnect-priority={}",
-            // Lower number means higher priority for systemd, but it's the opposite for NM
-            100i32.saturating_sub(i32::from(self.priority))
+            *NmAutoconnectPriority::from_systemd_network_priority(self.priority),
         )?;
 
         if let Some(ref bond) = self.bond {
@@ -486,7 +535,7 @@ impl VirtualNetDev {
             writeln!(
                 config,
                 "autoconnect-priority={}",
-                100i32.saturating_sub_unsigned(priority)
+                *NmAutoconnectPriority::from_systemd_netdev_priority(priority),
             )?;
         }
 
@@ -938,7 +987,7 @@ MACAddress=00:00:00:00:00:00
 id=eth0
 type=ethernet
 autoconnect=true
-autoconnect-priority=100
+autoconnect-priority=999
 
 [ethernet]
 mac-address=00:00:00:00:00:00
@@ -1006,7 +1055,7 @@ id=bond0
 type=bond
 interface-name=bond0
 autoconnect=true
-autoconnect-priority=80
+autoconnect-priority=979
 
 [bond]
 mode=balance-rr
@@ -1051,7 +1100,7 @@ id=vlan0
 type=vlan
 interface-name=vlan0
 autoconnect=true
-autoconnect-priority=80
+autoconnect-priority=979
 
 [vlan]
 id=100

--- a/src/network.rs
+++ b/src/network.rs
@@ -19,6 +19,7 @@
 use anyhow::{anyhow, bail, Context, Result};
 use ipnetwork::IpNetwork;
 use pnet_base::MacAddr;
+use slog_scope::warn;
 use std::fmt::Write;
 use std::net::IpAddr;
 use std::string::String;
@@ -113,14 +114,52 @@ pub struct VirtualNetDev {
     pub kind: NetDevKind,
     pub mac_address: MacAddr,
     pub priority: Option<u32>,
-    pub sd_netdev_sections: Vec<SdSection>,
+    pub custom_sections: CustomNetworkSections,
 }
 
 /// A free-form `systemd.netdev` section.
+///
+/// Visit the [systemd documentation](docs) to learn more.
+///
+/// docs: https://www.freedesktop.org/software/systemd/man/latest/systemd.netdev.html
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SdSection {
     pub name: String,
     pub attributes: Vec<(String, String)>,
+}
+
+/// A free-form `NetworkManager` section.
+///
+/// Visit the [NetworkManager documentation](docs) to learn more.
+///
+/// docs: https://www.networkmanager.dev/docs/api/latest/ref-settings.html
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NmSection {
+    pub name: String,
+    pub attributes: Vec<(String, String)>,
+}
+
+/// Defines the free-form network sections used for defining custom attributes for
+/// `systemd.netdev` and `NetworkManager`.
+///
+/// See [`SdSection`] and [`NmSection`] for more information on each.
+//
+// NOTE: These are stored together in this struct to enforce setting
+// both at the same time. This should ensure any provider implementation
+// which uses custom attributes will at least consider both formats.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CustomNetworkSections {
+    sd_netdev_sections: Vec<SdSection>,
+    nm_sections: Vec<NmSection>,
+}
+
+impl CustomNetworkSections {
+    pub fn new(sd_netdev_sections: Vec<SdSection>, nm_sections: Vec<NmSection>) -> Self {
+        Self {
+            sd_netdev_sections,
+            nm_sections,
+        }
+    }
 }
 
 /// Supported virtual network device kinds.
@@ -185,19 +224,24 @@ impl DhcpSetting {
 }
 
 impl Interface {
-    /// Return a deterministic `systemd.network` unit name for this device.
-    pub fn sd_network_unit_name(&self) -> Result<String> {
-        let iface_name = match (&self.name, &self.mac_address, &self.path) {
-            (Some(ref name), _, _) => name.clone(),
+    /// Return a deterministic name for this device
+    pub fn name(&self) -> Result<String> {
+        Ok(match (&self.name, &self.mac_address, &self.path) {
+            (Some(ref name), _, _) => name.to_owned(),
             (None, Some(ref addr), _) => addr.to_string(),
-            (None, None, Some(ref path)) => path.to_string(),
+            (None, None, Some(ref path)) => path.to_owned(),
             (None, None, None) => bail!("network interface without name, MAC address, or path"),
-        };
-        let unit_name = format!("{:02}-{}.network", self.priority, iface_name);
-        Ok(unit_name)
+        })
     }
 
-    pub fn config(&self) -> String {
+    /// Return a deterministic `systemd.networkd` unit name for this device.
+    pub fn sd_unit_name(&self) -> Result<String> {
+        let iface_name = self.name()?;
+        Ok(format!("{:02}-{iface_name}.network", self.priority))
+    }
+
+    /// Return the `systemd.networkd` configuration for this device.
+    pub fn sd_config(&self) -> String {
         let mut config = String::new();
 
         // [Match] section
@@ -252,6 +296,148 @@ impl Interface {
 
         config
     }
+
+    /// Return the `NetworkManager` connection profile configuration for this device.
+    pub fn nm_config(&self) -> Result<String> {
+        let mut config = String::new();
+
+        // [connection] section
+        writeln!(config, "[connection]")?;
+        let iface_name = self.name()?;
+        writeln!(config, "id={}", iface_name)?;
+        writeln!(config, "type=ethernet")?;
+        // NOTE: Only write interface name if there is no mac address to match against.
+        // This is to avoid issues with modern systems which use predictable interface names.
+        // e.g. Hetzner's network-config names the primary interface eth0, but on FCOS the
+        // interface is instead given a predictable name (enp1s0) and hence won't be matched.
+        // See: https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames
+        if self.mac_address.is_none() {
+            if let Some(name) = &self.name {
+                writeln!(config, "interface-name={}", name)?;
+            }
+        }
+        writeln!(config, "autoconnect=true")?;
+        writeln!(
+            config,
+            "autoconnect-priority={}",
+            // Lower number means higher priority for systemd, but it's the opposite for NM
+            100i32.saturating_sub(i32::from(self.priority))
+        )?;
+
+        if let Some(ref bond) = self.bond {
+            writeln!(config, "master={bond}")?;
+            writeln!(config, "slave-type=bond")?;
+        }
+
+        // [ethernet] section
+        if let Some(ref mac) = self.mac_address {
+            writeln!(config, "\n[ethernet]")?;
+            writeln!(config, "mac-address={}", mac)?;
+        }
+
+        // [ipv4] and [ipv6] sections
+        self.write_nm_config_common(&mut config)?;
+
+        Ok(config)
+    }
+
+    /// Write NetworkManager configuration that is common to bond masters and other devices to the
+    /// given string.
+    fn write_nm_config_common(&self, config: &mut String) -> Result<()> {
+        // [ipv4] section
+        writeln!(config, "\n[ipv4]")?;
+
+        let ipv4_addresses: Vec<_> = self.ip_addresses.iter().filter(|a| a.is_ipv4()).collect();
+        if matches!(self.dhcp, Some(DhcpSetting::V4 | DhcpSetting::Both)) {
+            writeln!(config, "method=auto")?;
+        } else if ipv4_addresses.is_empty() {
+            writeln!(config, "method=disabled")?;
+        } else {
+            writeln!(config, "method=manual")?;
+            for (i, addr) in ipv4_addresses.iter().enumerate() {
+                writeln!(config, "address{}={}", i + 1, addr)?;
+            }
+
+            // IPv4 gateway
+            let (default_route, ipv4_routes): (Vec<NetworkRoute>, Vec<NetworkRoute>) = self
+                .routes
+                .iter()
+                .filter(|r| r.destination.is_ipv4())
+                .partition(|r| r.destination.prefix() == 0);
+            if let Some(default_route) = default_route.first() {
+                writeln!(config, "gateway={}", default_route.gateway)?;
+            }
+
+            // IPv4 routes (non-default)
+            for (i, route) in ipv4_routes.iter().enumerate() {
+                writeln!(
+                    config,
+                    "route{}={},{},0",
+                    i + 1,
+                    route.destination,
+                    route.gateway
+                )?;
+            }
+        }
+
+        // IPv4 DNS servers
+        let ipv4_dns: Vec<_> = self.nameservers.iter().filter(|n| n.is_ipv4()).collect();
+        if !ipv4_dns.is_empty() {
+            let dns_list: Vec<_> = ipv4_dns
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect();
+            writeln!(config, "dns={};", dns_list.join(";"))?;
+        }
+
+        // [ipv6] section
+        writeln!(config, "\n[ipv6]")?;
+
+        let ipv6_addresses: Vec<_> = self.ip_addresses.iter().filter(|a| a.is_ipv6()).collect();
+        if matches!(self.dhcp, Some(DhcpSetting::V6 | DhcpSetting::Both)) {
+            writeln!(config, "method=auto")?;
+        } else if ipv6_addresses.is_empty() {
+            writeln!(config, "method=disabled")?;
+        } else {
+            writeln!(config, "method=manual")?;
+            for (i, addr) in ipv6_addresses.iter().enumerate() {
+                writeln!(config, "address{}={}", i + 1, addr)?;
+            }
+
+            // IPv6 gateway
+            let (default_route, ipv6_routes): (Vec<NetworkRoute>, Vec<NetworkRoute>) = self
+                .routes
+                .iter()
+                .filter(|r| r.destination.is_ipv6())
+                .partition(|r| r.destination.prefix() == 0);
+            if let Some(default_route) = default_route.first() {
+                writeln!(config, "gateway={}", default_route.gateway)?;
+            }
+
+            // IPv6 routes (non-default)
+            for (i, route) in ipv6_routes.iter().enumerate() {
+                writeln!(
+                    config,
+                    "route{}={},{},0",
+                    i + 1,
+                    route.destination,
+                    route.gateway
+                )?;
+            }
+        }
+
+        // IPv6 DNS servers
+        let ipv6_dns: Vec<_> = self.nameservers.iter().filter(|n| n.is_ipv6()).collect();
+        if !ipv6_dns.is_empty() {
+            let dns_list: Vec<_> = ipv6_dns
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect();
+            writeln!(config, "dns={};", dns_list.join(";"))?;
+        }
+
+        Ok(())
+    }
 }
 
 impl VirtualNetDev {
@@ -271,7 +457,7 @@ impl VirtualNetDev {
         writeln!(config, "MACAddress={}", self.mac_address).unwrap();
 
         // Custom sections.
-        for section in &self.sd_netdev_sections {
+        for section in &self.custom_sections.sd_netdev_sections {
             writeln!(config, "\n[{}]", section.name).unwrap();
             for attr in &section.attributes {
                 writeln!(config, "{}={}", attr.0, attr.1).unwrap();
@@ -279,6 +465,86 @@ impl VirtualNetDev {
         }
 
         config
+    }
+
+    /// Return the `NetworkManager` connection profile configuration for this virtual device.
+    /// Optionally takes a physical interface, which is used for bond network configuration.
+    pub fn nm_config(&self, physical_interface: Option<&Interface>) -> Result<String> {
+        let mut config = String::new();
+        if self.kind == NetDevKind::Bond && physical_interface.is_none() {
+            warn!("writing bond configuration without networking information",);
+        };
+
+        writeln!(config, "[connection]")?;
+        writeln!(config, "id={}", self.name)?;
+        writeln!(config, "type={}", self.kind.sd_netdev_kind())?;
+        // Unlike in the `Interface` implementation, we don't need to worry about
+        // predictable names, as these devices will be created by NetworkManager.
+        writeln!(config, "interface-name={}", self.name)?;
+        writeln!(config, "autoconnect=true")?;
+        if let Some(priority) = self.priority {
+            writeln!(
+                config,
+                "autoconnect-priority={}",
+                100i32.saturating_sub_unsigned(priority)
+            )?;
+        }
+
+        // Bond and VLAN specific configurations
+        // See:
+        // - https://www.networkmanager.dev/docs/api/latest/settings-vlan.html
+        // - https://www.networkmanager.dev/docs/api/latest/settings-bond.html
+        // - https://www.kernel.org/doc/html/v5.9/networking/bonding.html
+        match self.kind {
+            NetDevKind::Bond => {
+                writeln!(config, "\n[bond]")?;
+
+                if let Some(section) = self
+                    .custom_sections
+                    .nm_sections
+                    .iter()
+                    .find(|s| s.name == "bond")
+                {
+                    for (key, value) in &section.attributes {
+                        writeln!(config, "{}={}", key, value)?;
+                    }
+                };
+
+                // WARN: does not set mac address when creating the device, only when reloading the configuration
+                writeln!(config, "\n[ethernet]")?;
+                writeln!(config, "cloned-mac-address={}", self.mac_address)?;
+
+                if let Some(interface) = physical_interface {
+                    interface.write_nm_config_common(&mut config)?;
+                }
+            }
+            NetDevKind::Vlan => {
+                writeln!(config, "\n[vlan]")?;
+                let mut has_parent = false;
+
+                if let Some(section) = self
+                    .custom_sections
+                    .nm_sections
+                    .iter()
+                    .find(|s| s.name == "vlan")
+                {
+                    for (key, value) in &section.attributes {
+                        if key == "parent" {
+                            has_parent = true;
+                        }
+                        writeln!(config, "{}={}", key, value)?;
+                    }
+                };
+
+                // Match parent based on mac-address
+                if !has_parent {
+                    writeln!(config, "\n[ethernet]")?;
+                    writeln!(config, "mac-address={}", self.mac_address)?;
+                }
+            }
+        }
+
+        Ok(config)
     }
 }
 
@@ -380,7 +646,7 @@ mod tests {
         ];
 
         for (iface, expected) in cases {
-            let unit_name = iface.sd_network_unit_name().unwrap();
+            let unit_name = iface.sd_unit_name().unwrap();
             assert_eq!(unit_name, expected);
         }
     }
@@ -400,7 +666,7 @@ mod tests {
             unmanaged: false,
             required_for_online: None,
         };
-        i.sd_network_unit_name().unwrap_err();
+        i.sd_unit_name().unwrap_err();
     }
 
     #[test]
@@ -412,7 +678,7 @@ mod tests {
                     kind: NetDevKind::Vlan,
                     mac_address: MacAddr(0, 0, 0, 0, 0, 0),
                     priority: Some(20),
-                    sd_netdev_sections: vec![],
+                    custom_sections: CustomNetworkSections::default(),
                 },
                 "20-vlan0.netdev",
             ),
@@ -422,7 +688,7 @@ mod tests {
                     kind: NetDevKind::Vlan,
                     mac_address: MacAddr(0, 0, 0, 0, 0, 0),
                     priority: None,
-                    sd_netdev_sections: vec![],
+                    custom_sections: CustomNetworkSections::default(),
                 },
                 "10-vlan0.netdev",
             ),
@@ -434,7 +700,7 @@ mod tests {
     }
 
     #[test]
-    fn interface_config() {
+    fn interface_sd_config() {
         let is = vec![
             (
                 Interface {
@@ -484,7 +750,7 @@ Gateway=127.0.0.1
 ",
             ),
             // this isn't really a valid interface object, but it's testing
-            // the minimum possible configuration for all peices at the same
+            // the minimum possible configuration for all pieces at the same
             // time, so I'll allow it. (sdemos)
             (
                 Interface {
@@ -578,12 +844,12 @@ DHCP=ipv4
         ];
 
         for (i, s) in is {
-            assert_eq!(i.config(), s);
+            assert_eq!(i.sd_config(), s);
         }
     }
 
     #[test]
-    fn virtual_netdev_config() {
+    fn virtual_netdev_sd_config() {
         let ds = vec![
             (
                 VirtualNetDev {
@@ -591,19 +857,22 @@ DHCP=ipv4
                     kind: NetDevKind::Vlan,
                     mac_address: MacAddr(0, 0, 0, 0, 0, 0),
                     priority: Some(20),
-                    sd_netdev_sections: vec![
-                        SdSection {
-                            name: String::from("Test"),
-                            attributes: vec![
-                                (String::from("foo"), String::from("bar")),
-                                (String::from("oingo"), String::from("boingo")),
-                            ],
-                        },
-                        SdSection {
-                            name: String::from("Empty"),
-                            attributes: vec![],
-                        },
-                    ],
+                    custom_sections: CustomNetworkSections::new(
+                        vec![
+                            SdSection {
+                                name: String::from("Test"),
+                                attributes: vec![
+                                    (String::from("foo"), String::from("bar")),
+                                    (String::from("oingo"), String::from("boingo")),
+                                ],
+                            },
+                            SdSection {
+                                name: String::from("Empty"),
+                                attributes: vec![],
+                            },
+                        ],
+                        vec![],
+                    ),
                 },
                 "[NetDev]
 Name=vlan0
@@ -623,7 +892,7 @@ oingo=boingo
                     kind: NetDevKind::Vlan,
                     mac_address: MacAddr(0, 0, 0, 0, 0, 0),
                     priority: Some(20),
-                    sd_netdev_sections: vec![],
+                    custom_sections: CustomNetworkSections::default(),
                 },
                 "[NetDev]
 Name=vlan0
@@ -635,6 +904,169 @@ MACAddress=00:00:00:00:00:00
 
         for (d, s) in ds {
             assert_eq!(d.sd_netdev_config(), s);
+        }
+    }
+
+    #[test]
+    fn interface_nm_config() {
+        let ds = vec![(
+            Interface {
+                name: Some(String::from("eth0")),
+                mac_address: Some(MacAddr(0, 0, 0, 0, 0, 0)),
+                path: None,
+                priority: 0,
+                nameservers: vec![
+                    IpAddr::V6(Ipv6Addr::new(0x2a01, 0x4ff, 0xff00, 0, 0, 0, 0x0add, 2)),
+                    IpAddr::V6(Ipv6Addr::new(0x2a01, 0x4ff, 0xff00, 0, 0, 0, 0x0add, 1)),
+                ],
+                ip_addresses: vec![IpNetwork::V6(
+                    Ipv6Network::new(Ipv6Addr::new(0x2a01, 0x4f9, 0xc014, 0x6d3b, 0, 0, 0, 1), 64)
+                        .unwrap(),
+                )],
+                dhcp: Some(DhcpSetting::V4),
+                routes: vec![NetworkRoute {
+                    destination: IpNetwork::V6(
+                        Ipv6Network::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0), 0).unwrap(),
+                    ),
+                    gateway: IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1)),
+                }],
+                bond: None,
+                unmanaged: false,
+                required_for_online: None,
+            },
+            "[connection]
+id=eth0
+type=ethernet
+autoconnect=true
+autoconnect-priority=100
+
+[ethernet]
+mac-address=00:00:00:00:00:00
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=manual
+address1=2a01:4f9:c014:6d3b::1/64
+gateway=fe80::1
+dns=2a01:4ff:ff00::add:2;2a01:4ff:ff00::add:1;
+",
+        )];
+
+        for (d, s) in ds {
+            assert_eq!(d.nm_config().unwrap(), s);
+        }
+    }
+
+    #[test]
+    fn virtual_netdev_nm_config() {
+        let interface = Interface {
+            name: Some(String::from("bond0")),
+            mac_address: Some(MacAddr(0, 0, 0, 0, 0, 0)),
+            path: None,
+            priority: 0,
+            nameservers: vec![],
+            ip_addresses: vec![],
+            dhcp: Some(DhcpSetting::V4),
+            routes: vec![],
+            bond: None,
+            unmanaged: false,
+            required_for_online: None,
+        };
+
+        let dis = vec![
+            (
+                VirtualNetDev {
+                    name: String::from("bond0"),
+                    kind: NetDevKind::Bond,
+                    mac_address: MacAddr(0, 0, 0, 0, 0, 0),
+                    priority: Some(20),
+                    custom_sections: CustomNetworkSections::new(
+                        vec![],
+                        vec![NmSection {
+                            name: String::from("bond"),
+                            attributes: vec![
+                                (
+                                    String::from("mode"),
+                                    bonding_mode_to_string(BONDING_MODE_BALANCE_RR).unwrap(),
+                                ),
+                                (String::from("miimon"), String::from("100")),
+                                (String::from("lp_interval"), String::from("2")),
+                                (String::from("arp_validate"), String::from("backup")),
+                                (String::from("all_slaves_active"), String::from("1")),
+                                (String::from("xmit_hash_policy"), String::from("layer2")),
+                            ],
+                        }],
+                    ),
+                },
+                Some(&interface),
+                "[connection]
+id=bond0
+type=bond
+interface-name=bond0
+autoconnect=true
+autoconnect-priority=80
+
+[bond]
+mode=balance-rr
+miimon=100
+lp_interval=2
+arp_validate=backup
+all_slaves_active=1
+xmit_hash_policy=layer2
+
+[ethernet]
+cloned-mac-address=00:00:00:00:00:00
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=disabled
+",
+            ),
+            (
+                VirtualNetDev {
+                    name: String::from("vlan0"),
+                    kind: NetDevKind::Vlan,
+                    mac_address: MacAddr(0, 0, 0, 0, 0, 0),
+                    priority: Some(20),
+                    custom_sections: CustomNetworkSections::new(
+                        vec![],
+                        vec![NmSection {
+                            name: String::from("vlan"),
+                            attributes: vec![
+                                (String::from("id"), String::from("100")),
+                                (String::from("ingress-priority-map"), String::from("25:5")),
+                                (String::from("protocol"), String::from("802.1ad")),
+                                (String::from("flags"), String::from("6")),
+                            ],
+                        }],
+                    ),
+                },
+                None,
+                "[connection]
+id=vlan0
+type=vlan
+interface-name=vlan0
+autoconnect=true
+autoconnect-priority=80
+
+[vlan]
+id=100
+ingress-priority-map=25:5
+protocol=802.1ad
+flags=6
+
+[ethernet]
+mac-address=00:00:00:00:00:00
+",
+            ),
+        ];
+
+        for (d, i, s) in dis {
+            assert_eq!(d.nm_config(i).unwrap(), s);
         }
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -46,15 +46,16 @@ pub mod upcloud;
 pub mod vmware;
 pub mod vultr;
 
-use crate::network;
+use crate::network::{self, NetDevKind};
 use anyhow::{anyhow, Context, Result};
 use libsystemd::logging;
 use nix::unistd;
 use openssh_keys::PublicKey;
 use slog_scope::warn;
 use std::collections::HashMap;
-use std::fs::{self, File};
+use std::fs::{self, File, Permissions};
 use std::io::prelude::*;
+use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use uzers::{self, User};
 
@@ -285,11 +286,11 @@ pub trait MetadataProvider {
 
         // Write `.network` fragments for network interfaces/links.
         for interface in &self.networks()? {
-            let unit_name = interface.sd_network_unit_name()?;
+            let unit_name = interface.sd_unit_name()?;
             let file_path = dir_path.join(unit_name);
             let mut unit_file = File::create(&file_path)
                 .with_context(|| format!("failed to create file {file_path:?}"))?;
-            write!(&mut unit_file, "{}", interface.config()).with_context(|| {
+            write!(&mut unit_file, "{}", interface.sd_config()).with_context(|| {
                 format!("failed to write network interface unit file {unit_file:?}")
             })?;
         }
@@ -302,6 +303,88 @@ pub trait MetadataProvider {
             write!(&mut unit_file, "{}", device.sd_netdev_config())
                 .with_context(|| format!("failed to write netdev unit file {unit_file:?}"))?;
         }
+        Ok(())
+    }
+
+    fn write_nm_profiles(&self, nm_profiles_dir: String) -> Result<()> {
+        let dir_path = Path::new(&nm_profiles_dir);
+        fs::create_dir_all(dir_path)
+            .with_context(|| format!("failed to create directory {dir_path:?}"))?;
+
+        let physical_interfaces = self.networks()?;
+        let virtual_devices = self.virtual_network_devices()?;
+        let mut configs = Vec::with_capacity(virtual_devices.len() + physical_interfaces.len());
+
+        // Separate bond master devices - since NetworkManager requires 1 configuration file with
+        // the information from both an `Interface` and `VirtualNetDev` we need to handle them
+        // separately.
+        let (virtual_bond_masters, virtual_devices): (Vec<_>, Vec<_>) = virtual_devices
+            .into_iter()
+            .partition(|v| v.kind == NetDevKind::Bond);
+        let (physical_bond_masters, physical_interfaces): (Vec<_>, Vec<_>) =
+            physical_interfaces.into_iter().partition(|i| {
+                let Some(ref name) = &i.name else {
+                    return false;
+                };
+                virtual_bond_masters.iter().any(|v| &v.name == name)
+            });
+
+        // Generate configurations for bond masters
+        for bond_master in virtual_bond_masters {
+            let name = &bond_master.name;
+            let physical_interface = physical_bond_masters
+                .iter()
+                .find(|p| p.name.as_ref().unwrap() == name);
+            configs.push((
+                name.to_owned(),
+                bond_master.nm_config(physical_interface)
+                    .with_context(|| {
+                        format!(
+                            "failed to generate NetworkManager connection profile for virtual device '{}'",
+                            name
+                        )
+                    })?)
+                );
+        }
+
+        // Generate configurations for remaining devices, including bond slaves
+        for interface in physical_interfaces {
+            let name = interface.name()?;
+            configs.push((
+                name,
+                interface.nm_config().with_context(|| {
+                    "failed to generate NetworkManager connection profile for interface '{name}'"
+                })?,
+            ));
+        }
+        for virt_dev in virtual_devices {
+            let name = virt_dev.name.clone();
+            let config = virt_dev.nm_config(None).with_context(|| {
+                format!(
+                    "failed to generate NetworkManager connection profile for virtual device '{}'",
+                    &name
+                )
+            })?;
+            configs.push((name, config));
+        }
+
+        // Write NetworkManager connection profile for all generated configurations
+        for (name, config) in configs {
+            let file_path = dir_path.join(format!("{name}.nmconnection"));
+            let mut keyfile = File::create(&file_path)
+                .with_context(|| format!("failed to create file {file_path:?}"))?;
+            keyfile.write_all(config.as_ref()).with_context(|| {
+                format!("failed to write NetworkManager profile to {file_path:?}")
+            })?;
+
+            // 0600 permissions required, since any file writeable or readable by
+            // any user other than root will be ignored.
+            // See: https://networkmanager.dev/docs/api/latest/nm-settings-keyfile.html
+            keyfile
+                .set_permissions(Permissions::from_mode(0o600))
+                .with_context(|| "failed to set NetworkManager keyfile permissions")?;
+        }
+
         Ok(())
     }
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -46,15 +46,16 @@ pub mod upcloud;
 pub mod vmware;
 pub mod vultr;
 
-use crate::network;
+use crate::network::{self, NetDevKind};
 use anyhow::{anyhow, Context, Result};
 use libsystemd::logging;
 use nix::unistd;
 use openssh_keys::PublicKey;
 use slog_scope::warn;
 use std::collections::HashMap;
-use std::fs::{self, File};
+use std::fs::{self, File, Permissions};
 use std::io::prelude::*;
+use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use uzers::{self, User};
 
@@ -285,11 +286,11 @@ pub trait MetadataProvider {
 
         // Write `.network` fragments for network interfaces/links.
         for interface in &self.networks()? {
-            let unit_name = interface.sd_network_unit_name()?;
+            let unit_name = interface.sd_unit_name()?;
             let file_path = dir_path.join(unit_name);
             let mut unit_file = File::create(&file_path)
                 .with_context(|| format!("failed to create file {file_path:?}"))?;
-            write!(&mut unit_file, "{}", interface.config()).with_context(|| {
+            write!(&mut unit_file, "{}", interface.sd_config()).with_context(|| {
                 format!("failed to write network interface unit file {unit_file:?}")
             })?;
         }
@@ -302,6 +303,86 @@ pub trait MetadataProvider {
             write!(&mut unit_file, "{}", device.sd_netdev_config())
                 .with_context(|| format!("failed to write netdev unit file {unit_file:?}"))?;
         }
+        Ok(())
+    }
+
+    fn write_nm_profiles(&self, nm_profiles_dir: String) -> Result<()> {
+        let dir_path = Path::new(&nm_profiles_dir);
+        fs::create_dir_all(dir_path)
+            .with_context(|| format!("failed to create directory {dir_path:?}"))?;
+
+        let physical_interfaces = self.networks()?;
+        let virtual_devices = self.virtual_network_devices()?;
+        let mut configs = Vec::with_capacity(virtual_devices.len() + physical_interfaces.len());
+
+        // Separate bond master devices - since NetworkManager requires 1 configuration file with
+        // the information from both an `Interface` and `VirtualNetDev` we need to handle them
+        // separately.
+        let (virtual_bond_masters, virtual_devices): (Vec<_>, Vec<_>) = virtual_devices
+            .into_iter()
+            .partition(|v| v.kind == NetDevKind::Bond);
+        let (physical_bond_masters, physical_interfaces): (Vec<_>, Vec<_>) =
+            physical_interfaces.into_iter().partition(|i| {
+                let Some(ref name) = &i.name else {
+                    return false;
+                };
+                virtual_bond_masters.iter().any(|v| &v.name == name)
+            });
+
+        // Generate configurations for bond masters
+        for bond_master in virtual_bond_masters {
+            let name = &bond_master.name;
+            let physical_interface = physical_bond_masters
+                .iter()
+                .find(|p| p.name.as_ref().unwrap() == name);
+            configs.push((
+                name.to_owned(),
+                bond_master.nm_config(physical_interface)
+                    .with_context(|| {
+                        format!(
+                            "failed to generate NetworkManager connection profile for virtual device '{name}'",
+                        )
+                    })?)
+                );
+        }
+
+        // Generate configurations for remaining devices, including bond slaves
+        for interface in physical_interfaces {
+            let name = interface.name()?;
+            let config = interface.nm_config().with_context(|| {
+                format!(
+                    "failed to generate NetworkManager connection profile for interface '{name}'"
+                )
+            })?;
+            configs.push((name, config));
+        }
+        for virt_dev in virtual_devices {
+            let name = virt_dev.name.clone();
+            let config = virt_dev.nm_config(None).with_context(|| {
+                format!(
+                    "failed to generate NetworkManager connection profile for virtual device '{name}'",
+                )
+            })?;
+            configs.push((name, config));
+        }
+
+        // Write NetworkManager connection profile for all generated configurations
+        for (name, config) in configs {
+            let file_path = dir_path.join(format!("{name}.nmconnection"));
+            let mut keyfile = File::create(&file_path)
+                .with_context(|| format!("failed to create file {file_path:?}"))?;
+            keyfile.write_all(config.as_ref()).with_context(|| {
+                format!("failed to write NetworkManager profile to {file_path:?}")
+            })?;
+
+            // 0600 permissions required, since any file writeable or readable by
+            // any user other than root will be ignored.
+            // See: https://networkmanager.dev/docs/api/latest/nm-settings-keyfile.html
+            keyfile
+                .set_permissions(Permissions::from_mode(0o600))
+                .with_context(|| "failed to set NetworkManager keyfile permissions")?;
+        }
+
         Ok(())
     }
 

--- a/src/providers/packet/mod.rs
+++ b/src/providers/packet/mod.rs
@@ -28,7 +28,7 @@ use pnet_base::MacAddr;
 use serde::Deserialize;
 use slog_scope::warn;
 
-use crate::network::{self, Interface, NetworkRoute};
+use crate::network::{self, CustomNetworkSections, Interface, NetworkRoute};
 use crate::providers::MetadataProvider;
 use crate::retry;
 use crate::util;
@@ -287,7 +287,7 @@ impl PacketProvider {
             return Ok((interfaces, vec![]));
         }
 
-        let mut attrs = vec![
+        let mut sd_attrs = vec![
             ("TransmitHashPolicy".to_owned(), "layer3+4".to_owned()),
             ("MIIMonitorSec".to_owned(), ".1".to_owned()),
             ("UpDelaySec".to_owned(), ".2".to_owned()),
@@ -297,9 +297,33 @@ impl PacketProvider {
                 network::bonding_mode_to_string(netinfo.bonding.mode)?,
             ),
         ];
+
+        let mut nm_attrs = vec![
+            ("xmit_hash_policy".to_owned(), "layer3+4".to_owned()),
+            ("miimon".to_owned(), "100".to_owned()),
+            ("updelay".to_owned(), "200".to_owned()),
+            ("downdelay".to_owned(), "200".to_owned()),
+            (
+                "mode".to_owned(),
+                network::bonding_mode_to_string(netinfo.bonding.mode)?,
+            ),
+        ];
+
         if netinfo.bonding.mode == network::BONDING_MODE_LACP {
-            attrs.push(("LACPTransmitRate".to_owned(), "fast".to_owned()));
+            sd_attrs.push(("LACPTransmitRate".to_owned(), "fast".to_owned()));
+            nm_attrs.push(("lacp_rate".to_owned(), "fast".to_owned()));
         }
+
+        let custom_sections = CustomNetworkSections::new(
+            vec![network::SdSection {
+                name: "Bond".to_owned(),
+                attributes: sd_attrs,
+            }],
+            vec![network::NmSection {
+                name: "bond".to_owned(),
+                attributes: nm_attrs,
+            }],
+        );
 
         let mut network_devices = Vec::with_capacity(bonds.len());
         for (mac, bond) in bonds {
@@ -312,10 +336,7 @@ impl PacketProvider {
                 kind: network::NetDevKind::Bond,
                 mac_address: mac,
                 priority: Some(5),
-                sd_netdev_sections: vec![network::SdSection {
-                    name: "Bond".to_owned(),
-                    attributes: attrs.clone(),
-                }],
+                custom_sections: custom_sections.clone(),
             };
             network_devices.push(bond_netdev);
 


### PR DESCRIPTION
I will be creating an issue for discussion, but as mentioned in #1266, I think this would be nice to have in `afterburn`. It is particularly important for the Hetzner implementation though as we need to fallback to IPv4 DHCP initially in order to request the network configuration metadata from Hetzner's locally available HTTP endpoint, meaning that as far as I understand it passing network kargs to initrd can't work.

With these changes and the Hetner PR, I've managed to configure an FCOS Hetzner system using the following butane snippet:

```yaml
systemd:
  units:
    - name: afterburn-networkmanager.service
      enabled: true
      contents: |
        [Unit]
        Description=Afterburn Network Configuration First Boot (Hetzner)
        Documentation=https://coreos.github.io/afterburn/
        After=network-online.target
        Wants=network-online.target
        ConditionKernelCommandLine=ignition.platform.id=hetzner
        ConditionPathExists=!/var/lib/afterburn-network-configured

        [Service]
        Type=oneshot
        ExecStart=/usr/bin/afterburn multi \
          --cmdline \
          --networkmanager-profiles /etc/NetworkManager/system-connections
        ExecStartPost=/usr/bin/touch /var/lib/afterburn-network-configured
        # Reboot to apply new network config
        ExecStartPost=/usr/bin/systemctl reboot
        RemainAfterExit=yes

        [Install]
        WantedBy=multi-user.target
```

If we do go ahead with adding this as a feature, I would appreciate any feedback on the code.

Also, I've initially pushed 2 commits, with the difference being how VLANs/Bonds are handled. The first commit tries to directly translate from the `VirtualNetDev::sd_netdev_sections` to the NetworkManager equivalents, though this had some limitations due to the fundamentally different 1 file vs several per connection, and required a lot of conversions of both keys and values. The second commit instead shifts the burden to the provider implementation, requiring a new `VirtualNetDev::nm_sections`, which comes out a lot simpler overall in my opinion but I'm open to suggestions.