### PR TITLE
build(deps): bump xml-rs version from 0.8 to 1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
  "tempfile",
  "uzers",
  "vmw_backdoor",
- "xml-rs",
+ "xml",
  "zbus",
 ]
 
@@ -3101,15 +3101,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xml"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636f85e5ca6488e96401b61eb7de54f4e44755c988af0f52cf90230c312a1a89"
-
-[[package]]
-name = "xml-rs"
-version = "0.8.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+checksum = "2f45bb2c13fec6a6cb4c0f76a7e94839e110a14ec803ec2940777a94c347bc52"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ slog-term = ">= 2.6, < 3"
 tempfile = ">= 3.2, < 4"
 uzers = "0.12"
 vmw_backdoor = "0.2"
-xml-rs = "0.8"
+xml = "1.4"
 zbus = ">= 2.3, < 6"
 
 [dev-dependencies]


### PR DESCRIPTION
As per https://crates.io/crates/xml-rs, updating from 0.8 to 1.0 requires changing the dep from xml-rs to xml. There were a couple other differences but it doesn't seem this code base included anything else that needed updating.

---

Updating manually since the requirement above is making [this dependabot PR](https://github.com/coreos/afterburn/pull/1293) fail.