### PR TITLE
proxmoxve: explicit static IP configuration

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -17,6 +17,7 @@ Minor changes:
 - Makefile: download `90-afterburn-authorized-keys-file.conf` for rpm building
 - ProxmoxVE: Define DNS entries for every interface, not just the first
 - Hetzner: Add the `HETZNER_PUBLIC_IPV6` attribute
+- ProxmoxVE: Explicitely deactivate Dracut IP autoconf as the IP is statically set
 
 Packaging changes:
 

--- a/src/providers/proxmoxve/cloudconfig.rs
+++ b/src/providers/proxmoxve/cloudconfig.rs
@@ -199,13 +199,17 @@ impl MetadataProvider for ProxmoxVECloudConfig {
                                 .find(|r| r.destination.is_ipv4() && r.destination.prefix() == 0)
                             {
                                 kargs.push(format!(
-                                    "ip={}::{}:{}",
+                                    "ip={}::{}:{}:::off",
                                     network.ip(),
                                     gateway.gateway,
                                     network.mask()
                                 ));
                             } else {
-                                kargs.push(format!("ip={}:::{}", network.ip(), network.mask()));
+                                kargs.push(format!(
+                                    "ip={}:::{}:::off",
+                                    network.ip(),
+                                    network.mask()
+                                ));
                             }
                         }
                         IpNetwork::V6(network) => {
@@ -215,13 +219,17 @@ impl MetadataProvider for ProxmoxVECloudConfig {
                                 .find(|r| r.destination.is_ipv6() && r.destination.prefix() == 0)
                             {
                                 kargs.push(format!(
-                                    "ip={}::{}:{}",
+                                    "ip={}::{}:{}:::off",
                                     network.ip(),
                                     gateway.gateway,
                                     network.prefix()
                                 ));
                             } else {
-                                kargs.push(format!("ip={}:::{}", network.ip(), network.prefix()));
+                                kargs.push(format!(
+                                    "ip={}:::{}:::off",
+                                    network.ip(),
+                                    network.prefix()
+                                ));
                             }
                         }
                     }

--- a/src/providers/proxmoxve/cloudconfig.rs
+++ b/src/providers/proxmoxve/cloudconfig.rs
@@ -1,5 +1,5 @@
 use crate::{
-    network::{self, DhcpSetting, NetworkRoute},
+    network::{self, dracut_addr, DhcpSetting, NetworkRoute},
     providers::MetadataProvider,
 };
 use anyhow::{Context, Result};
@@ -220,14 +220,14 @@ impl MetadataProvider for ProxmoxVECloudConfig {
                             {
                                 kargs.push(format!(
                                     "ip={}::{}:{}:::off",
-                                    network.ip(),
-                                    gateway.gateway,
+                                    dracut_addr(&IpAddr::V6(network.ip())),
+                                    dracut_addr(&gateway.gateway),
                                     network.prefix()
                                 ));
                             } else {
                                 kargs.push(format!(
                                     "ip={}:::{}:::off",
-                                    network.ip(),
+                                    dracut_addr(&IpAddr::V6(network.ip())),
                                     network.prefix()
                                 ));
                             }

--- a/src/providers/proxmoxve/tests.rs
+++ b/src/providers/proxmoxve/tests.rs
@@ -168,8 +168,8 @@ fn test_network_kargs() {
     let kargs = kargs.unwrap();
 
     // Check static IP configuration with gateway
-    assert!(kargs.contains("ip=192.168.1.1::192.168.1.254:255.255.255.0"));
-    assert!(kargs.contains("ip=2001:db8:85a3::8a2e:370:0::2001:db8:85a3::8a2e:370:9999:24"));
+    assert!(kargs.contains("ip=192.168.1.1::192.168.1.254:255.255.255.0:::off"));
+    assert!(kargs.contains("ip=2001:db8:85a3::8a2e:370:0::2001:db8:85a3::8a2e:370:9999:24:::off"));
 
     // Check nameservers
     assert!(kargs.contains("nameserver=1.1.1.1,8.8.8.8"));
@@ -202,7 +202,7 @@ fn test_network_kargs_no_gateway() {
     let kargs = kargs.unwrap();
 
     // Check static IP configuration without gateway
-    assert!(kargs.contains("ip=192.168.1.1:::255.255.255.0"));
+    assert!(kargs.contains("ip=192.168.1.1:::255.255.255.0:::off"));
 
     // Check nameservers
     assert!(kargs.contains("nameserver=1.1.1.1,8.8.8.8"));

--- a/src/providers/proxmoxve/tests.rs
+++ b/src/providers/proxmoxve/tests.rs
@@ -169,7 +169,9 @@ fn test_network_kargs() {
 
     // Check static IP configuration with gateway
     assert!(kargs.contains("ip=192.168.1.1::192.168.1.254:255.255.255.0:::off"));
-    assert!(kargs.contains("ip=2001:db8:85a3::8a2e:370:0::2001:db8:85a3::8a2e:370:9999:24:::off"));
+    assert!(
+        kargs.contains("ip=[2001:db8:85a3::8a2e:370:0]::[2001:db8:85a3::8a2e:370:9999]:24:::off")
+    );
 
     // Check nameservers
     assert!(kargs.contains("nameserver=1.1.1.1,8.8.8.8"));


### PR DESCRIPTION
This costs nothing to append - dracut explodes this 'ip=' into variables[^1], and downstream libraries might default to 'dhcp' if the 'autoconf' variable is empty.

[^1]: https://github.com/dracutdevs/dracut/blob/5d2bda46f4e75e85445ee4d3bd3f68bf966287b9/modules.d/40network/net-lib.sh#L541

---

Related to: https://github.com/flatcar/Flatcar/issues/2002, https://github.com/flatcar/scripts/pull/3677


(cc @theoraim)