### PR TITLE
initrd: Write an env file for systemd-network-generator to consume

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -27,6 +27,7 @@ Minor changes:
 - ProxmoxVE: Emit one `nameserver=` karg per address so multiple DNS servers work
 - ProxmoxVE: Prevent rd-network-kargs from failing without a config drive
 - KubeVirt: Use `off` rather than `static` to disable IP autoconf for Dracut and systemd compatibility
+- KubeVirt, ProxmoxVE: Use `ip=any` rather than `ip=dhcp,dhcp6` for systemd compatibility. As of Dracut 112, its network-legacy module treats `ip=any` as IPv4-only, so this change breaks IPv6 in that case. At the time of writing, a Dracut change to make this dual stack is under review.
 
 Packaging changes:
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -26,6 +26,7 @@ Minor changes:
 - Don't panic truncating an over-long hostname with multi-byte characters
 - ProxmoxVE: Emit one `nameserver=` karg per address so multiple DNS servers work
 - ProxmoxVE: Prevent rd-network-kargs from failing without a config drive
+- KubeVirt: Use `off` rather than `static` to disable IP autoconf for Dracut and systemd compatibility
 
 Packaging changes:
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -12,6 +12,7 @@ Major changes:
 - Azure: Add `render-ignition` subcommand to generate Ignition config fragments from IMDS metadata
 - Hetzner: Add support for network configuration
 - Support the generation of NetworkManager connection profiles (keyfile format)
+- Support systemd-network-generator by emitting `/run/afterburn/network-generator.env` from the initrd
 
 Minor changes:
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -25,6 +25,7 @@ Minor changes:
 - Drop the maplit dependency
 - Don't panic truncating an over-long hostname with multi-byte characters
 - ProxmoxVE: Emit one `nameserver=` karg per address so multiple DNS servers work
+- ProxmoxVE: Prevent rd-network-kargs from failing without a config drive
 
 Packaging changes:
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -28,6 +28,7 @@ Minor changes:
 - ProxmoxVE: Prevent rd-network-kargs from failing without a config drive
 - KubeVirt: Use `off` rather than `static` to disable IP autoconf for Dracut and systemd compatibility
 - KubeVirt, ProxmoxVE: Use `ip=any` rather than `ip=dhcp,dhcp6` for systemd compatibility. As of Dracut 112, its network-legacy module treats `ip=any` as IPv4-only, so this change breaks IPv6 in that case. At the time of writing, a Dracut change to make this dual stack is under review.
+- ProxmoxVE: Fix dual stack network configuration
 
 Packaging changes:
 

--- a/src/initrd/mod.rs
+++ b/src/initrd/mod.rs
@@ -9,11 +9,24 @@ use crate::providers::proxmoxve::ProxmoxVEConfigDrive;
 use crate::providers::vmware::VmwareProvider;
 use crate::providers::MetadataProvider;
 use anyhow::{Context, Result};
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::Write;
+use std::path::Path;
 
 /// Path to cmdline.d fragment for network kernel arguments.
 static KARGS_PATH: &str = "/etc/cmdline.d/50-afterburn-network-kargs.conf";
+
+/// Path to the environment file consumed by systemd-network-generator.
+///
+/// systemd-network-generator only parses /proc/cmdline (or the command line
+/// provided through the SYSTEMD_PROC_CMDLINE environment variable), so the
+/// kargs we inject into Dracut's cmdline.d fragment above are invisible to it.
+/// We therefore expose the augmented command line through this file, which a
+/// shipped generator drop-in references via EnvironmentFile=.
+static GENERATOR_ENV_PATH: &str = "/run/afterburn/network-generator.env";
+
+/// Path to the kernel command line.
+static PROC_CMDLINE_PATH: &str = "/proc/cmdline";
 
 /// Fetch network kargs for the given provider.
 pub(crate) fn fetch_network_kargs(provider: &str) -> Result<Option<String>> {
@@ -25,10 +38,17 @@ pub(crate) fn fetch_network_kargs(provider: &str) -> Result<Option<String>> {
     }
 }
 
