### PR TITLE
build(deps): bump the build group across 1 directory with 5 updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -1692,9 +1692,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -2398,9 +2398,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -2413,15 +2413,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
### Summary ###

cargo audit found 2 issues for quinn-proto and time [1][2]

```
$ cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 1216 security advisories (from /root/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (338 crate dependencies)
Crate:     quinn-proto
Version:   0.11.14
Title:      Remote memory exhaustion in quinn-proto from unbounded out-of-order stream reassembly
Date:      2026-06-22
ID:        RUSTSEC-2026-0185
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0185
Severity:  7.5 (high)
Solution:  Upgrade to >=0.11.15

Crate:     time
Version:   0.3.45
Title:     Denial of Service via Stack Exhaustion
Date:      2026-02-05
ID:        RUSTSEC-2026-0009
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0009
Severity:  6.8 (medium)
Solution:  Upgrade to >=0.3.47

<< snip >>

error: 2 vulnerabilities found!
warning: 1 allowed warning found
$
```

### Verify ###

Build the packages post update - no issues found

```
$ cargo build
   Compiling proc-macro2 v1.0.106
   Compiling quote v1.0.46
   Compiling unicode-ident v1.0.24
   Compiling libc v0.2.186
   Compiling syn v2.0.119
   Compiling pin-project-lite v0.2

<< snip >>

   Compiling uzers v0.12.2
   Compiling ipnetwork v0.21.1
   Compiling xml-rs v0.8.28
   Compiling afterburn v5.10.0 (/root/Y/afterburn)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 13s
warning: the following packages contain code that will be rejected by a future version of Rust: nix v0.29.0, nix v0.30.1, nix v0.31.3
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
$
$ ./target/debug/afterburn  --version
Aug 13 05:10:16.739 DEBG logging initialized
Afterburn-multi 5.10.0
$
```

[1] https://rustsec.org/advisories/RUSTSEC-2026-0185
[2] https://rustsec.org/advisories/RUSTSEC-2026-0009