### PR TITLE
feat: add Outscale metadata provider

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -32,6 +32,7 @@ use crate::providers::microsoft::azurestack::AzureStack;
 use crate::providers::openstack;
 use crate::providers::openstack::network::OpenstackProviderNetwork;
 use crate::providers::oraclecloud::OracleCloudProvider;
+use crate::providers::outscale::OutscaleProvider;
 use crate::providers::packet::PacketProvider;
 use crate::providers::powervs::PowerVSProvider;
 use crate::providers::proxmoxve;
@@ -71,6 +72,7 @@ pub fn fetch_metadata(provider: &str) -> Result<Box<dyn providers::MetadataProvi
         "kubevirt" => kubevirt::try_new_provider_else_noop(),
         "openstack" => openstack::try_config_drive_else_network(),
         "openstack-metadata" => box_result!(OpenstackProviderNetwork::try_new()?),
+        "outscale" => box_result!(OutscaleProvider::try_new()?),
         "oraclecloud" => box_result!(OracleCloudProvider::try_new()?),
         "packet" => box_result!(PacketProvider::try_new()?),
         "powervs" => box_result!(PowerVSProvider::try_new()?),

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -38,6 +38,7 @@ pub mod microsoft;
 pub mod noop;
 pub mod openstack;
 pub mod oraclecloud;
+pub mod outscale;
 pub mod packet;
 pub mod powervs;
 pub mod proxmoxve;

--- a/src/providers/outscale/mock_tests.rs
+++ b/src/providers/outscale/mock_tests.rs
@@ -1,0 +1,126 @@
+use std::collections::{BTreeMap, HashMap};
+
+use anyhow::Context;
+
+use crate::providers::outscale;
+use crate::providers::MetadataProvider;
+
+#[test]
+fn basic_hostname() {
+    let endpoint = "/latest/meta-data/hostname";
+    let hostname = "test-hostname";
+
+    let mut server = mockito::Server::new();
+    let client = crate::retry::Client::try_new()
+        .context("failed to create http client")
+        .unwrap()
+        .max_retries(0)
+        .return_on_404(true)
+        .mock_base_url(server.url());
+
+    let provider = outscale::OutscaleProvider { client };
+
+    server.mock("GET", endpoint).with_status(503).create();
+    provider.hostname().unwrap_err();
+
+    server
+        .mock("GET", endpoint)
+        .with_status(200)
+        .with_body(hostname)
+        .create();
+
+    assert_eq!(provider.hostname().unwrap(), Some(hostname.to_string()));
+
+    server.reset();
+    provider.hostname().unwrap_err();
+}
+
+#[test]
+fn basic_pubkeys() {
+    let key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+bqdi18/+JfjrqmOEtVKyCU0bsIc6tBqqU7p9mesJkALocLddDU6d97w2zwERhzaqReDyg4msvQQohgtncb4afKKWQjCCCWlcwtP0nAeg9GFtUfmLeYcP2KAjxblabncluuAnvMHyBixKAjr5eWD4B1HjOmpMRmycwmy85QhGTYhF+AkiHGCPPUDrVy2cIvrPSDXEEa7bz5aQUime0Eold56n3O7E5BJuAozf+oeiWCERRRt9ATlLkMvwVItzBHN25YoMOd0KfgYMtBVAw86TErYFx4Tu98blYNUQTthf9VxcU8xy0rFacXmuS7LHbp+CKDY0X5dNHuhqz0wFto4J test-comment";
+
+    let mut server = mockito::Server::new();
+    let client = crate::retry::Client::try_new()
+        .context("failed to create http client")
+        .unwrap()
+        .max_retries(0)
+        .return_on_404(true)
+        .mock_base_url(server.url());
+
+    let provider = outscale::OutscaleProvider { client };
+
+    server
+        .mock("GET", "/latest/meta-data/public-keys/0/openssh-key")
+        .with_status(200)
+        .with_body(key)
+        .create();
+
+    let keys = provider.ssh_keys().unwrap();
+
+    assert_eq!(keys.len(), 1);
+    assert_eq!(keys[0].comment, Some("test-comment".to_string()));
+
+    server.reset();
+    provider.ssh_keys().unwrap_err();
+}
+
+#[test]
+fn basic_attributes() {
+    let endpoints = BTreeMap::from([
+        ("/latest/meta-data/ami-id", "test-ami-id"),
+        ("/latest/meta-data/instance-id", "test-instance-id"),
+        ("/latest/meta-data/instance-type", "test-instance-type"),
+        ("/latest/meta-data/local-ipv4", "10.0.0.10"),
+        ("/latest/meta-data/hostname", "test-hostname"),
+        ("/latest/meta-data/public-hostname", "test-public-hostname"),
+        (
+            "/latest/meta-data/placement/availability-zone",
+            "eu-west-2a",
+        ),
+    ]);
+
+    let expected = HashMap::from([
+        ("OUTSCALE_AMI_ID".to_string(), "test-ami-id".to_string()),
+        (
+            "OUTSCALE_INSTANCE_ID".to_string(),
+            "test-instance-id".to_string(),
+        ),
+        (
+            "OUTSCALE_INSTANCE_TYPE".to_string(),
+            "test-instance-type".to_string(),
+        ),
+        ("OUTSCALE_IPV4_LOCAL".to_string(), "10.0.0.10".to_string()),
+        ("OUTSCALE_HOSTNAME".to_string(), "test-hostname".to_string()),
+        (
+            "OUTSCALE_PUBLIC_HOSTNAME".to_string(),
+            "test-public-hostname".to_string(),
+        ),
+        (
+            "OUTSCALE_AVAILABILITY_ZONE".to_string(),
+            "eu-west-2a".to_string(),
+        ),
+    ]);
+
+    let mut server = mockito::Server::new();
+
+    for (endpoint, body) in endpoints {
+        server
+            .mock("GET", endpoint)
+            .with_status(200)
+            .with_body(body)
+            .create();
+    }
+
+    let client = crate::retry::Client::try_new()
+        .unwrap()
+        .max_retries(0)
+        .return_on_404(true)
+        .mock_base_url(server.url());
+
+    let provider = outscale::OutscaleProvider { client };
+
+    assert_eq!(provider.attributes().unwrap(), expected);
+
+    server.reset();
+    provider.attributes().unwrap_err();
+}