-/// Write network kargs into a cmdline.d fragment.
+/// Write network kargs into a cmdline.d fragment and hand the augmented kernel
+/// command line to systemd-network-generator.
 pub(crate) fn write_network_kargs(kargs: &str) -> Result<()> {
-    let mut fragment_file = File::create(KARGS_PATH)
-        .with_context(|| format!("failed to create file {KARGS_PATH:?}"))?;
+    write_cmdline_fragment(KARGS_PATH, kargs)?;
+    write_generator_env(GENERATOR_ENV_PATH, PROC_CMDLINE_PATH, kargs)
+}
+
+/// Write network kargs into a Dracut cmdline.d fragment.
+fn write_cmdline_fragment(path: &str, kargs: &str) -> Result<()> {
+    let mut fragment_file =
+        File::create(path).with_context(|| format!("failed to create file {path:?}"))?;
 
     fragment_file
         .write_all(kargs.as_bytes())
@@ -38,4 +58,136 @@ pub(crate) fn write_network_kargs(kargs: &str) -> Result<()> {
         .context("failed to write trailing newline")?;
 
     Ok(())
+}
+
+/// Write the augmented kernel command line for systemd-network-generator.
+///
+/// The generator does not read Dracut's cmdline.d fragments, so we combine the
+/// real kernel command line with the injected kargs and expose the result via
+/// SYSTEMD_PROC_CMDLINE in an environment file consumed by the generator's
+/// drop-in.
+fn write_generator_env(path: &str, proc_cmdline_path: &str, kargs: &str) -> Result<()> {
+    let kargs = kargs.trim();
+    if kargs.is_empty() {
+        return Ok(());
+    }
+
+    let base = fs::read_to_string(proc_cmdline_path)
+        .with_context(|| format!("failed to read {proc_cmdline_path:?}"))?;
+    let base = base.trim();
+    let cmdline = if base.is_empty() {
+        kargs.to_string()
+    } else {
+        format!("{base} {kargs}")
+    };
+
+    if let Some(parent) = Path::new(path).parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create directory {parent:?}"))?;
+    }
+
+    let mut env_file =
+        File::create(path).with_context(|| format!("failed to create file {path:?}"))?;
+    writeln!(env_file, "SYSTEMD_PROC_CMDLINE={cmdline}")
+        .context("failed to write network generator environment file")?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn write_proc_cmdline(dir: &Path, contents: &str) -> String {
+        let path = dir.join("proc_cmdline");
+        fs::write(&path, contents).unwrap();
+        path.to_str().unwrap().to_owned()
+    }
+
+    #[test]
+    fn cmdline_fragment_appends_newline() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("50-afterburn-network-kargs.conf");
+        let path_str = path.to_str().unwrap();
+
+        write_cmdline_fragment(path_str, "ip=dhcp rd.neednet=1").unwrap();
+
+        assert_eq!(fs::read_to_string(&path).unwrap(), "ip=dhcp rd.neednet=1\n");
+    }
+
+    #[test]
+    fn generator_env_augments_proc_cmdline() {
+        let dir = tempdir().unwrap();
+        let proc_cmdline = write_proc_cmdline(dir.path(), "root=/dev/sda1 console=ttyS0\n");
+        let env_path = dir.path().join("network-generator.env");
+        let env_path_str = env_path.to_str().unwrap();
+
+        write_generator_env(env_path_str, &proc_cmdline, "ip=dhcp").unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&env_path).unwrap(),
+            "SYSTEMD_PROC_CMDLINE=root=/dev/sda1 console=ttyS0 ip=dhcp\n"
+        );
+    }
+
+    #[test]
+    fn generator_env_trims_kargs_and_cmdline() {
+        let dir = tempdir().unwrap();
+        let proc_cmdline = write_proc_cmdline(dir.path(), "  root=/dev/sda1  \n");
+        let env_path = dir.path().join("network-generator.env");
+        let env_path_str = env_path.to_str().unwrap();
+
+        write_generator_env(env_path_str, &proc_cmdline, "  ip=dhcp  ").unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&env_path).unwrap(),
+            "SYSTEMD_PROC_CMDLINE=root=/dev/sda1 ip=dhcp\n"
+        );
+    }
+
+    #[test]
+    fn generator_env_handles_empty_proc_cmdline() {
+        let dir = tempdir().unwrap();
+        let proc_cmdline = write_proc_cmdline(dir.path(), "");
+        let env_path = dir.path().join("network-generator.env");
+        let env_path_str = env_path.to_str().unwrap();
+
+        write_generator_env(env_path_str, &proc_cmdline, "ip=dhcp").unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&env_path).unwrap(),
+            "SYSTEMD_PROC_CMDLINE=ip=dhcp\n"
+        );
+    }
+
+    #[test]
+    fn generator_env_skips_when_kargs_empty() {
+        let dir = tempdir().unwrap();
+        // A non-existent proc cmdline path proves it is never read when the
+        // kargs are empty (the early return happens before the read).
+        let proc_cmdline = dir.path().join("does-not-exist");
+        let env_path = dir.path().join("network-generator.env");
+        let env_path_str = env_path.to_str().unwrap();
+
+        write_generator_env(env_path_str, proc_cmdline.to_str().unwrap(), "   ").unwrap();
+
+        assert!(!env_path.exists());
+    }
+
+    #[test]
+    fn generator_env_creates_parent_directory() {
+        let dir = tempdir().unwrap();
+        let proc_cmdline = write_proc_cmdline(dir.path(), "root=/dev/sda1\n");
+        let env_path = dir.path().join("afterburn").join("network-generator.env");
+        let env_path_str = env_path.to_str().unwrap();
+
+        write_generator_env(env_path_str, &proc_cmdline, "ip=dhcp").unwrap();
+
+        assert!(env_path.exists());
+        assert_eq!(
+            fs::read_to_string(&env_path).unwrap(),
+            "SYSTEMD_PROC_CMDLINE=root=/dev/sda1 ip=dhcp\n"
+        );
+    }
 }

