### PR TITLE
providers: Don't panic truncating a multi-byte hostname

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -22,6 +22,7 @@ Minor changes:
 - ProxmoxVE: Explicitely deactivate Dracut IP autoconf as the IP is statically set
 - Oracle Cloud: Handle nested metadata values for instance pool members
 - Drop the maplit dependency
+- Don't panic truncating an over-long hostname with multi-byte characters
 
 Packaging changes:
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -205,7 +205,14 @@ fn truncate_hostname(mut hostname: String) -> Result<String> {
                 hostname,
                 maxlen
             );
-            hostname.truncate(maxlen);
+            // Truncate on a character boundary: String::truncate() panics if the
+            // index lands in the middle of a multi-byte UTF-8 sequence, and
+            // maxlen counts bytes.
+            let mut end = maxlen;
+            while !hostname.is_char_boundary(end) {
+                end -= 1;
+            }
+            hostname.truncate(end);
             if let Some(idx) = hostname.find('.') {
                 hostname.truncate(idx);
             }
@@ -534,5 +541,30 @@ mod tests {
             try_write_hostname(&format!("{}.example.com", &long_string[0..maxlen - 10])),
             long_string[0..maxlen - 10]
         );
+    }
+
+    #[test]
+    fn test_hostname_truncation_multibyte() {
+        // maxlen counts bytes, so an over-long hostname can put the truncation
+        // point in the middle of a multi-byte character. Truncate back to the
+        // preceding character boundary rather than panicking.
+        let maxlen = max_hostname_len().unwrap().unwrap();
+
+        // Straddle the limit with a two-byte character: it starts at maxlen - 1
+        // and so occupies the byte at maxlen, whatever maxlen happens to be.
+        let straddle = format!("{}\u{e9}{}", "a".repeat(maxlen - 1), "b".repeat(maxlen));
+        assert!(!straddle.is_char_boundary(maxlen));
+        let out = try_write_hostname(&straddle);
+        assert_eq!(out, "a".repeat(maxlen - 1));
+
+        // Same, but with a dot section following, to exercise both truncations.
+        let out = try_write_hostname(&format!("{straddle}.example.com"));
+        assert_eq!(out, "a".repeat(maxlen - 1));
+
+        // An all-multi-byte hostname truncates to whole characters.
+        let wide = "\u{20ac}".repeat(maxlen);
+        let out = try_write_hostname(&wide);
+        assert!(out.len() <= maxlen);
+        assert_eq!(out, wide[0..out.len()]);
     }
 }


### PR DESCRIPTION
`truncate_hostname()` truncates the provider-supplied hostname to `sysconf(_SC_HOST_NAME_MAX)` (64 on Linux) with `String::truncate(maxlen)`. `maxlen` counts **bytes**, but `String::truncate` panics unless the index is a UTF-8 character boundary:

```
thread 'main' panicked at src/providers/mod.rs:205:
assertion failed: self.is_char_boundary(new_len)
```

So any hostname longer than 64 bytes whose 65th byte falls inside a multi-byte sequence panics Afterburn. This is reachable from `write_hostname()`, i.e. the ordinary `--hostname-file` path used by every provider that reports a hostname, and from `write_hostname_ignition_fragment()`. On a cloud instance that means `afterburn-hostname.service` fails at boot.

Walk back to the preceding character boundary before truncating, so an over-long hostname is cut to whole characters instead of panicking.

The added test straddles the limit with a two-byte character starting at `maxlen - 1`, so it is deterministic whatever `maxlen` turns out to be at runtime; a test using only three-byte characters would silently pass on any system where `maxlen % 3 == 0`.

Verified: the new test panics at `src/providers/mod.rs` without the fix and passes with it; `cargo test --all-targets` (150 passed), `cargo clippy --all-targets -- -D warnings` and `cargo fmt -- --check -l` are clean.
