### PR TITLE
ci/tmt-tests: fix verbosity flag

### DIFF
--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -59,4 +59,4 @@ jobs:
           else
             CONTEXT_PARAM="--context use_built_from_src=false"
           fi
-          eval "tmt $CONTEXT_PARAM run --all --debug -vvvv provision $TMT_PROVISION_OPTS $PLAN_FILTER_PARAM"
+          eval "tmt $CONTEXT_PARAM run --all --debug -vvv provision $TMT_PROVISION_OPTS $PLAN_FILTER_PARAM"


### PR DESCRIPTION
Only verbosity level 1-3 are supported, level 4 (-vvvv) is not. Let's drop it back to 3.

CI failure encountered in https://github.com/coreos/afterburn/pull/1299.