--- a/src/initrd/mod.rs
+++ b/src/initrd/mod.rs
@@ -5,7 +5,7 @@
 //! fetcher.
 
 use crate::providers::kubevirt;
-use crate::providers::proxmoxve::ProxmoxVEConfigDrive;
+use crate::providers::proxmoxve;
 use crate::providers::vmware::VmwareProvider;
 use crate::providers::MetadataProvider;
 use anyhow::{Context, Result};
@@ -32,7 +32,7 @@ static PROC_CMDLINE_PATH: &str = "/proc/cmdline";
 pub(crate) fn fetch_network_kargs(provider: &str) -> Result<Option<String>> {
     match provider {
         "vmware" => VmwareProvider::try_new()?.rd_network_kargs(),
-        "proxmoxve" => ProxmoxVEConfigDrive::try_new()?.rd_network_kargs(),
+        "proxmoxve" => proxmoxve::try_config_drive_else_leave()?.rd_network_kargs(),
         "kubevirt" => kubevirt::try_new_provider_else_noop()?.rd_network_kargs(),
         _ => Ok(None),
     }

--- a/src/providers/kubevirt/cloudconfig.rs
+++ b/src/providers/kubevirt/cloudconfig.rs
@@ -203,7 +203,7 @@ impl MetadataProvider for KubeVirtCloudConfig {
                     IpNetwork::V4(n) => (n.ip().to_string(), n.mask().to_string()),
                     IpNetwork::V6(n) => (dracut_addr(&n.ip().into()), n.prefix().to_string()),
                 };
-                kargs.push(format!("ip={}:::{}::{}:static", ip, netmask_or_prefix, id));
+                kargs.push(format!("ip={}:::{}::{}:off", ip, netmask_or_prefix, id));
             }
 
             // Add DHCP configuration

--- a/src/providers/kubevirt/cloudconfig.rs
+++ b/src/providers/kubevirt/cloudconfig.rs
@@ -211,7 +211,7 @@ impl MetadataProvider for KubeVirtCloudConfig {
                 match dhcp {
                     DhcpSetting::V4 => kargs.push(format!("ip={}:dhcp", id)),
                     DhcpSetting::V6 => kargs.push(format!("ip={}:dhcp6", id)),
-                    DhcpSetting::Both => kargs.push(format!("ip={}:dhcp,dhcp6", id)),
+                    DhcpSetting::Both => kargs.push(format!("ip={}:any", id)),
                 }
             }
 

