### PR TITLE
Use resolver="3" and update time dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2241,29 +2241,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.43"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 description = "A simple cloud provider agent"
 version = "5.10.0"
+resolver = "3"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
> build(deps): bump time from 0.3.43 to 0.3.45
>
> While we're still using a version vulnerable to CVE-2026-25727 /
> RUSTSEC-2026-0009 (fix is in 0.3.47), we don't actually use any of the
> affected versions, and updating further requires 2024 edition. Thanks to
> Jan Zerebecki for investigating.
> 
> cargo: Use resolver="3" for smarter dependency updates

Thanks @JanZerebecki for looking into the vulnerability (https://github.com/coreos/afterburn/pull/1259#issuecomment-3877088187).