### PR TITLE
oraclecloud: Handle nested metadata values

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -19,6 +19,7 @@ Minor changes:
 - ProxmoxVE: Define DNS entries for every interface, not just the first
 - Hetzner: Add the `HETZNER_PUBLIC_IPV6` attribute
 - ProxmoxVE: Explicitely deactivate Dracut IP autoconf as the IP is statically set
+- Oracle Cloud: Handle nested metadata values for instance pool members
 
 Packaging changes:
 

--- a/src/providers/oraclecloud/mock_tests.rs
+++ b/src/providers/oraclecloud/mock_tests.rs
@@ -59,6 +59,34 @@ fn test_pubkeys() {
     "shape": ""
 }"#;
 
+    let metadata_null_key = r#"{
+    "availabilityDomain": "",
+    "canonicalRegionName": "",
+    "compartmentId": "",
+    "faultDomain": "",
+    "id": "",
+    "hostname": "",
+    "shape": "",
+    "metadata": {
+        "ssh_authorized_keys": null
+    }
+}"#;
+
+    let metadata_non_string_key = r#"{
+    "availabilityDomain": "",
+    "canonicalRegionName": "",
+    "compartmentId": "",
+    "faultDomain": "",
+    "id": "",
+    "hostname": "",
+    "shape": "",
+    "metadata": {
+        "ssh_authorized_keys": {
+            "unexpected": "invalid-key"
+        }
+    }
+}"#;
+
     let mut server = mockito::Server::new();
     let client = retry::Client::try_new()
         .unwrap()
@@ -91,6 +119,69 @@ fn test_pubkeys() {
         .with_body(metadata_no_key)
         .create();
     let provider = oraclecloud::OracleCloudProvider::try_new_with_client(&client).unwrap();
+    let keys = provider.ssh_keys().unwrap();
+    assert_eq!(keys, vec![]);
+
+    server.reset();
+    server
+        .mock("GET", INSTANCE_METADATA_ENDPOINT)
+        .match_header("Authorization", "Bearer Oracle")
+        .with_status(200)
+        .with_body(metadata_null_key)
+        .create();
+    let provider = oraclecloud::OracleCloudProvider::try_new_with_client(&client).unwrap();
+    let keys = provider.ssh_keys().unwrap();
+    assert_eq!(keys, vec![]);
+
+    server.reset();
+    server
+        .mock("GET", INSTANCE_METADATA_ENDPOINT)
+        .match_header("Authorization", "Bearer Oracle")
+        .with_status(200)
+        .with_body(metadata_non_string_key)
+        .create();
+    let provider = oraclecloud::OracleCloudProvider::try_new_with_client(&client).unwrap();
+    let err = provider.ssh_keys().unwrap_err();
+    assert!(err.to_string().contains("invalid-key"));
+}
+
+#[test]
+fn test_instance_pool_metadata() {
+    let metadata = r#"{
+    "availabilityDomain": "EMIr:PHX-AD-2",
+    "canonicalRegionName": "us-phoenix-1",
+    "compartmentId": "ocid1.tenancy.oc1..exampleuniqueID",
+    "faultDomain": "FAULT-DOMAIN-1",
+    "id": "ocid1.instance.oc1.phx.exampleuniqueID",
+    "hostname": "fedora-coreos-pool",
+    "shape": "VM.Standard.A1.Flex",
+    "metadata": {
+        "compute_management": {
+            "instance_configuration": {
+                "state": "SUCCEEDED"
+            }
+        },
+        "user_data": "example-user-data"
+    }
+}"#;
+
+    let mut server = mockito::Server::new();
+    let client = retry::Client::try_new()
+        .unwrap()
+        .max_retries(0)
+        .mock_base_url(server.url());
+
+    server
+        .mock("GET", INSTANCE_METADATA_ENDPOINT)
+        .match_header("Authorization", "Bearer Oracle")
+        .with_status(200)
+        .with_body(metadata)
+        .create();
+
+    let provider = oraclecloud::OracleCloudProvider::try_new_with_client(&client).unwrap();
+    let hostname = provider.hostname().unwrap();
+    assert_eq!(hostname, Some("fedora-coreos-pool".to_string()));
+
     let keys = provider.ssh_keys().unwrap();
     assert_eq!(keys, vec![]);
 }

--- a/src/providers/oraclecloud/mod.rs
+++ b/src/providers/oraclecloud/mod.rs
@@ -106,10 +106,17 @@ impl MetadataProvider for OracleCloudProvider {
     }
 
     fn ssh_keys(&self) -> Result<Vec<PublicKey>> {
-        self.instance
-            .metadata
-            .get("ssh_authorized_keys")
-            .unwrap_or(&String::new())
+        let Some(ssh_authorized_keys) = self.instance.metadata.get("ssh_authorized_keys") else {
+            return Ok(vec![]);
+        };
+        if ssh_authorized_keys.is_null() {
+            return Ok(vec![]);
+        }
+        let ssh_authorized_keys = ssh_authorized_keys.as_str().with_context(|| {
+            format!("ssh_authorized_keys metadata value is not a string: {ssh_authorized_keys}")
+        })?;
+
+        ssh_authorized_keys
             .split_terminator('\n')
             .map(PublicKey::parse)
             .collect::<Result<_, _>>()
@@ -136,5 +143,5 @@ struct Instance {
     id: String,
     shape: String,
     #[serde(default)]
-    metadata: HashMap<String, String>,
+    metadata: HashMap<String, serde_json::Value>,
 }


### PR DESCRIPTION
## Summary

* Parse Oracle Cloud instance metadata values as JSON so nested OCI instance pool metadata does not fail deserialization
* Preserve strict string parsing for `ssh_authorized_keys`
* Add regression coverage for instance pool `compute_management` metadata and update release notes

Fixes coreos/afterburn#1279

## Testing

* `cargo fmt -- --check`
* `git diff --check`
* `cargo test --all-targets oraclecloud` was not run locally because this macOS target fails compiling Linux-specific `libsystemd`; CI should run it on Linux