--- a/src/providers/outscale/mod.rs
+++ b/src/providers/outscale/mod.rs
@@ -1,0 +1,97 @@
+// Copyright 2026 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Metadata fetcher for the OUTSCALE provider.
+//!
+//! OUTSCALE exposes an EC2-compatible metadata service at:
+//! http://169.254.169.254/latest/meta-data/
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use openssh_keys::PublicKey;
+
+use crate::providers::MetadataProvider;
+use crate::retry;
+
+#[cfg(test)]
+mod mock_tests;
+
+#[derive(Clone, Debug)]
+pub struct OutscaleProvider {
+    client: retry::Client,
+}
+
+impl OutscaleProvider {
+    pub fn try_new() -> Result<OutscaleProvider> {
+        let client = retry::Client::try_new()?.return_on_404(true);
+
+        Ok(OutscaleProvider { client })
+    }
+
+    fn endpoint_for(&self, key: &str) -> String {
+        format!("http://169.254.169.254/latest/meta-data/{key}")
+    }
+}
+
+impl MetadataProvider for OutscaleProvider {
+    fn attributes(&self) -> Result<HashMap<String, String>> {
+        let mut out = HashMap::with_capacity(7);
+
+        let add_value = |map: &mut HashMap<_, _>, key: &str, name: &str| -> Result<()> {
+            let value = self
+                .client
+                .get(retry::Raw, self.endpoint_for(name))
+                .send()?;
+
+            if let Some(value) = value {
+                map.insert(key.to_string(), value);
+            }
+
+            Ok(())
+        };
+
+        add_value(&mut out, "OUTSCALE_AMI_ID", "ami-id")?;
+        add_value(&mut out, "OUTSCALE_INSTANCE_ID", "instance-id")?;
+        add_value(&mut out, "OUTSCALE_INSTANCE_TYPE", "instance-type")?;
+        add_value(&mut out, "OUTSCALE_IPV4_LOCAL", "local-ipv4")?;
+        add_value(&mut out, "OUTSCALE_HOSTNAME", "hostname")?;
+        add_value(&mut out, "OUTSCALE_PUBLIC_HOSTNAME", "public-hostname")?;
+        add_value(
+            &mut out,
+            "OUTSCALE_AVAILABILITY_ZONE",
+            "placement/availability-zone",
+        )?;
+
+        Ok(out)
+    }
+
+    fn hostname(&self) -> Result<Option<String>> {
+        self.client
+            .get(retry::Raw, self.endpoint_for("hostname"))
+            .send()
+    }
+
+    fn ssh_keys(&self) -> Result<Vec<PublicKey>> {
+        let key: Option<String> = self
+            .client
+            .get(retry::Raw, self.endpoint_for("public-keys/0/openssh-key"))
+            .send()?;
+
+        match key {
+            Some(key) => Ok(vec![PublicKey::parse(&key)?]),
+            None => Ok(vec![]),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add Outscale as a metadata provider.

## Changes

- Add `OutscaleProvider` implementation.
- Fetch Outscale instance metadata from the metadata endpoint.
- Expose Outscale through the provider registry.
- Register the `outscale` provider in metadata provider selection.
- Add mock tests for the provider.

## Testing

- `cargo fmt`
- `git diff --check`