--- a/src/providers/kubevirt/tests.rs
+++ b/src/providers/kubevirt/tests.rs
@@ -205,8 +205,8 @@ fn test_network_data() {
 
         // Static IPs without gateway (gateway is passed via rd.route)
         let expected = [
-            "ip=192.168.1.10:::255.255.255.0::eth0:static",
-            "ip=[2001:db8::10]:::64::eth0:static",
+            "ip=192.168.1.10:::255.255.255.0::eth0:off",
+            "ip=[2001:db8::10]:::64::eth0:off",
             "ip=eth1:dhcp,dhcp6",
             "rd.route=0.0.0.0/0:192.168.1.1",
             "rd.route=[::/0]:[2001:db8::1]",

--- a/src/providers/kubevirt/tests.rs
+++ b/src/providers/kubevirt/tests.rs
@@ -207,7 +207,7 @@ fn test_network_data() {
         let expected = [
             "ip=192.168.1.10:::255.255.255.0::eth0:off",
             "ip=[2001:db8::10]:::64::eth0:off",
-            "ip=eth1:dhcp,dhcp6",
+            "ip=eth1:any",
             "rd.route=0.0.0.0/0:192.168.1.1",
             "rd.route=[::/0]:[2001:db8::1]",
             "nameserver=8.8.8.8",
@@ -292,7 +292,7 @@ fn assert_dhcp_with_static_gw_and_dns(config: &KubeVirtCloudConfig) {
     );
 
     let expected = [
-        "ip=eth0:dhcp,dhcp6",
+        "ip=eth0:any",
         "rd.route=0.0.0.0/0:192.168.1.1",
         "rd.route=[::/0]:[2001:db8::1]",
         "nameserver=8.8.8.8",
@@ -361,7 +361,7 @@ fn assert_no_duplicate_routes(config: &KubeVirtCloudConfig) {
 
     let kargs = config.rd_network_kargs().unwrap().unwrap();
     let expected = [
-        "ip=eth0:dhcp,dhcp6",
+        "ip=eth0:any",
         "rd.route=0.0.0.0/0:192.168.1.1",
         "rd.route=[::/0]:[2001:db8::1]",
     ];

--- a/src/providers/proxmoxve/cloudconfig.rs
+++ b/src/providers/proxmoxve/cloudconfig.rs
@@ -241,7 +241,7 @@ impl MetadataProvider for ProxmoxVECloudConfig {
                     match dhcp {
                         DhcpSetting::V4 => kargs.push("ip=dhcp".to_string()),
                         DhcpSetting::V6 => kargs.push("ip=dhcp6".to_string()),
-                        DhcpSetting::Both => kargs.push("ip=dhcp,dhcp6".to_string()),
+                        DhcpSetting::Both => kargs.push("ip=any".to_string()),
                     }
                 }
 

--- a/src/providers/proxmoxve/cloudconfig.rs
+++ b/src/providers/proxmoxve/cloudconfig.rs
@@ -403,10 +403,16 @@ impl ProxmoxVECloudNetworkConfigEntry {
             }
 
             if subnet.subnet_type == "dhcp" || subnet.subnet_type == "dhcp4" {
-                iface.dhcp = Some(DhcpSetting::V4)
+                iface.dhcp = iface
+                    .dhcp
+                    .map(|d| d.merge(DhcpSetting::V4))
+                    .or(Some(DhcpSetting::V4))
             }
             if subnet.subnet_type == "dhcp6" {
-                iface.dhcp = Some(DhcpSetting::V6)
+                iface.dhcp = iface
+                    .dhcp
+                    .map(|d| d.merge(DhcpSetting::V6))
+                    .or(Some(DhcpSetting::V6))
             }
             if subnet.subnet_type == "ipv6_slaac" {
                 warn!("subnet type \"ipv6_slaac\" not supported, ignoring");

--- a/src/providers/proxmoxve/tests.rs
+++ b/src/providers/proxmoxve/tests.rs
@@ -222,6 +222,39 @@ fn test_network_kargs_no_gateway() {
 }
 
 #[test]
+fn test_network_dhcp_dual() {
+    let config = ProxmoxVECloudConfig::try_new(Path::new("tests/fixtures/proxmoxve/dhcp-dual"))
+        .expect("cannot parse config");
+
+    let networks = config.networks().expect("cannot get networks");
+    let eth0 = networks
+        .iter()
+        .find(|i| i.name.as_deref() == Some("eth0"))
+        .expect("eth0 not found");
+
+    // dhcp4 and dhcp6 subnets on one interface merge into dual-stack.
+    assert_eq!(eth0.dhcp, Some(DhcpSetting::Both));
+}
+
+#[test]
+fn test_network_kargs_dhcp_dual() {
+    let config = ProxmoxVECloudConfig::try_new(Path::new("tests/fixtures/proxmoxve/dhcp-dual"))
+        .expect("cannot parse config");
+
+    let kargs = config.rd_network_kargs().expect("cannot get network kargs");
+    assert!(kargs.is_some());
+    let kargs = kargs.unwrap();
+
+    // Dual-stack DHCP maps to the "any" autoconf keyword.
+    assert!(kargs.contains("ip=any"));
+
+    // Check nameservers: one karg each, not a comma-separated list
+    assert!(!kargs.contains("nameserver=1.1.1.1,8.8.8.8"));
+    assert_eq!(kargs.matches("nameserver=1.1.1.1").count(), 1);
+    assert_eq!(kargs.matches("nameserver=8.8.8.8").count(), 1);
+}
+
+#[test]
 fn test_netplan_config_static() {
     let config = ProxmoxVECloudConfig::try_new(Path::new("tests/fixtures/proxmoxve/static"))
         .expect("cannot parse config");
@@ -307,4 +340,21 @@ fn test_netplan_config_dhcp() {
         .as_sequence()
         .unwrap()
         .contains(&serde_yaml::Value::String("8.8.8.8".into())));
+}
+
+#[test]
+fn test_netplan_config_dhcp_dual() {
+    let config = ProxmoxVECloudConfig::try_new(Path::new("tests/fixtures/proxmoxve/dhcp-dual"))
+        .expect("cannot parse config");
+
+    let netplan = config.netplan_config().expect("cannot get netplan config");
+    assert!(netplan.is_some());
+    let netplan = netplan.unwrap();
+
+    let parsed: serde_yaml::Value = serde_yaml::from_str(&netplan).expect("invalid YAML");
+    let eth0 = &parsed["network"]["ethernets"]["eth0"];
+
+    // Dual-stack DHCP enables both families in netplan.
+    assert_eq!(eth0["dhcp4"], serde_yaml::Value::Bool(true));
+    assert_eq!(eth0["dhcp6"], serde_yaml::Value::Bool(true));
 }

--- a/tests/fixtures/proxmoxve/dhcp-dual/meta-data
+++ b/tests/fixtures/proxmoxve/dhcp-dual/meta-data
@@ -1,0 +1,1 @@
+instance-id: 15a9919cb91024fbd1d70fa07f0efa749cbba03b

--- a/tests/fixtures/proxmoxve/dhcp-dual/network-config
+++ b/tests/fixtures/proxmoxve/dhcp-dual/network-config
@@ -1,0 +1,14 @@
+version: 1
+config:
+    - type: physical
+      name: eth0
+      mac_address: '01:23:45:67:89:00'
+      subnets:
+      - type: dhcp4
+      - type: dhcp6
+    - type: nameserver
+      address:
+      - '1.1.1.1'
+      - '8.8.8.8'
+      search:
+      - 'local.com'

--- a/tests/fixtures/proxmoxve/dhcp-dual/user-data
+++ b/tests/fixtures/proxmoxve/dhcp-dual/user-data
@@ -1,0 +1,2 @@
+#cloud-config
+hostname: dummy


### PR DESCRIPTION
systemd-network-generator parses /proc/cmdline or `SYSTEMD_PROC_CMDLINE`, so the kargs we inject into Dracut's cmdline.d fragment are invisible to it. Flatcar would like to switch from its own customer parser to the generator's parser (and not Dracut's own). Apart from writing the env file, some compatibility issues had to be addressed.

kubevirt currently uses `static` to disable IP autoconfiguration, but both Dracut and systemd-network-generator reject this as invalid. It was presumably added with NetworkManager in mind. We should therefore use `off` instead.  `none` would also work, but we already use `off` elsewhere.

**Important note!** NetworkManager does not treat `static` and `off` entirely equally. The former sets the method for the other protocol (the one not being configured by `ip=`) to `auto`, enabling DHCP for IPv4 or SLAAC for IPv6, while the latter sets it to `disabled`, giving the other protocol no address at all. Given that `static` is supposed to be exactly that, the current behaviour is arguably unexpected, while the `off` behaviour seems more correct.

systemd-network-generator also does not support multiple autoconf values, and fixing this appears difficult. Even then, Dracut does not treat `dhcp,dhcp6` in quite the same way that systemd and NetworkManager do. It only tries IPv6 if IPv4 fails. I am therefore changing kubevirt and proxmoxve to use `ip=any` rather than `ip=dhcp,dhcp6` for dual stack.

As of Dracut 112, `any` is treated as IPv4-only, despite the name. However, I have submitted dracut-ng/dracut#2628 to change this behaviour so that it is dual stack in the same manner as systemd and NetworkManager.

This would break Afterburn consumers relying on Dracut's network-legacy in the meantime. However, FCOS has already migrated to NetworkManager, and Flatcar is now migrating to systemd-network-manager. I'm not aware of any other consumers.

Dual stack configuration didn't work on proxmoxve anyway because Afterburn would iterate over the subnets, setting the type as either `V4` or `V6`, but never combining them. This includes a fix for that.